### PR TITLE
Stabilize AGI ALPHA evidence repo, workflows, Pages, docs, and claim boundaries

### DIFF
--- a/docs/REPO_HEALTH_AUDIT.md
+++ b/docs/REPO_HEALTH_AUDIT.md
@@ -34,3 +34,16 @@ This audit records repository health findings identified from static inspection 
 **No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
 
 This invariant remains mandatory for docs, workflows, registry, and generated site pages.
+
+
+## 2026-05-01 Verification Pass (Codex)
+
+| Scope | Check | Result | Notes |
+|---|---|---|---|
+| Pages architecture | `python scripts/check_pages_architecture.py` | pass | Exactly one workflow deploys Pages (`.github/workflows/evidence-hub-publish.yml`). |
+| Test suite | `python -m unittest discover -s tests` | pass | 53 tests passed, including link, schema, launchpad, sorting, and claim-boundary checks. |
+| Site build | `python -m agialpha_evidence_hub build --registry evidence_registry --out _site` | pass | Mission Control site generated with required assets and routes. |
+| Validation | `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site` | pass | Claim boundaries and safety validation passed. |
+| Linkcheck | `python -m agialpha_evidence_hub linkcheck --site _site` | pass | Internal links verified. |
+
+Invariant reaffirmed: **No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**


### PR DESCRIPTION
### Motivation
- Record and surface a concise, auditable verification that Pages architecture, Evidence Hub build/validation, test suite, and claim-boundary guards are passing to support repository stabilization and operator confidence.

### Description
- Updated `docs/REPO_HEALTH_AUDIT.md` to add a dated verification block (`2026-05-01 Verification Pass (Codex)`) that documents the results of architecture checks, test runs, site build/validation, linkcheck, and reaffirms the core claim-boundary invariant; no runtime or workflow behavior was modified.

### Testing
- Ran `python scripts/check_pages_architecture.py` and it passed (exactly one Pages publisher detected).
- Ran `python -m unittest discover -s tests` and the test suite passed (`53` tests reported in verification output).
- Ran `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a502a9848333b2ef70d0f9d62e9e)