### PR TITLE
Build AGI ALPHA Evidence Mission Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
### Motivation
- Prevent noisy Python bytecode artifacts from cluttering the working tree after running the Evidence Hub test/build pipeline so registry updates and site builds remain clean and deterministic.

### Description
- Add a repository-level `.gitignore` that excludes `__pycache__/` and `*.pyc` to keep test/build outputs from appearing as untracked changes (file: `.gitignore`).

### Testing
- Ran `python -m unittest discover -s tests` and all tests passed.
- Ran `python scripts/check_pages_architecture.py`, `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ef2f27708333aaa1dbe66f22100b)