### PR TITLE
Fix UTC timestamp helpers to eliminate deprecation warnings

### DIFF
--- a/agialpha_sovereign_capstone/core.py
+++ b/agialpha_sovereign_capstone/core.py
@@ -30,7 +30,7 @@ ROOT = Path.cwd()
 
 
 def now_iso() -> str:
-    return dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def canonical(obj: Any) -> bytes:

--- a/agialpha_usefulness_frontier/core.py
+++ b/agialpha_usefulness_frontier/core.py
@@ -85,7 +85,7 @@ OVERCLAIM_PATTERNS = [
 
 
 def now_iso() -> str:
-    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ensure_dir(path: str | pathlib.Path) -> pathlib.Path:


### PR DESCRIPTION
### Motivation
- Replace deprecated uses of `datetime.utcnow()` with timezone-aware UTC timestamps to remove deprecation warnings and ensure consistent ISO-8601 Zulu formatting.

### Description
- Updated `now_iso()` in `agialpha_usefulness_frontier/core.py` and `agialpha_sovereign_capstone/core.py` to use `datetime.now(datetime.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")`, preserving the existing `Z` suffix.

### Testing
- Ran `pytest -q` (all tests passed and the previous UTC deprecation warnings were eliminated), and ran `python scripts/check_pages_architecture.py` and `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f411a93a5483339e9a45951fac1e5d)