### PR TITLE
Build AGI ALPHA Evidence Mission Control

### DIFF
--- a/README_EVIDENCE_HUB.md
+++ b/README_EVIDENCE_HUB.md
@@ -74,3 +74,18 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 
 
 See also: [`CONTENT_PRESERVATION_MIGRATION_NOTES.md`](CONTENT_PRESERVATION_MIGRATION_NOTES.md).
+
+## Strict Prompt Profile (Mission Control Hard Mode)
+
+For large-scale Codex migrations, enforce these invariants explicitly in the prompt:
+
+- **No evidence downgrade:** lower-information backfill must never overwrite richer manifests/scoreboards.
+- **Project-path-safe assets:** nested pages must resolve `/agialpha-first-real-loop/assets/app.css` and `app.js`.
+- **Single Pages deployer:** only `evidence-hub-publish.yml` may publish GitHub Pages.
+- **Rich experiment pages required:** if evidence exists, render metrics/safety/replay tables (no shallow placeholders).
+- **Workflow launch controls:** per-workflow GitHub UI links and copyable `gh workflow run ...` commands only (no browser tokens).
+- **Persistent registry first:** preserve run history, artifacts, raw references, and conflict notes in `evidence_registry/CHANGELOG.md`.
+- **Claim boundary doctrine:** every page must include `No Evidence Docket, no empirical SOTA claim.`
+
+This profile keeps the site operator-friendly while preserving publication-grade evidence discipline.
+


### PR DESCRIPTION
### Motivation
- Codify strict Mission Control invariants for the Evidence Hub so future migrations and the central publisher preserve anti-downgrade, project-path-safe assets, single-pages-deployer rules, rich experiment rendering, safe workflow-launch controls, persistent registry preservation, and the claim-boundary doctrine.

### Description
- Add a `Strict Prompt Profile (Mission Control Hard Mode)` section to `README_EVIDENCE_HUB.md` that documents the non-negotiable operational invariants (no evidence downgrade, project-path-safe asset linking, single `evidence-hub-publish.yml` deployer, rich per-experiment pages, safe `gh workflow` run commands only, persistent registry changelog, and mandatory claim-boundary text).

### Testing
- Ran the test suite with `python -m unittest discover -s tests` which completed successfully (34 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f406ddcf508333bc968ac6002cbec2)