### PR TITLE
Build AGI ALPHA Evidence Mission Control

### DIFF
--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -13,21 +13,33 @@ def _load(base):
 def build_site(registry='evidence_registry', out='_site'):
     runs,exps,wfs=_load(registry)
     o=Path(out); o.mkdir(parents=True,exist_ok=True)
-    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety']:(o/d).mkdir(exist_ok=True)
+    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets']:
+        (o/d).mkdir(exist_ok=True)
+
+    o.joinpath('assets/app.css').write_text(':root{--bg:#f7f9fc;--text:#0f172a;--panel:#fff;--line:#dbe3ef;--accent:#2563eb}body{font-family:Inter,Arial,sans-serif;background:var(--bg);color:var(--text)}table{width:100%;border-collapse:collapse}td,th{border:1px solid var(--line);padding:.45rem}a{color:var(--accent)}')
+    o.joinpath('assets/app.js').write_text('document.querySelectorAll("[data-copy]").forEach(b=>b.onclick=()=>navigator.clipboard?.writeText(b.dataset.copy));')
+
     by_exp={}
-    for r in sorted(runs,key=lambda x:x.get('generated_at',''), reverse=True): by_exp.setdefault(r['experiment_slug'],[]).append(r)
+    for r in sorted(runs,key=lambda x:x.get('generated_at',''), reverse=True):
+        by_exp.setdefault(r['experiment_slug'],[]).append(r)
     rows=''.join([f"<tr><td>{html.escape(r.get('generated_at',''))}</td><td><a href='/agialpha-first-real-loop/experiments/{r['experiment_slug']}/'>{r['experiment_slug']}</a></td><td>{html.escape(r.get('workflow_name',''))}</td><td>{r.get('status')}</td><td>{r.get('claim_level')}</td><td>{r.get('metrics',{}).get('replay_passes','not_reported')}</td><td>{r.get('metrics',{}).get('baseline_count','not_reported')}</td><td>{r.get('metrics',{}).get('safety_incidents','not_reported')}</td><td>{r.get('external_review',{}).get('status','not_started')}</td><td>{r.get('pr_review',{}).get('status','not_applicable')}</td><td><a href='/agialpha-first-real-loop/runs/{r['run_id']}/'>run page</a></td><td><a href='{r.get('run_url','#')}'>actions</a></td></tr>" for r in runs])
     o.joinpath('index.html').write_text(page('AGI ALPHA Evidence Hub',f"<h2>Unified Evidence Docket registry for AGI ALPHA workflows, experiments, replay, baselines, safety ledgers, and external review.</h2><p>{CLAIM_BOUNDARY}</p><h3>Recent Runs</h3><table>{rows}</table>"))
     o.joinpath('404.html').write_text(page('Not Found','<a href="/agialpha-first-real-loop/">Back to hub</a>'))
     o.joinpath('experiments/index.html').write_text(page('Experiments',''.join([f"<li><a href='/agialpha-first-real-loop/experiments/{e['slug']}/'>{e['slug']}</a></li>" for e in exps])))
     o.joinpath('workflows/index.html').write_text(page('Workflows',''.join([f"<li><a href='/agialpha-first-real-loop/workflows/{w['slug']}/'>{w['name']}</a></li>" for w in wfs])))
     o.joinpath('runs/index.html').write_text(page('Runs',''.join([f"<li><a href='/agialpha-first-real-loop/runs/{r['run_id']}/'>{r['run_id']}</a></li>" for r in runs])))
-    for s in ['artifacts','external-review','safety','legacy']: o.joinpath(s,'index.html').write_text(page(s.title(),'<a href="/agialpha-first-real-loop/">Back</a>'))
+    for s in ['artifacts','external-review','safety','legacy','falsification']:
+        o.joinpath(s,'index.html').write_text(page(s.title(),'<a href="/agialpha-first-real-loop/">Back</a>'))
+
+    launch_rows=''.join([f"<tr><td>{w.get('name')}</td><td>{w.get('file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{w.get('file','')}'>{w.get('file')}</a></td><td><code>gh workflow run {w.get('file','')}</code></td></tr>" for w in wfs])
+    o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
+
     for exp,runs_exp in by_exp.items():
         ep=o/'experiments'/exp; (ep/'runs').mkdir(parents=True,exist_ok=True)
         latest=runs_exp[0]
         run_rows=''.join([f"<tr><td>{r['run_id']}</td><td>{r.get('status')}</td><td><a href='{r.get('run_url','#')}'>actions</a></td></tr>" for r in runs_exp])
         ep.joinpath('index.html').write_text(page(exp,f"<div>claim boundary: {html.escape(latest.get('claim_boundary','missing'))}</div><div>latest status: {latest.get('status')}</div><div>safety incidents: {latest.get('metrics',{}).get('safety_incidents','not_reported')}</div><table>{run_rows}</table><a href='/agialpha-first-real-loop/'>Back to hub</a>"))
+
     for r in runs:
         rp=o/'runs'/r['run_id']; rp.mkdir(parents=True,exist_ok=True)
         rp.joinpath('manifest.json').write_text(json.dumps(r,indent=2))
@@ -35,9 +47,17 @@ def build_site(registry='evidence_registry', out='_site'):
         exp_rp=o/'experiments'/r['experiment_slug']/'runs'/r['run_id']; exp_rp.mkdir(parents=True,exist_ok=True)
         exp_rp.joinpath('index.html').write_text(rp.joinpath('index.html').read_text())
         exp_rp.joinpath('manifest.json').write_text(json.dumps(r,indent=2))
+
     for slug in LEGACY_SLUGS:
         lp=o/slug; lp.mkdir(exist_ok=True)
         target=f"/agialpha-first-real-loop/experiments/{slug}/" if slug in by_exp else '/agialpha-first-real-loop/'
         msg='backfill required' if slug not in by_exp else 'legacy route mapped'
         lp.joinpath('index.html').write_text(page(slug,f"<meta http-equiv='refresh' content='0; url={target}'/><p>{msg}</p><a href='{target}'>Canonical page</a>"))
-    o.joinpath('data/runs.json').write_text(json.dumps(runs,indent=2)); o.joinpath('data/experiments.json').write_text(json.dumps(exps,indent=2)); o.joinpath('data/workflows.json').write_text(json.dumps(wfs,indent=2)); o.joinpath('data/latest.json').write_text(json.dumps(runs[0] if runs else {},indent=2)); o.joinpath('data/safety.json').write_text(json.dumps({'runs':len(runs)},indent=2)); o.joinpath('data/external_review.json').write_text(json.dumps({'runs':len(runs)},indent=2))
+
+    o.joinpath('data/runs.json').write_text(json.dumps(runs,indent=2))
+    o.joinpath('data/experiments.json').write_text(json.dumps(exps,indent=2))
+    o.joinpath('data/workflows.json').write_text(json.dumps(wfs,indent=2))
+    o.joinpath('data/latest.json').write_text(json.dumps(runs[0] if runs else {},indent=2))
+    o.joinpath('data/safety.json').write_text(json.dumps({'runs':len(runs)},indent=2))
+    o.joinpath('data/external_review.json').write_text(json.dumps({'runs':len(runs)},indent=2))
+    o.joinpath('data/workflow_catalog.json').write_text(json.dumps({'workflows':wfs},indent=2))

--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -8,6 +8,14 @@ def _load(base):
     runs=json.loads((b/'runs.json').read_text()) if (b/'runs.json').exists() else []
     exps=json.loads((b/'experiments.json').read_text()) if (b/'experiments.json').exists() else []
     wfs=json.loads((b/'workflows.json').read_text()) if (b/'workflows.json').exists() else []
+    catalog_path = b / 'workflow_catalog.json'
+    catalog = json.loads(catalog_path.read_text()) if catalog_path.exists() else {'workflows': []}
+    if isinstance(catalog, dict):
+        catalog_workflows = catalog.get('workflows', [])
+    else:
+        catalog_workflows = catalog
+    if catalog_workflows:
+        wfs = catalog_workflows
     return runs,exps,wfs
 
 def build_site(registry='evidence_registry', out='_site'):
@@ -26,12 +34,12 @@ def build_site(registry='evidence_registry', out='_site'):
     o.joinpath('index.html').write_text(page('AGI ALPHA Evidence Hub',f"<h2>Unified Evidence Docket registry for AGI ALPHA workflows, experiments, replay, baselines, safety ledgers, and external review.</h2><p>{CLAIM_BOUNDARY}</p><h3>Recent Runs</h3><table>{rows}</table>"))
     o.joinpath('404.html').write_text(page('Not Found','<a href="/agialpha-first-real-loop/">Back to hub</a>'))
     o.joinpath('experiments/index.html').write_text(page('Experiments',''.join([f"<li><a href='/agialpha-first-real-loop/experiments/{e['slug']}/'>{e['slug']}</a></li>" for e in exps])))
-    o.joinpath('workflows/index.html').write_text(page('Workflows',''.join([f"<li><a href='/agialpha-first-real-loop/workflows/{w['slug']}/'>{w['name']}</a></li>" for w in wfs])))
+    o.joinpath('workflows/index.html').write_text(page('Workflows',''.join([f"<li><a href='/agialpha-first-real-loop/workflows/{(w.get('slug') or Path(w.get('workflow_file','')).stem)}/'>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</a></li>" for w in wfs])))
     o.joinpath('runs/index.html').write_text(page('Runs',''.join([f"<li><a href='/agialpha-first-real-loop/runs/{r['run_id']}/'>{r['run_id']}</a></li>" for r in runs])))
     for s in ['artifacts','external-review','safety','legacy','falsification']:
         o.joinpath(s,'index.html').write_text(page(s.title(),'<a href="/agialpha-first-real-loop/">Back</a>'))
 
-    launch_rows=''.join([f"<tr><td>{w.get('name')}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>gh workflow run {Path(w.get('workflow_file','')).name}</code></td></tr>" for w in wfs])
+    launch_rows=''.join([f"<tr><td>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>{w.get('gh_command') or ('gh workflow run ' + Path(w.get('workflow_file','')).name)}</code></td></tr>" for w in wfs])
     o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
 
     for exp,runs_exp in by_exp.items():

--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -31,7 +31,7 @@ def build_site(registry='evidence_registry', out='_site'):
     for s in ['artifacts','external-review','safety','legacy','falsification']:
         o.joinpath(s,'index.html').write_text(page(s.title(),'<a href="/agialpha-first-real-loop/">Back</a>'))
 
-    launch_rows=''.join([f"<tr><td>{w.get('name')}</td><td>{w.get('file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{w.get('file','')}'>{w.get('file')}</a></td><td><code>gh workflow run {w.get('file','')}</code></td></tr>" for w in wfs])
+    launch_rows=''.join([f"<tr><td>{w.get('name')}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>gh workflow run {Path(w.get('workflow_file','')).name}</code></td></tr>" for w in wfs])
     o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
 
     for exp,runs_exp in by_exp.items():

--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -39,7 +39,7 @@ def build_site(registry='evidence_registry', out='_site'):
     for s in ['artifacts','external-review','safety','legacy','falsification']:
         o.joinpath(s,'index.html').write_text(page(s.title(),'<a href="/agialpha-first-real-loop/">Back</a>'))
 
-    launch_rows=''.join([f"<tr><td>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>{w.get('gh_command') or ('gh workflow run ' + Path(w.get('workflow_file','')).name)}</code></td></tr>" for w in wfs])
+    launch_rows=''.join([f"<tr><td>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>{w.get('gh_command') or 'workflow_dispatch not enabled'}</code></td></tr>" for w in wfs])
     o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
 
     for exp,runs_exp in by_exp.items():

--- a/agialpha_evidence_hub/cli.py
+++ b/agialpha_evidence_hub/cli.py
@@ -46,7 +46,8 @@ def main():
     elif a.cmd=='workflow-catalog':
         root=Path(a.repo_root)
         rows=[]
-        for wf in sorted((root/'.github/workflows').glob('*.yml')):
+        workflow_files = sorted((root/'.github/workflows').glob('*.yml')) + sorted((root/'.github/workflows').glob('*.yaml'))
+        for wf in sorted(workflow_files):
             text=wf.read_text()
             has_dispatch='workflow_dispatch' in text
             rows.append({'workflow_file':str(wf.relative_to(root)),'has_workflow_dispatch':has_dispatch,'inputs':parse_workflow_dispatch_inputs(text),'gh_command':workflow_gh_command(str(wf),has_dispatch)})

--- a/agialpha_evidence_hub/cli.py
+++ b/agialpha_evidence_hub/cli.py
@@ -7,6 +7,7 @@ from .registry import update_registry
 from .build import build_site
 from .linkcheck import linkcheck
 from .discover import discover_to_file
+from .workflow_dispatch import parse_workflow_dispatch_inputs, workflow_gh_command
 
 def _default_manifest(args):
     return {
@@ -24,6 +25,7 @@ def main():
     bs=sp.add_parser('build'); bs.add_argument('--registry',default='evidence_registry'); bs.add_argument('--out',default='_site')
     v=sp.add_parser('validate'); v.add_argument('--registry',default='evidence_registry'); v.add_argument('--site',default='_site')
     l=sp.add_parser('linkcheck'); l.add_argument('--site',default='_site')
+    wc=sp.add_parser('workflow-catalog'); wc.add_argument('--repo-root',default='.'); wc.add_argument('--registry',default='evidence_registry')
     a=ap.parse_args()
     if a.cmd=='discover': print(json.dumps(discover_to_file(a.repo_root,a.out),indent=2))
     elif a.cmd=='register-run': m=load_input(a.input); validate_manifest(m); update_registry(a.registry,m)
@@ -41,4 +43,15 @@ def main():
     elif a.cmd=='linkcheck': linkcheck(a.site)
     elif a.cmd=='ingest-artifacts': print('0')
     elif a.cmd=='github-discover': print(json.dumps({'limit':a.limit,'runs':[]},indent=2))
+    elif a.cmd=='workflow-catalog':
+        root=Path(a.repo_root)
+        rows=[]
+        for wf in sorted((root/'.github/workflows').glob('*.yml')):
+            text=wf.read_text()
+            has_dispatch='workflow_dispatch' in text
+            rows.append({'workflow_file':str(wf.relative_to(root)),'has_workflow_dispatch':has_dispatch,'inputs':parse_workflow_dispatch_inputs(text),'gh_command':workflow_gh_command(str(wf),has_dispatch)})
+        out=Path(a.registry)/'workflow_catalog.json'
+        out.parent.mkdir(parents=True,exist_ok=True)
+        out.write_text(json.dumps({'workflows':rows},indent=2))
+        print(json.dumps({'workflows':rows},indent=2))
 if __name__=='__main__': main()

--- a/agialpha_evidence_hub/ui.py
+++ b/agialpha_evidence_hub/ui.py
@@ -1,0 +1,11 @@
+MISSION_PAGE_CLAIM_BOUNDARY = (
+    "No Evidence Docket, no empirical SOTA claim. "
+    "Autonomous evidence production is allowed; autonomous claim promotion is not."
+)
+
+ROOT_CLAIM_BOUNDARY = (
+    "This hub records bounded Evidence Docket experiments. It does not claim achieved AGI, ASI, "
+    "empirical SOTA, safe autonomy, real-world certification, guaranteed economic return, or "
+    "civilization-scale capability. Stronger claims require independent replay, official public "
+    "benchmarks, cost/safety review, delayed outcomes, and external audit."
+)

--- a/agialpha_evidence_hub/workflow_dispatch.py
+++ b/agialpha_evidence_hub/workflow_dispatch.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import re
+
+
+def parse_workflow_dispatch_inputs(workflow_text: str) -> dict:
+    """Best-effort parser for top-level workflow_dispatch inputs."""
+    inputs = {}
+    in_dispatch = False
+    in_inputs = False
+    for line in workflow_text.splitlines():
+        if re.match(r"^\s*workflow_dispatch\s*:", line):
+            in_dispatch = True
+            continue
+        if in_dispatch and re.match(r"^\s*inputs\s*:", line):
+            in_inputs = True
+            continue
+        if in_inputs:
+            m = re.match(r"^\s{4,}([A-Za-z0-9_-]+)\s*:\s*$", line)
+            if m:
+                inputs[m.group(1)] = {}
+                continue
+            if line.strip() and not line.startswith(" "):
+                break
+    return inputs
+
+
+def workflow_gh_command(workflow_file: str, has_dispatch: bool) -> str | None:
+    if not has_dispatch:
+        return None
+    return f"gh workflow run {Path(workflow_file).name}"

--- a/agialpha_evidence_hub/workflow_dispatch.py
+++ b/agialpha_evidence_hub/workflow_dispatch.py
@@ -7,20 +7,37 @@ def parse_workflow_dispatch_inputs(workflow_text: str) -> dict:
     inputs = {}
     in_dispatch = False
     in_inputs = False
+    dispatch_indent = None
+    inputs_indent = None
+
     for line in workflow_text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+
         if re.match(r"^\s*workflow_dispatch\s*:", line):
             in_dispatch = True
+            in_inputs = False
+            dispatch_indent = indent
             continue
+
+        if in_dispatch and dispatch_indent is not None and indent <= dispatch_indent:
+            in_dispatch = False
+            in_inputs = False
+
         if in_dispatch and re.match(r"^\s*inputs\s*:", line):
             in_inputs = True
+            inputs_indent = indent
             continue
+
+        if in_inputs and inputs_indent is not None and indent <= inputs_indent:
+            in_inputs = False
+
         if in_inputs:
             m = re.match(r"^\s{4,}([A-Za-z0-9_-]+)\s*:\s*$", line)
             if m:
                 inputs[m.group(1)] = {}
-                continue
-            if line.strip() and not line.startswith(" "):
-                break
+
     return inputs
 
 

--- a/tests/test_evidence_hub_visual_assets.py
+++ b/tests/test_evidence_hub_visual_assets.py
@@ -1,0 +1,16 @@
+import subprocess
+import unittest
+
+
+class TestEvidenceHubVisualAssets(unittest.TestCase):
+    def test_visual_assets_exist_after_build(self):
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / 'site'
+            subprocess.run(['python','-m','agialpha_evidence_hub','build','--registry','evidence_registry','--out',str(out)], check=True)
+            self.assertTrue((out / 'assets' / 'app.css').exists())
+            self.assertTrue((out / 'assets' / 'app.js').exists())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evidence_hub_workflow_launchpad.py
+++ b/tests/test_evidence_hub_workflow_launchpad.py
@@ -41,6 +41,22 @@ class TestEvidenceHubWorkflowLaunchpad(unittest.TestCase):
             self.assertIn('replay.yml', html)
             self.assertIn('gh workflow run replay.yml', html)
 
+    def test_build_consumes_workflow_catalog_when_workflows_json_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            reg = Path(td) / 'registry'
+            out = Path(td) / 'site'
+            reg.mkdir(parents=True)
+            (reg / 'runs.json').write_text('[]')
+            (reg / 'experiments.json').write_text('[]')
+            (reg / 'workflows.json').write_text('[]')
+            (reg / 'workflow_catalog.json').write_text(json.dumps({'workflows':[{'workflow_file':'.github/workflows/replay.yml','name':'Replay','gh_command':'gh workflow run replay.yml'}]}))
+            build_site(str(reg), str(out))
+            html = (out / 'launchpad' / 'index.html').read_text()
+            self.assertIn('Replay', html)
+            self.assertIn('gh workflow run replay.yml', html)
+            published = json.loads((out / 'data' / 'workflow_catalog.json').read_text())
+            self.assertEqual(1, len(published['workflows']))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_evidence_hub_workflow_launchpad.py
+++ b/tests/test_evidence_hub_workflow_launchpad.py
@@ -34,7 +34,7 @@ class TestEvidenceHubWorkflowLaunchpad(unittest.TestCase):
             (reg / 'runs.json').write_text('[]')
             (reg / 'experiments.json').write_text('[]')
             (reg / 'workflows.json').write_text(json.dumps([
-                {'name': 'Replay', 'slug': 'replay', 'workflow_file': '.github/workflows/replay.yml'}
+                {'name': 'Replay', 'slug': 'replay', 'workflow_file': '.github/workflows/replay.yml', 'gh_command': 'gh workflow run replay.yml'}
             ]))
             build_site(str(reg), str(out))
             html = (out / 'launchpad' / 'index.html').read_text()
@@ -56,6 +56,32 @@ class TestEvidenceHubWorkflowLaunchpad(unittest.TestCase):
             self.assertIn('gh workflow run replay.yml', html)
             published = json.loads((out / 'data' / 'workflow_catalog.json').read_text())
             self.assertEqual(1, len(published['workflows']))
+
+    def test_launchpad_does_not_fabricate_command_without_dispatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            reg = Path(td) / 'registry'
+            out = Path(td) / 'site'
+            reg.mkdir(parents=True)
+            (reg / 'runs.json').write_text('[]')
+            (reg / 'experiments.json').write_text('[]')
+            (reg / 'workflows.json').write_text('[]')
+            (reg / 'workflow_catalog.json').write_text(json.dumps({'workflows':[{'workflow_file':'.github/workflows/no-dispatch.yml','name':'No Dispatch','gh_command':None}]}))
+            build_site(str(reg), str(out))
+            html = (out / 'launchpad' / 'index.html').read_text()
+            self.assertIn('workflow_dispatch not enabled', html)
+            self.assertNotIn('gh workflow run no-dispatch.yml', html)
+
+    def test_workflow_catalog_includes_yaml_extension(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            wf_dir = root / '.github' / 'workflows'
+            wf_dir.mkdir(parents=True)
+            (wf_dir / 'alpha.yaml').write_text('on:\n  workflow_dispatch:\n')
+            registry = root / 'registry'
+            subprocess.run(['python','-m','agialpha_evidence_hub','workflow-catalog','--repo-root',str(root),'--registry',str(registry)], check=True)
+            data = json.loads((registry / 'workflow_catalog.json').read_text())
+            files = {w['workflow_file'] for w in data['workflows']}
+            self.assertIn('.github/workflows/alpha.yaml', files)
 
 
 if __name__ == '__main__':

--- a/tests/test_evidence_hub_workflow_launchpad.py
+++ b/tests/test_evidence_hub_workflow_launchpad.py
@@ -1,0 +1,21 @@
+import json
+import subprocess
+import unittest
+
+
+class TestEvidenceHubWorkflowLaunchpad(unittest.TestCase):
+    def test_workflow_catalog_generates_gh_commands(self):
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as td:
+            registry = Path(td) / 'registry'
+            subprocess.run([
+                'python','-m','agialpha_evidence_hub','workflow-catalog','--repo-root','.', '--registry', str(registry)
+            ], check=True)
+            data = json.loads((registry / 'workflow_catalog.json').read_text())
+            self.assertTrue(data['workflows'])
+            self.assertTrue(any(w['has_workflow_dispatch'] for w in data['workflows']))
+            self.assertTrue(any((w.get('gh_command') or '').startswith('gh workflow run') for w in data['workflows']))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evidence_hub_workflow_launchpad.py
+++ b/tests/test_evidence_hub_workflow_launchpad.py
@@ -1,12 +1,15 @@
 import json
 import subprocess
+import tempfile
 import unittest
+from pathlib import Path
+
+from agialpha_evidence_hub.build import build_site
+from agialpha_evidence_hub.workflow_dispatch import parse_workflow_dispatch_inputs
 
 
 class TestEvidenceHubWorkflowLaunchpad(unittest.TestCase):
     def test_workflow_catalog_generates_gh_commands(self):
-        import tempfile
-        from pathlib import Path
         with tempfile.TemporaryDirectory() as td:
             registry = Path(td) / 'registry'
             subprocess.run([
@@ -16,6 +19,28 @@ class TestEvidenceHubWorkflowLaunchpad(unittest.TestCase):
             self.assertTrue(data['workflows'])
             self.assertTrue(any(w['has_workflow_dispatch'] for w in data['workflows']))
             self.assertTrue(any((w.get('gh_command') or '').startswith('gh workflow run') for w in data['workflows']))
+
+    def test_dispatch_inputs_do_not_include_push_paths(self):
+        workflow = Path('.github/workflows/benchmark-gauntlet-001-autonomous.yml').read_text()
+        inputs = parse_workflow_dispatch_inputs(workflow)
+        self.assertIn('challenge_dir', inputs)
+        self.assertNotIn('paths', inputs)
+
+    def test_launchpad_uses_workflow_file_field(self):
+        with tempfile.TemporaryDirectory() as td:
+            reg = Path(td) / 'registry'
+            out = Path(td) / 'site'
+            reg.mkdir(parents=True)
+            (reg / 'runs.json').write_text('[]')
+            (reg / 'experiments.json').write_text('[]')
+            (reg / 'workflows.json').write_text(json.dumps([
+                {'name': 'Replay', 'slug': 'replay', 'workflow_file': '.github/workflows/replay.yml'}
+            ]))
+            build_site(str(reg), str(out))
+            html = (out / 'launchpad' / 'index.html').read_text()
+            self.assertIn('replay.yml', html)
+            self.assertIn('gh workflow run replay.yml', html)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation
- The Evidence Hub lacked a polished operator-facing launchpad and visual assets, and workflow discovery/CLI integration was incomplete which hampered centralized publishing and operator workflows. 
- The change implements central discovery and UX primitives so the hub can surface workflows, provide copyable `gh workflow run` commands, emit standardized manifests, and preserve claim-boundary language across pages.

### Description
- Added `agialpha_evidence_hub/workflow_dispatch.py` to best-effort parse `.github/workflows/*.yml` for `workflow_dispatch` inputs and synthesize copyable `gh workflow run <file>.yml` commands. 
- Added `agialpha_evidence_hub/ui.py` holding mission/root claim-boundary constants to ensure consistent messaging on generated pages. 
- Extended the CLI in `agialpha_evidence_hub/cli.py` with a `workflow-catalog` command that writes `workflow_catalog.json` into the registry and prints discovered workflows. 
- Enhanced the site builder in `agialpha_evidence_hub/build.py` to emit visual assets (`assets/app.css`, `assets/app.js`), create `/launchpad/` and related directories, render a basic launchpad table with GitHub workflow links + CLI commands, and output `data/workflow_catalog.json`. 
- Added tests `tests/test_evidence_hub_workflow_launchpad.py` and `tests/test_evidence_hub_visual_assets.py` to validate workflow catalog generation and that visual assets are produced by the build.

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests`, which completed successfully (all tests passed). 
- Executed architecture and site checks via `python scripts/check_pages_architecture.py`, `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, which returned OK in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e4ae1c0883339abb47a574e7da98)