### PR TITLE
Harden Evidence Hub GitHub Pages publishing workflow

### DIFF
--- a/.github/workflows/evidence-hub-publish.yml
+++ b/.github/workflows/evidence-hub-publish.yml
@@ -38,12 +38,18 @@ jobs:
         run: python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry
       - name: Build site
         run: python -m agialpha_evidence_hub build --registry evidence_registry --out _site
+      - name: Ensure Pages root files
+        run: |
+          test -f _site/index.html || { echo 'Missing _site/index.html' >&2; exit 1; }
+          touch _site/.nojekyll
       - name: Validate site and registry
         run: python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
       - name: Linkcheck
         run: python -m agialpha_evidence_hub linkcheck --site _site
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: _site
       - name: Deploy Pages


### PR DESCRIPTION
### Motivation
- Prevent intermittent GitHub Pages deployment failures by validating the built site and making Pages artifacts deterministic and compatible with current GitHub Pages actions.

### Description
- Add a guard step that fails if `_site/index.html` is missing and create `_site/.nojekyll` to ensure predictable static serving.
- Add `actions/configure-pages@v5` before uploading the artifact and upgrade `actions/upload-pages-artifact` to `@v4` for modern Pages deployment flow.
- Change applied to `.github/workflows/evidence-hub-publish.yml` to implement the above steps.

### Testing
- Ran unit tests with `python -m unittest discover -s tests`, which completed successfully (`OK`, 37 tests).
- Ran the architecture check with `python scripts/check_pages_architecture.py`, which returned `ok`.
- Ran the site build with `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f416cb20908333b7fad96b7be4bc74)