### PR TITLE
Implement RSI-GOVERNOR-001: autonomous lifecycle for executable governance-kernel RSI

### DIFF
--- a/agialpha_rsi_governor/cli.py
+++ b/agialpha_rsi_governor/cli.py
@@ -116,6 +116,53 @@ def vnext_canary(repo_root: str, out: str):
     print(json.dumps(report))
 
 
+def validate_autonomy_contract(contract: str):
+    payload = json.loads(Path(contract).read_text())
+    required = {
+        "schema_version": "agialpha.rsi_governor_autonomy_contract.v1",
+        "experiment_slug": "rsi-governor-001",
+    }
+    for key, val in required.items():
+        if payload.get(key) != val:
+            raise SystemExit(f"invalid {key}: expected {val}")
+
+    required_pre = {
+        "run_replay",
+        "run_falsification_audit",
+        "open_safe_pr_if_candidate_passes",
+        "notify_evidence_hub_publisher",
+    }
+    required_post = {
+        "run_delayed_outcome_sentinel",
+        "run_vnext_canary",
+        "notify_evidence_hub_publisher",
+    }
+    pre = set(payload.get("autonomous_pre_promotion_actions", []))
+    post = set(payload.get("autonomous_post_merge_actions", []))
+    missing_pre = sorted(required_pre - pre)
+    missing_post = sorted(required_post - post)
+    if missing_pre or missing_post:
+        raise SystemExit(
+            "contract requires manual chaining for: "
+            + ", ".join(missing_pre + missing_post)
+        )
+
+    op = set(payload.get("operator_required_actions", []))
+    forbidden_manual = {
+        "run_replay",
+        "run_falsification_audit",
+        "run_safe_pr",
+        "run_delayed_outcome",
+        "run_vnext_canary",
+        "notify_evidence_hub_publisher",
+    }
+    overlap = sorted(op & forbidden_manual)
+    if overlap:
+        raise SystemExit(f"forbidden manual actions present: {', '.join(overlap)}")
+
+    print(json.dumps({"status": "ok", "contract": contract}))
+
+
 def main():
     p = argparse.ArgumentParser()
     sp = p.add_subparsers(dest="cmd", required=True)
@@ -132,8 +179,17 @@ def main():
     v = sp.add_parser("vnext-canary")
     v.add_argument("--repo-root", required=True)
     v.add_argument("--out", required=True)
+    c = sp.add_parser("validate-autonomy-contract")
+    c.add_argument("--contract", required=True)
     a = p.parse_args()
-    {"run": lambda: run(a.repo_root, a.out), "replay": lambda: replay(a.docket), "falsification-audit": lambda: falsification_audit(a.docket), "lifecycle": lambda: lifecycle(a.repo_root, a.out), "vnext-canary": lambda: vnext_canary(a.repo_root, a.out)}[a.cmd]()
+    {
+        "run": lambda: run(a.repo_root, a.out),
+        "replay": lambda: replay(a.docket),
+        "falsification-audit": lambda: falsification_audit(a.docket),
+        "lifecycle": lambda: lifecycle(a.repo_root, a.out),
+        "vnext-canary": lambda: vnext_canary(a.repo_root, a.out),
+        "validate-autonomy-contract": lambda: validate_autonomy_contract(a.contract),
+    }[a.cmd]()
 
 
 if __name__ == "__main__":

--- a/agialpha_rsi_governor/cli.py
+++ b/agialpha_rsi_governor/cli.py
@@ -151,8 +151,8 @@ def validate_autonomy_contract(contract: str):
     forbidden_manual = {
         "run_replay",
         "run_falsification_audit",
-        "run_safe_pr",
-        "run_delayed_outcome",
+        "open_safe_pr_if_candidate_passes",
+        "run_delayed_outcome_sentinel",
         "run_vnext_canary",
         "notify_evidence_hub_publisher",
     }

--- a/config/rsi_governor_autonomy_contract.json
+++ b/config/rsi_governor_autonomy_contract.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "agialpha.rsi_governor_autonomy_contract.v1",
+  "experiment_slug": "rsi-governor-001",
+  "operator_required_actions": [
+    "start_lifecycle_orchestrator_or_allow_schedule",
+    "review_promotion_pr",
+    "approve_reject_request_changes_or_merge_pr"
+  ],
+  "autonomous_pre_promotion_actions": [
+    "load_incumbent_kernel",
+    "verify_state_and_drift_sentinel",
+    "generate_candidate_kernels",
+    "lock_candidate_hashes",
+    "generate_heldout_tasks_after_lock",
+    "evaluate_baselines_B0_to_B6",
+    "select_candidate_or_reject_all",
+    "produce_evidence_docket",
+    "run_replay",
+    "run_falsification_audit",
+    "run_safety_and_claim_boundary_gates",
+    "produce_promotion_dossier",
+    "open_safe_pr_if_candidate_passes",
+    "publish_evidence_manifest",
+    "notify_evidence_hub_publisher"
+  ],
+  "autonomous_post_merge_actions": [
+    "detect_human_merge",
+    "verify_human_review_record",
+    "run_delayed_outcome_sentinel",
+    "run_vnext_canary",
+    "update_rsi_state_after_verified_merge",
+    "publish_final_evidence_manifest",
+    "notify_evidence_hub_publisher"
+  ],
+  "forbidden_autonomous_actions": [
+    "merge_pr",
+    "enable_automerge",
+    "persist_kernel_without_pr",
+    "delete_rejected_candidates",
+    "hide_failed_evaluations",
+    "relax_claim_boundaries",
+    "mark_missing_metrics_as_zero",
+    "execute_downloaded_artifact_code",
+    "deploy_pages_directly_from_rsi_workflow"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Make the RSI governance autonomy contract machine-checkable and enforceable so the lifecycle cannot rely on manual chaining of replay, falsification, safe-PR, delayed-outcome, vNext canary, or Evidence Hub notification steps.
- Provide an executable gate that CI/workflows can call to fail fast when contract fields or automation requirements are missing, preventing accidental manual-only workflows.

### Description
- Add `config/rsi_governor_autonomy_contract.json` containing operator-required actions, autonomous pre-promotion actions, autonomous post-merge actions, and forbidden autonomous actions as a machine-checkable contract.
- Implement `validate-autonomy-contract` in the `agialpha_rsi_governor` CLI to validate `schema_version` and `experiment_slug`, require critical pre/post automation actions, and fail if operator-required actions incorrectly include forbidden manual actions.
- Wire the validator into argparse so `python -m agialpha_rsi_governor validate-autonomy-contract --contract <path>` is available from the module entrypoint.
- Commit the new contract and CLI changes without introducing any automatic merge/persistence behavior or bypass of human review gates.

### Testing
- Ran the test suite with `python -m unittest discover -s tests` and it completed successfully (`OK`).
- Validated the new contract with `python -m agialpha_rsi_governor validate-autonomy-contract --contract config/rsi_governor_autonomy_contract.json` and it returned success.
- Exercised the lifecycle tooling with `python -m agialpha_rsi_governor run --repo-root . --out rsi-governor-runs/test`, `python -m agialpha_rsi_governor replay --docket rsi-governor-runs/test/rsi-governor-evidence-docket`, `python -m agialpha_rsi_governor falsification-audit --docket rsi-governor-runs/test/rsi-governor-evidence-docket`, `python -m agialpha_rsi_governor lifecycle --repo-root . --out rsi-governor-runs/test-lifecycle`, and `python -m agialpha_rsi_governor vnext-canary --repo-root . --out rsi-governor-runs/test-vnext`, all of which completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d5e1ae888333942e47703587a265)