### PR TITLE
Unify dynamic Evidence Hub publishing across all AGI ALPHA workflows

### DIFF
--- a/scripts/check_pages_architecture.py
+++ b/scripts/check_pages_architecture.py
@@ -1,14 +1,37 @@
 from pathlib import Path
-forbidden=['actions/deploy-pages','actions/upload-pages-artifact','github-pages-deploy-action','peaceiris/actions-gh-pages','jamesives/github-pages-deploy-action']
-allowed='evidence-hub-publish.yml'
-viol=[]
-for p in Path('.github/workflows').glob('*.yml'):
-    t=p.read_text().lower()
-    for f in forbidden:
-        if f in t and p.name!=allowed:
-            viol.append((p.name,f))
-if viol:
-    raise SystemExit('forbidden pages deploy references: '+str(viol))
-if 'actions/deploy-pages' not in Path('.github/workflows',allowed).read_text().lower():
-    raise SystemExit('central publisher missing deploy-pages')
-print('ok')
+import re
+
+forbidden_refs = [
+    "actions/deploy-pages",
+    "actions/upload-pages-artifact",
+    "github-pages-deploy-action",
+    "peaceiris/actions-gh-pages",
+    "jamesives/github-pages-deploy-action",
+]
+forbidden_cmd_patterns = [
+    r"\bgit\s+push\s+.*\bgh-pages\b",
+    r"\bgh-pages\b",
+]
+allowed = "evidence-hub-publish.yml"
+violations = []
+
+for workflow in Path(".github/workflows").glob("*.yml"):
+    text = workflow.read_text().lower()
+    if workflow.name == allowed:
+        continue
+    for ref in forbidden_refs:
+        if ref in text:
+            violations.append((workflow.name, ref))
+    for cmd_pattern in forbidden_cmd_patterns:
+        if re.search(cmd_pattern, text):
+            violations.append((workflow.name, f"cmd:{cmd_pattern}"))
+
+if violations:
+    raise SystemExit(f"forbidden pages deploy references: {violations}")
+
+central_text = Path(".github/workflows", allowed).read_text().lower()
+for required in ("actions/deploy-pages", "actions/upload-pages-artifact"):
+    if required not in central_text:
+        raise SystemExit(f"central publisher missing {required}")
+
+print("ok")


### PR DESCRIPTION
### Motivation
- Prevent non-central workflows from accidentally overwriting the Pages site by strengthening the CI guard that enforces a single central publisher for the Evidence Hub.

### Description
- Hardened `scripts/check_pages_architecture.py` to detect forbidden Pages action references and `gh-pages`-style command patterns in any workflow other than `evidence-hub-publish.yml`, and to require that the central publisher contains both `actions/upload-pages-artifact` and `actions/deploy-pages`.

### Testing
- Ran `python scripts/check_pages_architecture.py` and `python -m unittest discover -s tests`, which completed successfully (25 tests passed), and executed the build/validate/linkcheck steps via `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site` without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e2ad7fd083339d9c09d68ab23fc3)