### PR TITLE
Fix GitHub Actions artifact action versions

### DIFF
--- a/.github/workflows/cyber-sovereign-001-autonomous.yml
+++ b/.github/workflows/cyber-sovereign-001-autonomous.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run Cybersecurity Sovereign 001
         run: python -m agialpha_sovereign_capstone cyber --out "$OUT" --root .
       - name: Upload Cybersecurity Sovereign artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: cyber-sovereign-001-${{ github.run_id }}
           path: ${{ env.OUT }}

--- a/.github/workflows/cyber-sovereign-001-delayed-outcome.yml
+++ b/.github/workflows/cyber-sovereign-001-delayed-outcome.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Generate delayed-outcome sentinel
         run: python -m agialpha_sovereign_capstone delayed --out runs/cyber-sovereign-delayed/${{ github.run_id }}
       - name: Upload delayed-outcome artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: cyber-sovereign-delayed-outcome-${{ github.run_id }}
           path: runs/cyber-sovereign-delayed/${{ github.run_id }}

--- a/.github/workflows/cyber-sovereign-001-external-replay.yml
+++ b/.github/workflows/cyber-sovereign-001-external-replay.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Try downloading prior Cybersecurity Sovereign artifact
         if: ${{ github.event_name == 'workflow_run' }}
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
@@ -50,7 +50,7 @@ jobs:
       - name: Run external replay report
         run: python -m agialpha_sovereign_capstone external-replay --source "$SRC" --out "$OUT"
       - name: Upload external replay artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: cyber-sovereign-external-replay-${{ github.run_id }}
           path: ${{ env.OUT }}

--- a/.github/workflows/cyber-sovereign-001-falsification-audit.yml
+++ b/.github/workflows/cyber-sovereign-001-falsification-audit.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run falsification audit
         run: python -m agialpha_sovereign_capstone audit --source "$SRC" --out "$OUT"
       - name: Upload falsification audit artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: cyber-sovereign-falsification-audit-${{ github.run_id }}
           path: ${{ env.OUT }}

--- a/.github/workflows/cyber-sovereign-001-scaling.yml
+++ b/.github/workflows/cyber-sovereign-001-scaling.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate scaling matrix
         run: python -m agialpha_sovereign_capstone scaling --out runs/cyber-sovereign-scaling/${{ github.run_id }}
       - name: Upload scaling artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: cyber-sovereign-scaling-${{ github.run_id }}
           path: runs/cyber-sovereign-scaling/${{ github.run_id }}

--- a/.github/workflows/evidence-factory-autonomous.yml
+++ b/.github/workflows/evidence-factory-autonomous.yml
@@ -178,7 +178,7 @@ jobs:
           PY
 
       - name: Upload completed Evidence Docket artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: evidence-docket-${{ github.run_id }}
           path: |
@@ -228,7 +228,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Evidence Docket artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: evidence-docket-${{ github.run_id }}
           path: evidence_factory_artifact

--- a/.github/workflows/falsification-audit-autonomous.yml
+++ b/.github/workflows/falsification-audit-autonomous.yml
@@ -87,7 +87,7 @@ jobs:
           python -S -m agialpha_seed_runner landing --docs docs
 
       - name: Upload falsification audit report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: falsification-audit-report
           path: |

--- a/.github/workflows/frontier-external-review.yml
+++ b/.github/workflows/frontier-external-review.yml
@@ -52,7 +52,7 @@ jobs:
           python -m agialpha_usefulness_frontier replay --portfolio "$PORTFOLIO" --out "external-review/frontier-usefulness-${{ github.run_id }}"
 
       - name: Upload external review replay artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: frontier-external-review-${{ github.run_id }}
           path: external-review/

--- a/.github/workflows/frontier-usefulness-autonomous.yml
+++ b/.github/workflows/frontier-usefulness-autonomous.yml
@@ -87,7 +87,7 @@ jobs:
           python -m agialpha_usefulness_frontier replay --portfolio "$OUTPUT_DIR" --out "runs/frontier-usefulness-replay/${{ github.run_id }}"
 
       - name: Upload Frontier Usefulness artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: frontier-usefulness-${{ github.run_id }}
           path: |

--- a/.github/workflows/helios-001-autonomous.yml
+++ b/.github/workflows/helios-001-autonomous.yml
@@ -96,7 +96,7 @@ jobs:
           python -m agialpha_helios audit --source "$HELIOS_DIR" --out "runs/helios-audit/${{ github.run_id }}"
 
       - name: Upload HELIOS Evidence Docket artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-001-evidence
           path: |

--- a/.github/workflows/helios-001-falsification-audit.yml
+++ b/.github/workflows/helios-001-falsification-audit.yml
@@ -72,7 +72,7 @@ jobs:
           python -m agialpha_helios audit --source "$SOURCE" --out "runs/helios-falsification-audit/${{ github.run_id }}"
 
       - name: Upload falsification audit report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-001-falsification-audit-report
           path: runs/helios-falsification-audit/${{ github.run_id }}

--- a/.github/workflows/helios-001-independent-replay.yml
+++ b/.github/workflows/helios-001-independent-replay.yml
@@ -81,7 +81,7 @@ jobs:
           python -m agialpha_helios replay --source "$SOURCE" --out "runs/helios-independent-replay/${{ github.run_id }}"
 
       - name: Upload independent replay report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-001-independent-replay-report
           path: runs/helios-independent-replay/${{ github.run_id }}

--- a/.github/workflows/helios-001-vnext-transfer.yml
+++ b/.github/workflows/helios-001-vnext-transfer.yml
@@ -70,7 +70,7 @@ jobs:
           python -m agialpha_helios vnext --source "$SOURCE" --out "runs/helios-vnext/${{ github.run_id }}"
 
       - name: Upload vNext transfer artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-001-vnext-transfer
           path: runs/helios-vnext/${{ github.run_id }}

--- a/.github/workflows/helios-002-autonomous.yml
+++ b/.github/workflows/helios-002-autonomous.yml
@@ -93,7 +93,7 @@ jobs:
           python -m agialpha_helios2 run --out "$OUT_DIR" --source "$SOURCE_EVIDENCE_DOCKET" --docs "$DOCS_DIR"
 
       - name: Upload HELIOS-002 evidence artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-002-evidence-${{ github.run_id }}
           path: ${{ env.OUT_DIR }}

--- a/.github/workflows/helios-002-benchmark-adapters.yml
+++ b/.github/workflows/helios-002-benchmark-adapters.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: python -m agialpha_helios2 adapters --out "$OUT_DIR" --docs "$DOCS_DIR"
       - name: Upload adapter artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-002-benchmark-adapters-${{ github.run_id }}
           path: ${{ env.OUT_DIR }}

--- a/.github/workflows/helios-002-external-replay.yml
+++ b/.github/workflows/helios-002-external-replay.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Upload HELIOS-002 external replay artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-002-external-replay-${{ github.run_id }}
           path: ${{ env.OUT_DIR }}

--- a/.github/workflows/helios-002-falsification-audit.yml
+++ b/.github/workflows/helios-002-falsification-audit.yml
@@ -52,7 +52,7 @@ jobs:
             python -m agialpha_helios2 audit --out "$OUT_DIR"
           fi
       - name: Upload HELIOS-002 audit artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-002-falsification-audit-${{ github.run_id }}
           path: ${{ env.OUT_DIR }}

--- a/.github/workflows/helios-002-scaling.yml
+++ b/.github/workflows/helios-002-scaling.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: python -m agialpha_helios2 scaling --out "$OUT_DIR" --docs "$DOCS_DIR"
       - name: Upload scaling artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-002-scaling-${{ github.run_id }}
           path: ${{ env.OUT_DIR }}

--- a/.github/workflows/helios-004-completion.yml
+++ b/.github/workflows/helios-004-completion.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Generate HELIOS completion dossier
         run: python -m agialpha_sovereign_capstone helios-complete --out "$OUT"
       - name: Upload HELIOS completion artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: helios-004-completion-${{ github.run_id }}
           path: ${{ env.OUT }}

--- a/.github/workflows/independent-replay-autonomous.yml
+++ b/.github/workflows/independent-replay-autonomous.yml
@@ -89,7 +89,7 @@ jobs:
           python -S -m agialpha_seed_runner landing --docs docs
 
       - name: Upload independent replay report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: independent-replay-report
           path: |

--- a/.github/workflows/l4-external-reviewer-replay.yml
+++ b/.github/workflows/l4-external-reviewer-replay.yml
@@ -80,7 +80,7 @@ jobs:
           EOF
 
       - name: Upload external reviewer replay artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: external-reviewer-replay-${{ github.run_id }}
           path: ${{ env.RUN_DIR }}

--- a/.github/workflows/l4-l7-evidence-autopilot.yml
+++ b/.github/workflows/l4-l7-evidence-autopilot.yml
@@ -105,7 +105,7 @@ jobs:
           python -m agialpha_l4_l7 falsify --bundle "$RUN_DIR" --out "$RUN_DIR/falsification_audit"
 
       - name: Upload L4-L7 evidence artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: l4-l7-evidence-${{ github.run_id }}
           path: |

--- a/.github/workflows/seed-runner-autonomous.yml
+++ b/.github/workflows/seed-runner-autonomous.yml
@@ -96,7 +96,7 @@ jobs:
           python -S -m agialpha_seed_runner landing --docs docs
 
       - name: Upload seed Evidence Dockets
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: seed-dockets
           path: |


### PR DESCRIPTION
### Motivation
- Several GitHub Actions workflow steps used non-existent or unsupported major versions of the artifact actions, which caused workflow failures and blocked Pages/artifact upload-download steps. 
- The intent is to restore CI/workflow reliability and GitHub Pages deployments by pinning to currently supported action versions.

### Description
- Replaced `actions/upload-artifact@v7` with `actions/upload-artifact@v4` across affected workflow files under `.github/workflows/`.
- Replaced `actions/download-artifact@v8` with `actions/download-artifact@v4` where present.
- Changes are limited to action version strings only and do not modify workflow logic or runtime commands; the edits touch multiple workflow files (23 files updated).

### Testing
- Ran `python scripts/check_pages_architecture.py` and it completed successfully (`ok`).
- Ran `pytest -q` and the test suite passed (`45 passed`, with warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40cfc80dc8333b4cfd3ea0df477c8)