### PR TITLE
Unify dynamic Evidence Hub publishing across all AGI ALPHA workflows

### DIFF
--- a/tests/test_evidence_hub_sorting.py
+++ b/tests/test_evidence_hub_sorting.py
@@ -1,6 +1,21 @@
-import unittest, json
+import json
+import pathlib
+import unittest
+
+
 class T(unittest.TestCase):
     def test_sorted(self):
-        runs=json.load(open('evidence_registry/runs.json')) if __import__('pathlib').Path('evidence_registry/runs.json').exists() else []
-        self.assertEqual(runs, sorted(runs,key=lambda x:x.get('generated_at',''), reverse=True))
-if __name__=='__main__': unittest.main()
+        runs_path = pathlib.Path("evidence_registry/runs.json")
+        if runs_path.exists():
+            with runs_path.open("r", encoding="utf-8") as handle:
+                runs = json.load(handle)
+        else:
+            runs = []
+        self.assertEqual(
+            runs,
+            sorted(runs, key=lambda x: x.get("generated_at", ""), reverse=True),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent intermittent `ResourceWarning` and improve test stability by closing the file handle opened in `tests/test_evidence_hub_sorting.py` while preserving the Evidence Hub behavior and sorting assertion.

### Description
- Replaced inline `open(...)` usage in `tests/test_evidence_hub_sorting.py` with `pathlib.Path` and a context-managed `with ... open(...)`, added explicit imports and clearer formatting while keeping the newest-first `generated_at` sorting assertion unchanged.

### Testing
- Ran `python scripts/check_pages_architecture.py`, `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, `python -m agialpha_evidence_hub linkcheck --site _site`, and `python -m unittest discover -s tests`, and all automated checks and tests passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d7fef00483338db42ec87c9c1bb4)