### PR TITLE
Unify dynamic Evidence Hub publishing across all AGI ALPHA workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,13 @@ python -m unittest discover -s tests
 ```
 
 That confirms the loop remains replayable after every commit.
-\n## Evidence Hub publishing architecture\nSee README_EVIDENCE_HUB.md for central registry + single deploy workflow design.
+\n
+
+## Evidence Hub publishing architecture
+
+- One central Pages publisher (`.github/workflows/evidence-hub-publish.yml`) builds and deploys the full site snapshot.
+- Experiment workflows emit evidence manifests plus artifacts, and do not deploy Pages directly.
+- A persistent registry in `evidence_registry/` retains run history beyond artifact expiration.
+- Dynamic discovery scans manifests, workflow metadata, docs outputs, artifacts, and historical evidence for future autonomous experiments.
+- No Evidence Docket, no empirical SOTA claim.
+

--- a/README_EVIDENCE_HUB.md
+++ b/README_EVIDENCE_HUB.md
@@ -1,16 +1,73 @@
-# Evidence Hub publishing architecture
+# AGI ALPHA Evidence Hub Operations Guide
 
-Central publisher workflow: `.github/workflows/evidence-hub-publish.yml`.
+## Why central publishing is required
+GitHub Pages serves a complete static snapshot, so per-workflow deployments can overwrite prior evidence.
+This repository now uses a **single publisher workflow** (`.github/workflows/evidence-hub-publish.yml`) that rebuilds and deploys one complete hub from durable registry data.
 
-- Experiment workflows emit evidence manifests and artifacts.
-- Persistent registry lives in `evidence_registry/registry`.
-- Static site is built from registry using `python -m agialpha_evidence_hub build`.
-- Only central publisher deploys GitHub Pages.
+## Evidence emission from experiment workflows
+Experiment workflows keep their scientific/runtime logic, but they must:
+1. Emit `evidence-run-manifest.json` via `python -m agialpha_evidence_hub emit-manifest`.
+2. Upload the manifest plus dockets/scoreboards/replay/safety/cost artifacts.
+3. Never deploy Pages directly.
+4. Optionally dispatch `repository_dispatch` (`evidence_run_completed`) to trigger central rebuild.
 
-## Add a future workflow
-1. Generate a manifest matching `schemas/evidence_run_manifest.schema.json`.
-2. Upload manifest as artifact.
-3. Invoke `python -m agialpha_evidence_hub register-run --input <manifest>`.
-4. Let central publisher rebuild Pages.
+## Persistent registry model
+Registry state is stored in `evidence_registry/` and preserved across runs, including when artifacts later expire.
+Important files:
+- `evidence_registry/runs.json`
+- `evidence_registry/experiments.json`
+- `evidence_registry/workflows.json`
+- `evidence_registry/latest.json`
+- per-experiment and per-run JSON under `evidence_registry/experiments/**`
 
-No Evidence Docket, no empirical SOTA claim.
+## Dynamic discovery for future autonomous experiments
+Discovery is intentionally multi-path:
+- manifest scan
+- repository path scan (docs, dockets, autonomous outputs, gauntlet/sovereign families)
+- workflow YAML scan
+- Actions run metadata scan
+- artifact ingest scan
+- historical backfill scan
+
+This prevents hardcoding to current families and supports newly created autonomous experiments.
+
+## Common operator commands
+- Discover: `python -m agialpha_evidence_hub discover --repo-root . --out evidence_registry/discovered.json`
+- GitHub runs: `python -m agialpha_evidence_hub github-discover --registry evidence_registry --limit 500`
+- Backfill: `python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry`
+- Register a run: `python -m agialpha_evidence_hub register-run --input <manifest_or_docket_dir> --registry evidence_registry`
+- Build site: `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`
+- Validate site: `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`
+- Link check: `python -m agialpha_evidence_hub linkcheck --site _site`
+
+## Manual central publisher trigger
+- GitHub UI: run `.github/workflows/evidence-hub-publish.yml` with `workflow_dispatch`.
+- API/CLI: send `repository_dispatch` type `evidence_run_completed`.
+
+## Handling historical runs and missing data
+If older runs lack complete manifests, backfill creates conservative entries with explicit statuses such as
+`pending`, `unavailable`, `not_reported`, `artifact_expired`, `discovered_without_manifest`, or `backfill_required`.
+No metrics are invented.
+
+## Debugging missing runs
+1. Confirm workflow emitted and uploaded `evidence-run-manifest.json`.
+2. Check `evidence_registry/discovered.json` and `evidence_registry/runs.json`.
+3. Run backfill/discover/github-discover locally.
+4. Rebuild `_site` and inspect generated `/_site/data/*.json`.
+
+## Claim levels and overclaim policy
+Claim levels are bounded evidence labels (e.g., `L3`, `L4-ready`, `L6-CI-proxy`, `pending`, `historical-local`)
+and are governed by schema and safety validation. Unsafe positive claims are rejected unless clearly negated
+in claim-boundary context.
+
+## Artifact expiration handling
+The registry keeps run metadata even if artifacts expire. Expired artifact links remain visible with explicit
+status messaging rather than silent deletion.
+
+## Content Preservation / Migration Notes
+- Legacy experiment routes (e.g., `/helios-001/`, `/cyber-sovereign-002/`) are preserved and mapped to canonical summaries when data exists.
+- Historical placeholder pages are replaced by bounded summaries with explicit missing-data states when evidence is partial.
+- Existing richer evidence pages are preserved and not downgraded to generic placeholders.
+
+## Claim boundary
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.


### PR DESCRIPTION
### Motivation
- Make the Evidence Hub operationally clear so a single central publisher builds and deploys a complete, persistent site from durable run metadata instead of per-workflow Pages deployments. 
- Document the required evidence emission pattern (manifest-first), persistent registry model, multi-path discovery for future autonomous experiments, and strict claim-boundary rules so operators and workflows follow a safe, auditable process. 
- Preserve legacy route content and provide conservative historical backfill rules so existing rich pages are not downgraded and missing data is rendered explicitly. 

### Description
- Expanded `README_EVIDENCE_HUB.md` into an operator-focused guide that documents central publishing rationale, `evidence-run-manifest.json` emission, registry persistence (`evidence_registry/`), multi-path discovery, backfill semantics, operator commands, and the claim-boundary policy. 
- Added explicit "Content Preservation / Migration Notes" to describe handling of legacy routes (e.g., `/helios-001/`, `/cyber-sovereign-002/`) and rules for bounded historical summaries without inventing metrics. 
- Updated the root `README.md` under `## Evidence Hub publishing architecture` to call out the single central publisher (`.github/workflows/evidence-hub-publish.yml`), manifest-first workflows, registry persistence, dynamic discovery, and the root claim boundary. 
- Kept all existing code and workflows intact; this change is documentation/operator guidance and does not alter runtime logic or deployment steps in other workflows. 

### Testing
- Ran unit tests with `python -m unittest discover -s tests` and all tests passed (`Ran 25 tests ... OK`). 
- Ran the architecture guard `python scripts/check_pages_architecture.py` which returned `ok`. 
- Built and validated the site with `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3da9e1a408333b12b0b3f8a6ef310)