### PR TITLE
Split Pages workflow into build/validate and gated deploy; add docs and tests

### DIFF
--- a/.github/workflows/evidence-hub-publish.yml
+++ b/.github/workflows/evidence-hub-publish.yml
@@ -1,30 +1,41 @@
 name: evidence-hub-publish
+
 on:
-  workflow_dispatch:
-  repository_dispatch:
-    types: [evidence_run_completed]
-  schedule:
-    - cron: '0 */4 * * *'
+  pull_request:
+    paths:
+      - 'evidence_registry/**'
+      - 'agialpha_evidence_hub/**'
+      - 'docs/**'
+      - '.github/workflows/**'
+      - 'scripts/check_pages_architecture.py'
+      - 'tests/**'
   push:
     paths:
       - 'evidence_registry/**'
       - 'agialpha_evidence_hub/**'
       - 'docs/**'
       - '.github/workflows/**'
+      - 'scripts/check_pages_architecture.py'
+      - 'tests/**'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [evidence_run_completed]
+  schedule:
+    - cron: '0 */4 * * *'
+
 concurrency:
-  group: evidence-hub-publish
+  group: evidence-hub-publish-${{ github.ref }}
   cancel-in-progress: false
-permissions:
-  contents: write
-  actions: read
-  pages: write
-  id-token: write
-  pull-requests: read
-  issues: read
+
 jobs:
-  build-and-deploy:
+  build-validate:
     if: ${{ !contains(github.event.head_commit.message || '', '[skip evidence-hub-loop]') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -46,11 +57,52 @@ jobs:
         run: python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
       - name: Linkcheck
         run: python -m agialpha_evidence_hub linkcheck --site _site
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
+      - name: Upload build diagnostics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-hub-site-preview
+          path: _site
+      - name: PR/non-main deploy note
+        if: ${{ github.ref != 'refs/heads/main' || github.event_name == 'pull_request' }}
+        run: echo "Build/validate completed. Deployment skipped because this is not main."
+
+  deploy-pages:
+    needs: build-validate
+    if: >
+      github.repository == 'MontrealAI/agialpha-first-real-loop' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'repository_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
+      issues: read
+      pull-requests: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Discover and backfill registry
+        run: |
+          python -m agialpha_evidence_hub discover --repo-root . --out evidence_registry/discovered.json
+          python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry
+      - name: Build site for Pages artifact
+        run: |
+          python -m agialpha_evidence_hub build --registry evidence_registry --out _site
+          python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
+          python -m agialpha_evidence_hub linkcheck --site _site
+          test -f _site/index.html
+          touch _site/.nojekyll
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: _site
       - name: Deploy Pages
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/README_EVIDENCE_HUB.md
+++ b/README_EVIDENCE_HUB.md
@@ -3,3 +3,38 @@
 Evidence Hub and Mission Control architecture and publisher boundaries.
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+## GitHub Pages publishing model
+
+- Central publisher: `.github/workflows/evidence-hub-publish.yml`
+- Build/validate-only mode:
+  - `pull_request`
+  - non-main refs
+  - runs discover/backfill/build/validate/linkcheck
+  - does **not** deploy Pages
+- Trusted deploy mode:
+  - `push` to `main`
+  - `workflow_dispatch` on `main`
+  - `schedule` on default branch
+  - `repository_dispatch` on `main`
+  - uploads Pages artifact and deploys via `actions/deploy-pages`
+
+## Why only one workflow may deploy
+
+To prevent race conditions and accidental overwrite of the Mission Control site, only the central publisher may use:
+- `actions/upload-pages-artifact`
+- `actions/deploy-pages`
+
+Architecture enforcement:
+- `python scripts/check_pages_architecture.py`
+- `python -m unittest tests/test_pages_architecture.py`
+- `python -m unittest tests/test_evidence_hub_pr_deploy_guard.py`
+
+## Operator commands
+
+```bash
+python scripts/check_pages_architecture.py
+python -m agialpha_evidence_hub build --registry evidence_registry --out _site
+python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
+python -m agialpha_evidence_hub linkcheck --site _site
+```

--- a/docs/GITHUB_PAGES_SETTINGS.md
+++ b/docs/GITHUB_PAGES_SETTINGS.md
@@ -1,0 +1,15 @@
+# GitHub Pages Settings (Required Baseline)
+
+## Pages source
+In **Settings → Pages**:
+- Set **Source** to **GitHub Actions**.
+
+## Environment guardrails
+In **Settings → Environments → github-pages**:
+- Allow deployments from the protected/default branch policy used by `main`.
+- Do not require impossible manual approvals for the automation identity if autonomous publishing is expected.
+- Keep deployment source constrained to trusted default branch deployments.
+
+## Operational expectation
+- PR and non-main branches build/validate only.
+- Trusted `main` runs in `evidence-hub-publish.yml` are the only path that deploys to `https://montrealai.github.io/agialpha-first-real-loop/`.

--- a/docs/PAGES_DEPLOYMENT_DIAGNOSIS.md
+++ b/docs/PAGES_DEPLOYMENT_DIAGNOSIS.md
@@ -1,0 +1,26 @@
+# GitHub Pages Deployment Diagnosis
+
+## Failing run
+- **Run URL:** https://github.com/MontrealAI/agialpha-first-real-loop/actions/runs/25192121986
+- **Workflow:** `evidence-hub-publish`
+- **Ref/branch:** `codex/fix-github-pages-evidence-architecture-348bok` (`push` event)
+- **Failing job/step:** `build-and-deploy` → `python -m agialpha_evidence_hub backfill --repo-root . --out evidence_registry/registry`
+
+## Root cause
+The failing deployment was initiated from a non-main `codex/*` branch push, while the workflow still attempted a combined build-and-deploy pattern. The run failed in backfill before deploy, and the deployment path was not isolated behind a strict trusted-branch deploy gate.
+
+## Exact fix
+1. Split central publisher into `build-validate` and `deploy-pages` jobs.
+2. Add explicit deploy guard so deployment only runs when all conditions are true:
+   - repository is `MontrealAI/agialpha-first-real-loop`
+   - ref is `refs/heads/main`
+   - event is `push`, `workflow_dispatch`, `schedule`, or `repository_dispatch`
+3. Keep PR/non-main behavior build+validate only, with explicit skip message:
+   - "Build/validate completed. Deployment skipped because this is not main."
+4. Keep only `.github/workflows/evidence-hub-publish.yml` authorized to call:
+   - `actions/upload-pages-artifact`
+   - `actions/deploy-pages`
+
+## Prevention test added
+- `tests/test_evidence_hub_pr_deploy_guard.py` verifies deploy guard conditions and PR skip behavior.
+- `scripts/check_pages_architecture.py` + `tests/test_pages_architecture.py` enforce single-workflow Pages deployment architecture.

--- a/tests/test_evidence_hub_pr_deploy_guard.py
+++ b/tests/test_evidence_hub_pr_deploy_guard.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+
+class TestEvidenceHubPRDeployGuard(unittest.TestCase):
+    def test_deploy_guard_is_main_and_trusted_events_only(self):
+        wf = Path('.github/workflows/evidence-hub-publish.yml').read_text()
+        self.assertIn("github.repository == 'MontrealAI/agialpha-first-real-loop'", wf)
+        self.assertIn("github.ref == 'refs/heads/main'", wf)
+        self.assertIn("github.event_name == 'push'", wf)
+        self.assertIn("github.event_name == 'workflow_dispatch'", wf)
+        self.assertIn("github.event_name == 'schedule'", wf)
+        self.assertIn("github.event_name == 'repository_dispatch'", wf)
+
+    def test_pr_mode_prints_deploy_skip_message(self):
+        wf = Path('.github/workflows/evidence-hub-publish.yml').read_text()
+        self.assertIn('Build/validate completed. Deployment skipped because this is not main.', wf)
+        self.assertIn('pull_request:', wf)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Prevent accidental GitHub Pages deployments and race conditions by disallowing deploys from PRs and non-main refs. 
- Centralize Pages publishing so only the designated workflow can upload and deploy the Pages artifact. 

### Description

- Reworked `.github/workflows/evidence-hub-publish.yml` to introduce a `build-validate` job and a gated `deploy-pages` job, with the deploy job conditioned on `github.repository == 'MontrealAI/agialpha-first-real-loop'`, `github.ref == 'refs/heads/main'`, and trusted event names. 
- Added PR/non-main behavior to run discover/backfill/build/validate/linkcheck and upload a preview artifact while printing an explicit deploy-skip note for non-main runs. 
- Adjusted concurrency to include the ref, reduced permissions on the build job, and moved Pages upload/deploy steps into the guarded deploy job. 
- Added documentation (`docs/GITHUB_PAGES_SETTINGS.md`, `docs/PAGES_DEPLOYMENT_DIAGNOSIS.md`) and README updates to describe the publishing model and operator commands, and added an enforcement test and architecture check integration. 

### Testing

- Added `tests/test_evidence_hub_pr_deploy_guard.py` and referenced the existing `tests/test_pages_architecture.py` as automated tests. 
- Ran `python -m unittest tests/test_pages_architecture.py` and `python -m unittest tests/test_evidence_hub_pr_deploy_guard.py`, and both tests passed. 
- The `build-validate` job runs `python scripts/check_pages_architecture.py` and the `agialpha_evidence_hub` `discover/backfill/build/validate/linkcheck` commands as part of workflow validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f419a07a0083339163e9ebe4a321a5)