### PR TITLE
Build AGI ALPHA Evidence Mission Control

### DIFF
--- a/agialpha_evidence_hub/registry.py
+++ b/agialpha_evidence_hub/registry.py
@@ -30,6 +30,18 @@ def update_registry(base, manifest):
     reg=load_registry(base)
     run_id=manifest.get('run_id') or f"historical-{manifest.get('experiment_slug','unknown')}"
     manifest['run_id']=run_id
+    existing=next((r for r in reg['runs'] if r.get('run_id')==run_id), None)
+    if existing:
+        merged=dict(existing)
+        merged.update({k:v for k,v in manifest.items() if v not in (None,'',[],{},'unavailable','not_reported')})
+        old_metrics=existing.get('metrics',{}) if isinstance(existing.get('metrics',{}),dict) else {}
+        new_metrics=manifest.get('metrics',{}) if isinstance(manifest.get('metrics',{}),dict) else {}
+        metrics=dict(old_metrics)
+        for k,v in new_metrics.items():
+            if k not in metrics or metrics.get(k) in (None,'','unavailable','not_reported'):
+                metrics[k]=v
+        merged['metrics']=metrics
+        manifest=merged
     reg['runs']=[r for r in reg['runs'] if r.get('run_id')!=run_id]+[manifest]
     exp={'slug':manifest.get('experiment_slug','unknown'),'name':manifest.get('experiment_name',manifest.get('experiment_slug','unknown')),'family':manifest.get('experiment_family','other')}
     if exp['slug'] not in [e['slug'] for e in reg['experiments']]: reg['experiments'].append(exp)

--- a/tests/test_no_rich_evidence_downgrade.py
+++ b/tests/test_no_rich_evidence_downgrade.py
@@ -1,0 +1,46 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agialpha_evidence_hub.registry import update_registry, load_registry
+
+
+class TestNoRichEvidenceDowngrade(unittest.TestCase):
+    def test_sparse_update_does_not_clobber_rich_metrics(self):
+        with tempfile.TemporaryDirectory() as d:
+            rich = {
+                "run_id": "123",
+                "experiment_slug": "cyber-sovereign-002",
+                "experiment_name": "Cyber Sovereign 002",
+                "workflow_name": "cyber-sovereign-002-autonomous",
+                "workflow_file": ".github/workflows/cyber-sovereign-002-autonomous.yml",
+                "metrics": {
+                    "B6_beats_B5_count": 7,
+                    "valid_findings_count": 11,
+                    "replay_passes": 3,
+                },
+                "source": "manifest",
+            }
+            sparse = {
+                "run_id": "123",
+                "experiment_slug": "cyber-sovereign-002",
+                "experiment_name": "Cyber Sovereign 002",
+                "workflow_name": "cyber-sovereign-002-autonomous",
+                "workflow_file": ".github/workflows/cyber-sovereign-002-autonomous.yml",
+                "metrics": {
+                    "B6_beats_B5_count": "unavailable",
+                },
+                "source": "historical_backfill",
+            }
+            update_registry(d, rich)
+            update_registry(d, sparse)
+            reg = load_registry(d)
+            run = next(r for r in reg["runs"] if r["run_id"] == "123")
+            self.assertEqual(run["metrics"]["B6_beats_B5_count"], 7)
+            self.assertEqual(run["metrics"]["valid_findings_count"], 11)
+            self.assertEqual(run["metrics"]["replay_passes"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent historical or low-information backfill from overwriting richer run evidence in the persistent registry by enforcing the project’s "no evidence downgrade" merge rule during registry updates.

### Description
- Change `agialpha_evidence_hub.registry.update_registry` to detect existing runs and merge conservatively: copy existing top-level fields, update only with non-empty/non-placeholder values, and merge `metrics` field-by-field so richer metric values are preserved; add `tests/test_no_rich_evidence_downgrade.py` to assert this behavior.

### Testing
- Ran the focused unit tests `python -m unittest tests/test_no_rich_evidence_downgrade.py tests/test_evidence_hub_backfill.py` and both tests passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40a8855d48333b2dd5eaa9019d95d)