### PR TITLE
Unify dynamic Evidence Hub publishing across all AGI ALPHA workflows

### DIFF
--- a/.github/workflows/benchmark-gauntlet-001-autonomous.yml
+++ b/.github/workflows/benchmark-gauntlet-001-autonomous.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: docs
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish BENCHMARK-GAUNTLET-001 scoreboard
     if: ${{ false }}
     needs: benchmark-gauntlet

--- a/.github/workflows/cyber-sovereign-001-autonomous.yml
+++ b/.github/workflows/cyber-sovereign-001-autonomous.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           path: _pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish Cybersecurity Sovereign scoreboard
     needs: cyber-sovereign
     if: ${{ false }}

--- a/.github/workflows/cyber-sovereign-002-autonomous.yml
+++ b/.github/workflows/cyber-sovereign-002-autonomous.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           path: _pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish CYBER-SOVEREIGN-002 scoreboard to GitHub Pages
     needs: cyber-sovereign-002
     if: ${{ false }}

--- a/.github/workflows/evidence-factory-autonomous.yml
+++ b/.github/workflows/evidence-factory-autonomous.yml
@@ -196,7 +196,7 @@ jobs:
         with:
           path: ${{ env.DOCS_DIR }}
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish live Evidence Factory scoreboard
     needs: evidence-factory
     if: ${{ false }}

--- a/.github/workflows/falsification-audit-autonomous.yml
+++ b/.github/workflows/falsification-audit-autonomous.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           path: docs
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish Falsification Audit scoreboard
     needs: falsification-audit
     runs-on: ubuntu-latest

--- a/.github/workflows/frontier-usefulness-autonomous.yml
+++ b/.github/workflows/frontier-usefulness-autonomous.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           path: public
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish Frontier Usefulness scoreboard
     if: ${{ false }}
     needs: frontier-usefulness

--- a/.github/workflows/helios-001-autonomous.yml
+++ b/.github/workflows/helios-001-autonomous.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           path: _pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Notify central Evidence Hub publisher
     needs: helios
     if: ${{ false }}

--- a/.github/workflows/helios-002-autonomous.yml
+++ b/.github/workflows/helios-002-autonomous.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           path: _pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish HELIOS-002 scoreboard to GitHub Pages
     if: ${{ false }}
     needs: helios-002

--- a/.github/workflows/helios-002-benchmark-adapters.yml
+++ b/.github/workflows/helios-002-benchmark-adapters.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           path: ${{ env.DOCS_DIR }}
 
-  deploy-pages:
+  notify-evidence-hub:
     if: ${{ false }}
     needs: adapters
     runs-on: ubuntu-latest

--- a/.github/workflows/helios-002-scaling.yml
+++ b/.github/workflows/helios-002-scaling.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           path: ${{ env.DOCS_DIR }}
 
-  deploy-pages:
+  notify-evidence-hub:
     if: ${{ false }}
     needs: scaling
     runs-on: ubuntu-latest

--- a/.github/workflows/helios-003-autonomous.yml
+++ b/.github/workflows/helios-003-autonomous.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           path: _pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish HELIOS-003 scoreboard to GitHub Pages
     needs: helios-003
     if: ${{ false }}

--- a/.github/workflows/helios-004-completion.yml
+++ b/.github/workflows/helios-004-completion.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           path: _pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish HELIOS completion page
     needs: helios-complete
     if: ${{ false }}

--- a/.github/workflows/independent-replay-autonomous.yml
+++ b/.github/workflows/independent-replay-autonomous.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           path: docs
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish Independent Replay scoreboard
     needs: independent-replay
     runs-on: ubuntu-latest

--- a/.github/workflows/l4-l7-evidence-autopilot.yml
+++ b/.github/workflows/l4-l7-evidence-autopilot.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           path: ${{ env.DOCS_DIR }}
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish L4-L7 scoreboard to GitHub Pages
     needs: l4-l7-autopilot
     if: ${{ false }}

--- a/.github/workflows/omega-gauntlet-001-autonomous.yml
+++ b/.github/workflows/omega-gauntlet-001-autonomous.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           path: pages
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish OMEGA scoreboard to GitHub Pages
     if: ${{ false }}
     needs: omega-gauntlet

--- a/.github/workflows/seed-runner-autonomous.yml
+++ b/.github/workflows/seed-runner-autonomous.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           path: docs
 
-  deploy-pages:
+  notify-evidence-hub:
     name: Publish Edge Seed Runner scoreboard
     needs: run-seeds
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Remove ambiguous per-workflow Pages deploy labeling so only a single central publisher controls GitHub Pages publishing and to prevent accidental partial-site overwrites. 
- Make the intended architecture explicit: experiment workflows produce artifacts and notify the hub instead of attempting to deploy the site themselves.

### Description
- Renamed non-central workflow job keys from `deploy-pages` to `notify-evidence-hub` across the autonomous/experiment workflows so those jobs no longer appear to (or attempt to) perform Pages deployment. 
- Preserved each workflow's experiment logic, artifact uploads, and conditional experiment bundle upload behavior while leaving the central `.github/workflows/evidence-hub-publish.yml` as the only workflow using `actions/upload-pages-artifact` and `actions/deploy-pages`. 
- Ensured the architecture guard `scripts/check_pages_architecture.py` still enforces the rule that only `evidence-hub-publish.yml` may reference Pages deployment actions. 
- Files touched include the autonomous experiment workflow files such as `helios-*`, `cyber-sovereign-*`, `benchmark-gauntlet-001-autonomous.yml`, `omega-gauntlet-001-autonomous.yml`, `evidence-factory-autonomous.yml`, `seed-runner-autonomous.yml`, `falsification-audit-autonomous.yml`, `frontier-usefulness-autonomous.yml`, `l4-l7-evidence-autopilot.yml`, and related adapters/scaling workflows. 

### Testing
- Ran `python scripts/check_pages_architecture.py` which completed successfully and confirmed only the central publisher references Pages deploy actions. 
- Ran the unit test suite with `python -m unittest discover -s tests` which executed 25 tests and returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3dfba48a08333b21eb5115c3c3ddc)