### PR TITLE
docs: add missing Ascension-001 workflows to workflow catalog

### DIFF
--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -26,6 +26,10 @@ Current as of 2026-05-01.
 ## Workflow inventory
 | Workflow file | How to run | Pages publisher? |
 |---|---|---|
+| `ascension-001-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `ascension-001-falsification-audit.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `ascension-001-independent-replay.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `ascension-001-vnext.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `benchmark-gauntlet-001-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `benchmark-gauntlet-001-challenge-pack.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `benchmark-gauntlet-001-external-replay.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |


### PR DESCRIPTION
### Motivation
- Fix failing documentation parity checks by adding entries for the Ascension-001 workflows that were present under `.github/workflows` but not listed in the catalog.

### Description
- Add four workflow entries to the inventory table in `docs/WORKFLOW_CATALOG.md`: `ascension-001-autonomous.yml`, `ascension-001-falsification-audit.yml`, `ascension-001-independent-replay.yml`, and `ascension-001-vnext.yml`.

### Testing
- Ran `python -m unittest discover -s tests` and the test suite passed (53/53).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a2614cc48333ad025f4eb638c82e)