### PR TITLE
Group Evidence Hub scoreboard by experiment and add experiment navigation

### DIFF
--- a/agialpha_evidence_factory/core.py
+++ b/agialpha_evidence_factory/core.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import time
+from urllib.parse import quote
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -522,7 +523,7 @@ def _row_from_docket(docket: Path) -> dict[str, Any] | None:
 def _experiment_key(row: dict[str, Any]) -> str:
     run_id = str(row.get("run_id") or "")
     if "-" not in run_id:
-        return "misc"
+        return run_id or "unknown"
     parts = run_id.split("-")
     if len(parts) >= 2 and parts[-1].isdigit():
         return "-".join(parts[:-1])
@@ -557,7 +558,10 @@ def build_scoreboard(dockets: list[Path], out: Path) -> dict[str, Any]:
         "experiments": {k: len(v) for k, v in sorted(experiments.items())},
     }
     write_json(out / "evidence-index.json", index)
-    links = " ".join(f"<a href='#{html.escape(name)}'>{html.escape(name)}</a>" for name in sorted(experiments))
+    links = " ".join(
+        f"<a href='#{quote(name, safe='')}'>{html.escape(name)}</a>"
+        for name in sorted(experiments)
+    )
     html_lines = [
         "<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>",
         "<title>AGI ALPHA Evidence Factory Scoreboard</title>",
@@ -569,7 +573,7 @@ def build_scoreboard(dockets: list[Path], out: Path) -> dict[str, Any]:
     ]
     for experiment_name in sorted(experiments):
         html_lines.append(
-            f"<tr id='{html.escape(experiment_name)}'><th colspan='9'>"
+            f"<tr id='{quote(experiment_name, safe='')}'><th colspan='9'>"
             f"Experiment: {html.escape(experiment_name)} ({len(experiments[experiment_name])} runs)"
             "</th></tr>"
         )

--- a/agialpha_evidence_factory/core.py
+++ b/agialpha_evidence_factory/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import json
 import os
 import shutil
@@ -518,6 +519,16 @@ def _row_from_docket(docket: Path) -> dict[str, Any] | None:
     }
 
 
+def _experiment_key(row: dict[str, Any]) -> str:
+    run_id = str(row.get("run_id") or "")
+    if "-" not in run_id:
+        return "misc"
+    parts = run_id.split("-")
+    if len(parts) >= 2 and parts[-1].isdigit():
+        return "-".join(parts[:-1])
+    return run_id
+
+
 def build_scoreboard(dockets: list[Path], out: Path) -> dict[str, Any]:
     out.mkdir(parents=True, exist_ok=True)
     rows = []
@@ -535,32 +546,49 @@ def build_scoreboard(dockets: list[Path], out: Path) -> dict[str, Any]:
         if row:
             rows.append(row)
     rows = sorted(rows, key=lambda r: (str(r.get("run_id")), str(r.get("path"))))
-    index = {"schema": "agialpha.evidence_scoreboard.v1", "generated_at_epoch": now_epoch(), "claim_boundary": CLAIM_BOUNDARY, "runs": rows}
+    experiments: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        experiments.setdefault(_experiment_key(row), []).append(row)
+    index = {
+        "schema": "agialpha.evidence_scoreboard.v1",
+        "generated_at_epoch": now_epoch(),
+        "claim_boundary": CLAIM_BOUNDARY,
+        "runs": rows,
+        "experiments": {k: len(v) for k, v in sorted(experiments.items())},
+    }
     write_json(out / "evidence-index.json", index)
-    html = [
+    links = " ".join(f"<a href='#{html.escape(name)}'>{html.escape(name)}</a>" for name in sorted(experiments))
+    html_lines = [
         "<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>",
         "<title>AGI ALPHA Evidence Factory Scoreboard</title>",
         "<style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:2rem;line-height:1.45;color:#172033;background:#fbfbfd}h1{letter-spacing:.02em}.box{background:#fff;border:1px solid #ddd;border-radius:12px;padding:1rem;margin:1rem 0}table{border-collapse:collapse;width:100%;background:#fff}td,th{border:1px solid #e1e4e8;padding:.55rem;text-align:left;vertical-align:top}th{background:#f3f5f8}.pass{color:#087a2e;font-weight:700}.pending{color:#8a6100;font-weight:700}.fail{color:#b42318;font-weight:700}code{background:#f2f2f2;padding:.15rem .3rem;border-radius:4px}</style></head><body>",
         "<h1>AGI ALPHA Evidence Factory Scoreboard</h1>",
+        f"<div class='box'><strong>Experiments:</strong> {links or 'none yet'}</div>",
         f"<div class='box'><strong>Claim boundary:</strong> {CLAIM_BOUNDARY}</div>",
         "<table><thead><tr><th>Run</th><th>Claim level</th><th>Replay</th><th>Baseline win</th><th>Full baselines?</th><th>Reuse lift</th><th>Safety incidents</th><th>Root hash</th><th>Path</th></tr></thead><tbody>"
     ]
-    for r in rows:
-        replay_class = "pass" if r["replay_status"] == "pass" else ("fail" if r["replay_status"] == "fail" else "pending")
-        html.append("<tr>" + "".join([
-            f"<td>{r['run_id']}</td>",
-            f"<td><code>{r['claim_level']}</code></td>",
-            f"<td class='{replay_class}'>{r['replay_status']}</td>",
-            f"<td>{r['baseline_win_against_B0']}</td>",
-            f"<td>{r['full_baseline_suite_executed']}</td>",
-            f"<td>{r['reuse_lift_percent']}</td>",
-            f"<td>{r['critical_safety_violations']}</td>",
-            f"<td><code>{(r.get('root_sha256') or '')[:16]}</code></td>",
-            f"<td><code>{r['path']}</code></td>",
-        ]) + "</tr>")
-    html.append("</tbody></table><p>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</p></body></html>")
-    (out / "scoreboard.html").write_text("\n".join(html), encoding="utf-8")
-    (out / "index.html").write_text("\n".join(html), encoding="utf-8")
+    for experiment_name in sorted(experiments):
+        html_lines.append(
+            f"<tr id='{html.escape(experiment_name)}'><th colspan='9'>"
+            f"Experiment: {html.escape(experiment_name)} ({len(experiments[experiment_name])} runs)"
+            "</th></tr>"
+        )
+        for r in experiments[experiment_name]:
+            replay_class = "pass" if r["replay_status"] == "pass" else ("fail" if r["replay_status"] == "fail" else "pending")
+            html_lines.append("<tr>" + "".join([
+                f"<td>{html.escape(str(r['run_id']))}</td>",
+                f"<td><code>{html.escape(str(r['claim_level']))}</code></td>",
+                f"<td class='{replay_class}'>{html.escape(str(r['replay_status']))}</td>",
+                f"<td>{html.escape(str(r['baseline_win_against_B0']))}</td>",
+                f"<td>{html.escape(str(r['full_baseline_suite_executed']))}</td>",
+                f"<td>{html.escape(str(r['reuse_lift_percent']))}</td>",
+                f"<td>{html.escape(str(r['critical_safety_violations']))}</td>",
+                f"<td><code>{html.escape(str((r.get('root_sha256') or '')[:16]))}</code></td>",
+                f"<td><code>{html.escape(str(r['path']))}</code></td>",
+            ]) + "</tr>")
+    html_lines.append("</tbody></table><p>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</p></body></html>")
+    (out / "scoreboard.html").write_text("\n".join(html_lines), encoding="utf-8")
+    (out / "index.html").write_text("\n".join(html_lines), encoding="utf-8")
     return index
 
 

--- a/tests/test_evidence_factory.py
+++ b/tests/test_evidence_factory.py
@@ -17,4 +17,7 @@ def test_scoreboard_builds(tmp_path: Path):
     complete_docket(src, out)
     index = build_scoreboard([out], docs)
     assert index["runs"]
+    assert index["experiments"]
     assert (docs / "index.html").exists()
+    html = (docs / "index.html").read_text(encoding="utf-8")
+    assert "Experiments:" in html

--- a/tests/test_evidence_factory.py
+++ b/tests/test_evidence_factory.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from agialpha_evidence_factory.core import complete_docket, lint_docket, build_scoreboard
+import json
 
 
 def test_seed_docket_completes(tmp_path: Path):
@@ -21,3 +22,14 @@ def test_scoreboard_builds(tmp_path: Path):
     assert (docs / "index.html").exists()
     html = (docs / "index.html").read_text(encoding="utf-8")
     assert "Experiments:" in html
+
+
+def test_scoreboard_preserves_non_hyphen_run_id_and_encodes_anchor(tmp_path: Path):
+    docs = tmp_path / "docs"
+    docket = tmp_path / "alpha dossier"
+    docket.mkdir(parents=True)
+    (docket / "00_manifest.json").write_text(json.dumps({"docket_id": "alpha dossier"}), encoding="utf-8")
+    index = build_scoreboard([docket], docs)
+    assert index["experiments"]["alpha dossier"] == 1
+    html = (docs / "index.html").read_text(encoding="utf-8")
+    assert "href='#alpha%20dossier'" in html


### PR DESCRIPTION
### Motivation
- Make the Evidence Hub scoreboard render past and future experiment runs in a discoverable way by grouping runs from the same workflow family and providing direct navigation links. 
- Prevent malformed scoreboard HTML when run metadata contains arbitrary strings by escaping values before rendering. 
- Expose a lightweight `experiments` summary in the generated index to support downstream UI/automation.

### Description
- Add `_experiment_key` to infer an experiment family from `run_id` (e.g., `helios-003` → `helios`) and group runs by that key in `build_scoreboard` in `agialpha_evidence_factory/core.py`.
- Emit an `experiments` map in `evidence-index.json` summarizing experiment counts and render an `Experiments:` navigation strip with anchor links at the top of the generated `index.html`/`scoreboard.html` so each experiment section is directly addressable.
- Render grouped section headers and per-run rows grouped by experiment in the scoreboard table and escape dynamic cell values with `html.escape` to harden generated HTML.
- Update tests in `tests/test_evidence_factory.py` to assert the presence of `experiments` metadata and the navigation content in the generated HTML.

### Testing
- Ran `pytest -q tests/test_evidence_factory.py` (initial collection failed due to import path), then ran `PYTHONPATH=. pytest -q tests/test_evidence_factory.py` and the test suite passed: `2 passed`.
- Verified that `build_scoreboard` writes `evidence-index.json`, `index.html`, and `scoreboard.html` and that the generated HTML contains the experiment navigation string.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c347acbc83338f4b9a71499dd470)