### PR TITLE
Fix UTC timestamp generation deprecation warnings

### DIFF
--- a/agialpha_sovereign_capstone/core.py
+++ b/agialpha_sovereign_capstone/core.py
@@ -30,7 +30,7 @@ ROOT = Path.cwd()
 
 
 def now_iso() -> str:
-    return dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def canonical(obj: Any) -> bytes:

--- a/agialpha_usefulness_frontier/core.py
+++ b/agialpha_usefulness_frontier/core.py
@@ -85,7 +85,7 @@ OVERCLAIM_PATTERNS = [
 
 
 def now_iso() -> str:
-    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ensure_dir(path: str | pathlib.Path) -> pathlib.Path:


### PR DESCRIPTION
### Motivation
- Remove DeprecationWarning caused by `datetime.utcnow()` and produce timezone-aware, future-compatible UTC ISO timestamps while preserving the trailing `Z` format.

### Description
- Replaced `datetime.utcnow()` with timezone-aware `datetime.now(datetime.UTC)` and normalized the ISO output to end with `Z` in `agialpha_usefulness_frontier/core.py` and `agialpha_sovereign_capstone/core.py`.
- Kept the change minimal and scoped to the two `now_iso()` helpers to avoid unrelated modifications.

### Testing
- Ran `pytest -q` which passed: `45 passed`.
- Ran `python scripts/check_pages_architecture.py` which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f411a93a5483339e9a45951fac1e5d)