### PR TITLE
Stabilize AGI ALPHA evidence repo, workflows, Pages, docs, and claim boundaries

### DIFF
--- a/docs/ADDING_NEW_EXPERIMENTS.md
+++ b/docs/ADDING_NEW_EXPERIMENTS.md
@@ -1,0 +1,37 @@
+# Adding New Experiments
+
+## 1) Create workflow
+
+- Add a new workflow in `.github/workflows/`.
+- Keep least-privilege permissions.
+- Do **not** deploy GitHub Pages directly from experiment workflows.
+- Ensure `workflow_dispatch` is present for operator use.
+
+## 2) Emit manifest
+
+At workflow end, emit `evidence-run-manifest.json` via:
+
+`python -m agialpha_evidence_hub emit-manifest ...`
+
+Include claim boundary and safety counters where required.
+
+## 3) Upload artifacts
+
+Upload the manifest and experiment outputs as artifacts.
+
+## 4) Register and publish centrally
+
+Use central publisher workflow (`evidence-hub-publish.yml`) to ingest and rebuild site.
+
+## 5) Validate
+
+Run locally:
+
+- `python scripts/check_pages_architecture.py`
+- `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`
+- `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`
+- `python -m agialpha_evidence_hub linkcheck --site _site`
+
+## Policy invariant
+
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**

--- a/docs/EVIDENCE_DOCKET_STANDARD.md
+++ b/docs/EVIDENCE_DOCKET_STANDARD.md
@@ -1,0 +1,19 @@
+# Evidence Docket Standard
+
+Evidence Dockets are the canonical units of claim-bounded experimental evidence.
+
+## Requirements
+
+- Include manifest and run metadata.
+- Include claim boundary statement.
+- Include safety counters for cyber/security/gauntlet families.
+- Include replay/falsification and reviewer-relevant metadata where available.
+- Missing metrics must be explicit (`pending`, `unavailable`, `not_reported`) and must not be fabricated as zero.
+
+## Claim boundary invariant
+
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
+
+## Publishing rule
+
+Only evidence with bounded claims may be promoted to public registry and pages.

--- a/docs/NON_TECHNICAL_OPERATOR_GUIDE.md
+++ b/docs/NON_TECHNICAL_OPERATOR_GUIDE.md
@@ -1,0 +1,37 @@
+# Non-Technical Operator Guide
+
+This guide is for operators using only the GitHub web UI.
+
+## Run a workflow
+
+1. Go to the repository **Actions** tab.
+2. Select a workflow from the left panel.
+3. Click **Run workflow**.
+4. Keep default branch as `main` unless directed otherwise.
+5. Submit and wait for a green check.
+
+## Check evidence output
+
+1. Open the completed run.
+2. Download artifacts.
+3. Open the public Evidence Mission Control page.
+4. Confirm the run appears in Recent Runs and experiment pages.
+5. Confirm claim boundary banner is visible.
+
+## If a workflow fails
+
+- Open logs for the failed job.
+- Confirm required inputs were provided.
+- Check artifact upload steps executed.
+- Re-run workflow once after fixing obvious input/branch mistakes.
+- If still failing, open a bug issue with run URL and screenshot.
+
+## If Pages does not update
+
+- Run `evidence-hub-publish` from Actions on `main`.
+- Confirm build/validate/linkcheck jobs pass.
+- Confirm deploy job runs only from trusted `main` events.
+
+## Required policy reminder
+
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**

--- a/docs/REPO_HEALTH_AUDIT.md
+++ b/docs/REPO_HEALTH_AUDIT.md
@@ -1,0 +1,36 @@
+# Repository Health Audit (2026-05-01)
+
+This audit records repository health findings identified from static inspection and local validation runs.
+
+## Scope and method
+
+- Reviewed workflow files under `.github/workflows/`.
+- Reviewed issue templates under `.github/ISSUE_TEMPLATE/`.
+- Verified Pages deployment architecture with `scripts/check_pages_architecture.py`.
+- Ran full test suite and evidence-hub build/validate/linkcheck commands.
+- Confirmed required docs and operator-facing pages are present.
+
+## Findings
+
+| Category | File path / area | Error type | Severity | Current behavior | Proposed fix | Fixed in this PR |
+|---|---|---|---|---|---|---|
+| Documentation | `docs/REPO_HEALTH_AUDIT.md` | Missing audit artifact | High | Required audit document absent | Add complete health-audit document with issue table and verification commands | Yes |
+| Documentation | `docs/WORKFLOW_LAUNCHPAD.md` | Missing operator launchpad guide | Medium | Launchpad usage guidance not available in required path | Add workflow launchpad guide with UI + CLI usage and safety boundary | Yes |
+| Documentation | `docs/NON_TECHNICAL_OPERATOR_GUIDE.md` | Missing non-technical runbook | High | Non-technical operators had no dedicated instruction file in required path | Add explicit click-by-click workflow runbook + failure handling | Yes |
+| Documentation | `docs/EVIDENCE_DOCKET_STANDARD.md` | Missing required standard path | Medium | Evidence docket documentation existed under different filename(s) | Add canonical standard document at required path | Yes |
+| Documentation | `docs/ADDING_NEW_EXPERIMENTS.md` | Missing required onboarding path | Medium | Add-experiment guidance existed under a different filename | Add canonical guide at required path | Yes |
+
+## Validated healthy areas (no open defect detected locally)
+
+| Category | Area | Validation evidence |
+|---|---|---|
+| GitHub Actions architecture | Pages deploy ownership | `python scripts/check_pages_architecture.py` passed (`ok`), confirming exactly one Pages deploy workflow policy enforcement |
+| Workflow/YAML quality | Workflows and tests | `python -m unittest discover -s tests` passed (`52` tests) including workflow, schema, launchpad, safety, and no-overclaim suites |
+| Evidence Hub build pipeline | Site generation | `python -m agialpha_evidence_hub build --registry evidence_registry --out _site` completed successfully |
+| Claim/safety/link validation | Registry + site checks | `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site` and `python -m agialpha_evidence_hub linkcheck --site _site` both passed |
+
+## Claim boundary invariant
+
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
+
+This invariant remains mandatory for docs, workflows, registry, and generated site pages.

--- a/docs/WORKFLOW_LAUNCHPAD.md
+++ b/docs/WORKFLOW_LAUNCHPAD.md
@@ -1,0 +1,26 @@
+# Workflow Launchpad Guide
+
+The Evidence Hub Launchpad is the operator entry point for running repository workflows.
+
+## What it provides
+
+- Workflow catalog discovered from `.github/workflows`.
+- Direct links to each workflow run page.
+- Latest run status when available.
+- Workflow dispatch availability and expected inputs.
+- Copyable CLI commands (`gh workflow run <workflow-file>.yml`).
+
+## Non-technical flow
+
+1. Open the public Evidence Mission Control site.
+2. Open **Launchpad**.
+3. Click **Open Run Workflow Page** for the workflow you want.
+4. In GitHub UI, click **Run workflow**.
+5. Wait for completion, then return to the Evidence Hub to verify run ingestion.
+
+## Safety and claim boundary
+
+- Launchpad does **not** dispatch workflows from the browser.
+- No tokens are embedded in site pages.
+- Launchpad usage is bounded by the claim policy:  
+  **No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**


### PR DESCRIPTION
### Motivation
- The repository was missing several canonical operator- and governance-facing documents and a formal repo health audit required by the Evidence Hub standards. 
- Operators and auditors need clear, click-by-click guidance and a canonical Evidence Docket standard to avoid unsafe claim language and ensure reproducible ingestion and publishing. 
- The global claim-boundary invariant must be explicit across docs and discoverable pages to prevent autonomous claim promotion. 

### Description
- Added a structured repository health audit at `docs/REPO_HEALTH_AUDIT.md` that records findings, severities, current behavior, proposed fixes, and whether each was fixed in this PR. 
- Added operator- and process-facing canonical docs at `docs/WORKFLOW_LAUNCHPAD.md`, `docs/NON_TECHNICAL_OPERATOR_GUIDE.md`, `docs/EVIDENCE_DOCKET_STANDARD.md`, and `docs/ADDING_NEW_EXPERIMENTS.md` that include the claim-boundary invariant and actionable run/publish guidance. 
- Preserved existing workflow and Evidence Hub code paths and explicitly reiterated the claim-boundary text: "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not." 

### Testing
- Ran the pages architecture checker with `python scripts/check_pages_architecture.py`, which completed successfully (enforced single-pages-publisher policy). 
- Executed the unit test suite with `python -m unittest discover -s tests`, which ran 52 tests and returned `OK`. 
- Built and validated the static site with `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, and all commands completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49929e52c8333962e9d12641ec207)