### PR TITLE
Fix Evidence Hub Pages deployment and stabilize central publisher

### DIFF
--- a/.github/workflows/evidence-hub-publish.yml
+++ b/.github/workflows/evidence-hub-publish.yml
@@ -1,28 +1,41 @@
 name: evidence-hub-publish
+
 on:
-  workflow_dispatch:
-  repository_dispatch:
-    types: [evidence_run_completed]
-  schedule:
-    - cron: '0 */4 * * *'
-  push:
+  pull_request:
     paths:
       - 'evidence_registry/**'
       - 'agialpha_evidence_hub/**'
       - 'docs/**'
       - '.github/workflows/**'
+      - 'scripts/check_pages_architecture.py'
+      - 'tests/**'
+  push:
+    branches: [main]
+    paths:
+      - 'evidence_registry/**'
+      - 'agialpha_evidence_hub/**'
+      - 'docs/**'
+      - '.github/workflows/**'
+      - 'scripts/check_pages_architecture.py'
+      - 'tests/**'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [evidence_run_completed]
+  schedule:
+    - cron: '0 */4 * * *'
+
 concurrency:
-  group: evidence-hub-publish
+  group: evidence-hub-publish-${{ github.ref }}
   cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
   actions: read
-  pages: write
-  id-token: write
   pull-requests: read
   issues: read
+
 jobs:
-  build-and-deploy:
+  build-validate:
     if: ${{ !contains(github.event.head_commit.message || '', '[skip evidence-hub-loop]') }}
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +59,49 @@ jobs:
         run: python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
       - name: Linkcheck
         run: python -m agialpha_evidence_hub linkcheck --site _site
+      - name: Upload build diagnostics
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-hub-site-preview
+          path: _site
+      - name: PR/non-main deploy guard message
+        if: ${{ github.ref != 'refs/heads/main' || github.event_name == 'pull_request' }}
+        run: echo "Build/validate completed. Deployment skipped because this is not main."
+
+  deploy-pages:
+    needs: build-validate
+    if: >
+      github.repository == 'MontrealAI/agialpha-first-real-loop' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'repository_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pages: write
+      id-token: write
+      pull-requests: read
+      issues: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Architecture check
+        run: python scripts/check_pages_architecture.py
+      - name: Discover repo evidence
+        run: python -m agialpha_evidence_hub discover --repo-root . --out evidence_registry/discovered.json
+      - name: Backfill registry
+        run: python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry
+      - name: Build site
+        run: python -m agialpha_evidence_hub build --registry evidence_registry --out _site
+      - name: Validate site and registry
+        run: python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
+      - name: Linkcheck
+        run: python -m agialpha_evidence_hub linkcheck --site _site
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact
@@ -53,4 +109,5 @@ jobs:
         with:
           path: _site
       - name: Deploy Pages
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/GITHUB_PAGES_SETTINGS.md
+++ b/docs/GITHUB_PAGES_SETTINGS.md
@@ -1,0 +1,15 @@
+# GitHub Pages Settings (Evidence Hub)
+
+## Required settings
+
+1. **Settings → Pages**
+   - **Source:** GitHub Actions
+
+2. **Settings → Environments → github-pages**
+   - Allow deployments from the default/protected branch policy used by the repository.
+   - Do not require impossible manual approvals for the bot if autonomous publication is expected.
+   - Keep deployment source constrained to trusted branch executions (main).
+
+## Why
+
+The publisher workflow now has strict main-branch deploy guards. PR and feature branches build/validate only and cannot deploy Pages.

--- a/docs/PAGES_DEPLOYMENT_DIAGNOSIS.md
+++ b/docs/PAGES_DEPLOYMENT_DIAGNOSIS.md
@@ -1,0 +1,28 @@
+# Pages Deployment Diagnosis
+
+## Failing run details
+
+- Failing deployment status log URL: https://github.com/MontrealAI/agialpha-first-real-loop/actions/runs/25191403229/job/73862032851
+- Failing workflow: `evidence-hub-publish`
+- Failing branch/ref: `codex/fix-github-pages-evidence-architecture`
+- Failing job/step: `deploy` job (`actions/deploy-pages`)
+
+## Root cause
+
+The central publisher was allowed to run and deploy from non-`main` branches. GitHub Deployments shows a failed `github-pages` deployment created from a `codex/*` ref (`deployment id 4541692837`), which is not a trusted default-branch deployment path for Pages. This violated the desired architecture (PR/feature branches should build/validate only, not deploy).
+
+## Exact fix
+
+1. Split the workflow into separate build/validate and deploy jobs.
+2. Added explicit deploy guard:
+   - `github.repository == 'MontrealAI/agialpha-first-real-loop'`
+   - `github.ref == 'refs/heads/main'`
+   - event is one of `push|workflow_dispatch|schedule|repository_dispatch`
+3. Added `pull_request` trigger for build/validate-only mode.
+4. Kept official Pages pattern (`actions/upload-pages-artifact` + `actions/deploy-pages`) in **only** `evidence-hub-publish.yml`.
+5. Added PR/non-main skip message: “Build/validate completed. Deployment skipped because this is not main.”
+
+## Prevention test added
+
+- `tests/test_evidence_hub_pr_deploy_guard.py`: enforces trusted-main-only deploy condition in central publisher workflow.
+- `tests/test_pages_architecture.py` and `scripts/check_pages_architecture.py`: enforce that only the central publisher contains Pages deploy actions.

--- a/tests/test_evidence_hub_pr_deploy_guard.py
+++ b/tests/test_evidence_hub_pr_deploy_guard.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import unittest
+
+
+class TestEvidenceHubPrDeployGuard(unittest.TestCase):
+    def test_central_workflow_has_trusted_main_guard(self):
+        text = Path('.github/workflows/evidence-hub-publish.yml').read_text()
+        self.assertIn("github.repository == 'MontrealAI/agialpha-first-real-loop'", text)
+        self.assertIn("github.ref == 'refs/heads/main'", text)
+        self.assertIn("github.event_name == 'push'", text)
+        self.assertIn("github.event_name == 'workflow_dispatch'", text)
+        self.assertIn("github.event_name == 'schedule'", text)
+        self.assertIn("github.event_name == 'repository_dispatch'", text)
+
+    def test_pull_request_trigger_exists_for_build_validate(self):
+        text = Path('.github/workflows/evidence-hub-publish.yml').read_text()
+        self.assertIn("pull_request:", text)
+        self.assertIn("Deployment skipped because this is not main", text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- The repository had a failed `github-pages` deployment originated from a non-main `codex/*` ref which allowed untrusted branches to attempt Pages deploys and broke the central Evidence Hub publishing guarantees.  
- The goal is to make Pages deployment single-source (central publisher), restrict deploys to trusted `main` events, keep PRs/builds diagnostic-only, and restore a publication-grade site with claim-boundary safeguards.

### Description

- Reworked `.github/workflows/evidence-hub-publish.yml` to split into a `build-validate` job (runs on `pull_request` and non-main runs) and a `deploy-pages` job (runs only when the deploy guard condition for `main` and trusted events is met).  
- Added an explicit deploy guard requiring `github.repository == 'MontrealAI/agialpha-first-real-loop' && github.ref == 'refs/heads/main' && (github.event_name in push|workflow_dispatch|schedule|repository_dispatch)` so PRs and feature branches cannot deploy.  
- Kept the official Pages pattern in a single workflow only: `actions/upload-pages-artifact` + `actions/deploy-pages` appear only in `evidence-hub-publish.yml`, while PRs upload a diagnostic artifact via `actions/upload-artifact@v4` and print a clear non-deploy message `Build/validate completed. Deployment skipped because this is not main.`  
- Added docs and tests to prevent regressions: `docs/PAGES_DEPLOYMENT_DIAGNOSIS.md` (captures the failing run URL and root cause), `docs/GITHUB_PAGES_SETTINGS.md` (required Pages/environment settings), and `tests/test_evidence_hub_pr_deploy_guard.py` plus the existing `scripts/check_pages_architecture.py`/`tests/test_pages_architecture.py` to enforce exactly-one-deployer and trusted-main-only deploy gating.

### Testing

- Ran the architecture check with `python scripts/check_pages_architecture.py` and it passed.  
- Ran the full unit test suite with `python -m unittest discover -s tests` and it passed (tests ran successfully).  
- Executed site build/validation/linkcheck with `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`; all commands completed successfully.  
- Documented the failing deployment run and root cause in `docs/PAGES_DEPLOYMENT_DIAGNOSIS.md` (failing run URL: `https://github.com/MontrealAI/agialpha-first-real-loop/actions/runs/25191403229/job/73862032851`, failing ref: `codex/fix-github-pages-evidence-architecture`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f419a07a0083339163e9ebe4a321a5)