### PR TITLE
Document missing ascension-001 workflows in catalog

### DIFF
--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -26,6 +26,10 @@ Current as of 2026-05-01.
 ## Workflow inventory
 | Workflow file | How to run | Pages publisher? |
 |---|---|---|
+| `ascension-001-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `ascension-001-falsification-audit.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `ascension-001-independent-replay.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `ascension-001-vnext.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `benchmark-gauntlet-001-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `benchmark-gauntlet-001-challenge-pack.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `benchmark-gauntlet-001-external-replay.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |

--- a/evidence_registry/discovered.json
+++ b/evidence_registry/discovered.json
@@ -1,6 +1,10 @@
 {
   "repo_root": ".",
   "discovered_files": [
+    ".github/workflows/ascension-001-autonomous.yml",
+    ".github/workflows/ascension-001-falsification-audit.yml",
+    ".github/workflows/ascension-001-independent-replay.yml",
+    ".github/workflows/ascension-001-vnext.yml",
     ".github/workflows/benchmark-gauntlet-001-autonomous.yml",
     ".github/workflows/benchmark-gauntlet-001-challenge-pack.yml",
     ".github/workflows/benchmark-gauntlet-001-external-replay.yml",


### PR DESCRIPTION
### Motivation
- CI tests were failing because four `ascension-001` workflow files present in `.github/workflows` were not listed in the workflow catalog or the discovered registry. 
- The repository needs the source-of-truth docs and generated inventory to match so documentation checks and inventory-based tooling pass.

### Description
- Added entries for `ascension-001-autonomous.yml`, `ascension-001-falsification-audit.yml`, `ascension-001-independent-replay.yml`, and `ascension-001-vnext.yml` to `docs/WORKFLOW_CATALOG.md`.
- Updated `evidence_registry/discovered.json` to include the same four `.github/workflows/ascension-001-*.yml` files so discovered inventory aligns with documentation.
- No other code behavior was modified; the change is documentation/registry-only.

### Testing
- Ran `python -m unittest discover -s tests` before the fix and the test suite reported 2 failures related to undocumented workflows. 
- Ran `python -m unittest discover -s tests` after the changes and all tests passed (53 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a2614cc48333ad025f4eb638c82e)