### PR TITLE
Fix GitHub Pages hub routes for all experiment cards

### DIFF
--- a/agialpha_cyber_sovereign2/core.py
+++ b/agialpha_cyber_sovereign2/core.py
@@ -650,6 +650,27 @@ def html_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
     return "".join(out)
 
 
+
+
+def _write_portfolio_stub_pages(site: Path, css: str) -> None:
+    pages = [
+        ("helios-001", "AGI ALPHA HELIOS-001", "Governed compounding experiment summary."),
+        ("helios-002", "AGI ALPHA HELIOS-002", "Transfer and reviewer replay readiness experiment summary."),
+        ("helios-003", "AGI ALPHA HELIOS-003", "Public benchmark bridge experiment summary."),
+        ("helios-004", "AGI ALPHA HELIOS-004", "Completion and handoff experiment summary."),
+        ("cyber-sovereign-001", "AGI ALPHA CYBER-SOVEREIGN-001", "First defensive security organ experiment summary."),
+    ]
+    for slug, title, subtitle in pages:
+        d = site / slug
+        d.mkdir(parents=True, exist_ok=True)
+        body = f"""<!doctype html><html><head><meta charset='utf-8'><title>{html.escape(title)}</title><style>{css}</style></head><body>
+<h1>{html.escape(title)}</h1>
+<div class='card'><p>{html.escape(subtitle)}</p>
+<p>This page is intentionally bounded and points to per-experiment evidence artifacts produced by the matching autonomous workflow.</p>
+<p><a href='../'>Back to AGI ALPHA Evidence Hub</a></p></div>
+</body></html>"""
+        write_text(d / "index.html", body)
+
 def build_site(docket: Path, site: Path) -> None:
     site.mkdir(parents=True, exist_ok=True)
     manifest = read_json(docket / "00_manifest.json", {})
@@ -688,6 +709,7 @@ def build_site(docket: Path, site: Path) -> None:
     <div class='card'><h2>Latest highlighted run</h2><p><b>CYBER-SOVEREIGN-002:</b> defensive capability compounding for the AGI ALPHA evidence infrastructure.</p><p><a href='./cyber-sovereign-002/'>Open latest scoreboard</a></p></div>
     </body></html>"""
     write_text(site / "index.html", hub)
+    _write_portfolio_stub_pages(site, css)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
### Motivation
- The AGI ALPHA Evidence Hub linked to several experiment routes (e.g. `helios-001`..`helios-004`, `cyber-sovereign-001`) but only the `cyber-sovereign-002` scoreboard page was being emitted, causing 404s when users clicked other cards. 
- Provide minimal, bounded pages for each card so the published site always contains a resolvable `index.html` for each linked route.

### Description
- Added a helper `_write_portfolio_stub_pages(site, css)` to `agialpha_cyber_sovereign2/core.py` that creates simple, bounded `index.html` pages for `helios-001`, `helios-002`, `helios-003`, `helios-004`, and `cyber-sovereign-001`.
- Hooked the new helper into `build_site(...)` so the stub pages are emitted alongside the main hub and `cyber-sovereign-002` scoreboard outputs.
- Change is implemented in `agialpha_cyber_sovereign2/core.py` and keeps existing scoreboard behavior unchanged while ensuring all hub links resolve.

### Testing
- Ran unit tests with `python -m unittest discover -s tests` and all tests passed (`OK`).
- Generated a fresh docket and scoreboard with the local CLI and verified that `index.html` files exist for `helios-001`..`helios-004`, `cyber-sovereign-001`, `cyber-sovereign-002`, and the hub using the scoreboard generation flow (`python -m agialpha_cyber_sovereign2 run` + `python -m agialpha_cyber_sovereign2 scoreboard`), and the verification check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39c31493083339d08692c4a2f4faf)