### PR TITLE
Add autonomy contract validation CLI and default contract JSON

### DIFF
--- a/agialpha_rsi_governor/cli.py
+++ b/agialpha_rsi_governor/cli.py
@@ -116,6 +116,53 @@ def vnext_canary(repo_root: str, out: str):
     print(json.dumps(report))
 
 
+def validate_autonomy_contract(contract: str):
+    payload = json.loads(Path(contract).read_text())
+    required = {
+        "schema_version": "agialpha.rsi_governor_autonomy_contract.v1",
+        "experiment_slug": "rsi-governor-001",
+    }
+    for key, val in required.items():
+        if payload.get(key) != val:
+            raise SystemExit(f"invalid {key}: expected {val}")
+
+    required_pre = {
+        "run_replay",
+        "run_falsification_audit",
+        "open_safe_pr_if_candidate_passes",
+        "notify_evidence_hub_publisher",
+    }
+    required_post = {
+        "run_delayed_outcome_sentinel",
+        "run_vnext_canary",
+        "notify_evidence_hub_publisher",
+    }
+    pre = set(payload.get("autonomous_pre_promotion_actions", []))
+    post = set(payload.get("autonomous_post_merge_actions", []))
+    missing_pre = sorted(required_pre - pre)
+    missing_post = sorted(required_post - post)
+    if missing_pre or missing_post:
+        raise SystemExit(
+            "contract requires manual chaining for: "
+            + ", ".join(missing_pre + missing_post)
+        )
+
+    op = set(payload.get("operator_required_actions", []))
+    forbidden_manual = {
+        "run_replay",
+        "run_falsification_audit",
+        "open_safe_pr_if_candidate_passes",
+        "run_delayed_outcome_sentinel",
+        "run_vnext_canary",
+        "notify_evidence_hub_publisher",
+    }
+    overlap = sorted(op & forbidden_manual)
+    if overlap:
+        raise SystemExit(f"forbidden manual actions present: {', '.join(overlap)}")
+
+    print(json.dumps({"status": "ok", "contract": contract}))
+
+
 def main():
     p = argparse.ArgumentParser()
     sp = p.add_subparsers(dest="cmd", required=True)
@@ -132,8 +179,17 @@ def main():
     v = sp.add_parser("vnext-canary")
     v.add_argument("--repo-root", required=True)
     v.add_argument("--out", required=True)
+    c = sp.add_parser("validate-autonomy-contract")
+    c.add_argument("--contract", required=True)
     a = p.parse_args()
-    {"run": lambda: run(a.repo_root, a.out), "replay": lambda: replay(a.docket), "falsification-audit": lambda: falsification_audit(a.docket), "lifecycle": lambda: lifecycle(a.repo_root, a.out), "vnext-canary": lambda: vnext_canary(a.repo_root, a.out)}[a.cmd]()
+    {
+        "run": lambda: run(a.repo_root, a.out),
+        "replay": lambda: replay(a.docket),
+        "falsification-audit": lambda: falsification_audit(a.docket),
+        "lifecycle": lambda: lifecycle(a.repo_root, a.out),
+        "vnext-canary": lambda: vnext_canary(a.repo_root, a.out),
+        "validate-autonomy-contract": lambda: validate_autonomy_contract(a.contract),
+    }[a.cmd]()
 
 
 if __name__ == "__main__":

--- a/agialpha_rsi_governor/cli.py
+++ b/agialpha_rsi_governor/cli.py
@@ -118,6 +118,15 @@ def vnext_canary(repo_root: str, out: str):
 
 def validate_autonomy_contract(contract: str):
     payload = json.loads(Path(contract).read_text())
+
+    def _require_action_list(field: str) -> list[str]:
+        value = payload.get(field)
+        if not isinstance(value, list):
+            raise SystemExit(f"invalid {field}: expected JSON array of action strings")
+        if not all(isinstance(x, str) for x in value):
+            raise SystemExit(f"invalid {field}: all actions must be strings")
+        return value
+
     required = {
         "schema_version": "agialpha.rsi_governor_autonomy_contract.v1",
         "experiment_slug": "rsi-governor-001",
@@ -137,8 +146,8 @@ def validate_autonomy_contract(contract: str):
         "run_vnext_canary",
         "notify_evidence_hub_publisher",
     }
-    pre = set(payload.get("autonomous_pre_promotion_actions", []))
-    post = set(payload.get("autonomous_post_merge_actions", []))
+    pre = set(_require_action_list("autonomous_pre_promotion_actions"))
+    post = set(_require_action_list("autonomous_post_merge_actions"))
     missing_pre = sorted(required_pre - pre)
     missing_post = sorted(required_post - post)
     if missing_pre or missing_post:
@@ -147,7 +156,7 @@ def validate_autonomy_contract(contract: str):
             + ", ".join(missing_pre + missing_post)
         )
 
-    op = set(payload.get("operator_required_actions", []))
+    op = set(_require_action_list("operator_required_actions"))
     forbidden_manual = {
         "run_replay",
         "run_falsification_audit",

--- a/agialpha_rsi_governor/cli.py
+++ b/agialpha_rsi_governor/cli.py
@@ -12,6 +12,19 @@ from .promotion import promotion_gate
 from .render import scoreboard_html
 
 
+POLICY_FORBIDDEN_AUTONOMOUS_ACTIONS = {
+    "merge_pr",
+    "enable_automerge",
+    "persist_kernel_without_pr",
+    "delete_rejected_candidates",
+    "hide_failed_evaluations",
+    "relax_claim_boundaries",
+    "mark_missing_metrics_as_zero",
+    "execute_downloaded_artifact_code",
+    "deploy_pages_directly_from_rsi_workflow",
+}
+
+
 def _next_run_id(outp: Path) -> str:
     existing = sorted(p.name for p in outp.glob("run-*") if p.is_dir())
     if not existing:
@@ -148,9 +161,15 @@ def validate_autonomy_contract(contract: str):
     }
     pre = set(_require_action_list("autonomous_pre_promotion_actions"))
     post = set(_require_action_list("autonomous_post_merge_actions"))
-    forbidden_auto = set(_require_action_list("forbidden_autonomous_actions"))
+    contract_forbidden_auto = set(_require_action_list("forbidden_autonomous_actions"))
+    missing_forbidden_policy_actions = sorted(POLICY_FORBIDDEN_AUTONOMOUS_ACTIONS - contract_forbidden_auto)
+    if missing_forbidden_policy_actions:
+        raise SystemExit(
+            "contract missing required forbidden_autonomous_actions policy entries: "
+            + ", ".join(missing_forbidden_policy_actions)
+        )
 
-    forbidden_overlap = sorted((pre | post) & forbidden_auto)
+    forbidden_overlap = sorted((pre | post) & POLICY_FORBIDDEN_AUTONOMOUS_ACTIONS)
     if forbidden_overlap:
         raise SystemExit(
             "forbidden autonomous actions present in autonomous action lists: "

--- a/agialpha_rsi_governor/cli.py
+++ b/agialpha_rsi_governor/cli.py
@@ -148,6 +148,15 @@ def validate_autonomy_contract(contract: str):
     }
     pre = set(_require_action_list("autonomous_pre_promotion_actions"))
     post = set(_require_action_list("autonomous_post_merge_actions"))
+    forbidden_auto = set(_require_action_list("forbidden_autonomous_actions"))
+
+    forbidden_overlap = sorted((pre | post) & forbidden_auto)
+    if forbidden_overlap:
+        raise SystemExit(
+            "forbidden autonomous actions present in autonomous action lists: "
+            + ", ".join(forbidden_overlap)
+        )
+
     missing_pre = sorted(required_pre - pre)
     missing_post = sorted(required_post - post)
     if missing_pre or missing_post:

--- a/config/rsi_governor_autonomy_contract.json
+++ b/config/rsi_governor_autonomy_contract.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "agialpha.rsi_governor_autonomy_contract.v1",
+  "experiment_slug": "rsi-governor-001",
+  "operator_required_actions": [
+    "start_lifecycle_orchestrator_or_allow_schedule",
+    "review_promotion_pr",
+    "approve_reject_request_changes_or_merge_pr"
+  ],
+  "autonomous_pre_promotion_actions": [
+    "load_incumbent_kernel",
+    "verify_state_and_drift_sentinel",
+    "generate_candidate_kernels",
+    "lock_candidate_hashes",
+    "generate_heldout_tasks_after_lock",
+    "evaluate_baselines_B0_to_B6",
+    "select_candidate_or_reject_all",
+    "produce_evidence_docket",
+    "run_replay",
+    "run_falsification_audit",
+    "run_safety_and_claim_boundary_gates",
+    "produce_promotion_dossier",
+    "open_safe_pr_if_candidate_passes",
+    "publish_evidence_manifest",
+    "notify_evidence_hub_publisher"
+  ],
+  "autonomous_post_merge_actions": [
+    "detect_human_merge",
+    "verify_human_review_record",
+    "run_delayed_outcome_sentinel",
+    "run_vnext_canary",
+    "update_rsi_state_after_verified_merge",
+    "publish_final_evidence_manifest",
+    "notify_evidence_hub_publisher"
+  ],
+  "forbidden_autonomous_actions": [
+    "merge_pr",
+    "enable_automerge",
+    "persist_kernel_without_pr",
+    "delete_rejected_candidates",
+    "hide_failed_evaluations",
+    "relax_claim_boundaries",
+    "mark_missing_metrics_as_zero",
+    "execute_downloaded_artifact_code",
+    "deploy_pages_directly_from_rsi_workflow"
+  ]
+}

--- a/tests/test_rsi_governor_autonomy_contract.py
+++ b/tests/test_rsi_governor_autonomy_contract.py
@@ -1,0 +1,25 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestRsiGovernorAutonomyContract(unittest.TestCase):
+    def test_operator_required_actions_must_be_list(self):
+        base = json.loads(Path('config/rsi_governor_autonomy_contract.json').read_text())
+        base['operator_required_actions'] = 'run_replay'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad-contract.json'
+            p.write_text(json.dumps(base))
+            proc = subprocess.run(
+                ['python', '-m', 'agialpha_rsi_governor', 'validate-autonomy-contract', '--contract', str(p)],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn('invalid operator_required_actions', proc.stderr + proc.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_rsi_governor_autonomy_contract.py
+++ b/tests/test_rsi_governor_autonomy_contract.py
@@ -20,6 +20,20 @@ class TestRsiGovernorAutonomyContract(unittest.TestCase):
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn('invalid operator_required_actions', proc.stderr + proc.stdout)
 
+    def test_forbidden_action_rejected_in_autonomous_pre(self):
+        base = json.loads(Path('config/rsi_governor_autonomy_contract.json').read_text())
+        base['autonomous_pre_promotion_actions'] = list(base['autonomous_pre_promotion_actions']) + ['merge_pr']
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad-contract-forbidden.json'
+            p.write_text(json.dumps(base))
+            proc = subprocess.run(
+                ['python', '-m', 'agialpha_rsi_governor', 'validate-autonomy-contract', '--contract', str(p)],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn('forbidden autonomous actions present', proc.stderr + proc.stdout)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_rsi_governor_autonomy_contract.py
+++ b/tests/test_rsi_governor_autonomy_contract.py
@@ -34,6 +34,21 @@ class TestRsiGovernorAutonomyContract(unittest.TestCase):
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn('forbidden autonomous actions present', proc.stderr + proc.stdout)
 
+    def test_cannot_bypass_with_empty_forbidden_list(self):
+        base = json.loads(Path('config/rsi_governor_autonomy_contract.json').read_text())
+        base['forbidden_autonomous_actions'] = []
+        base['autonomous_pre_promotion_actions'] = list(base['autonomous_pre_promotion_actions']) + ['merge_pr']
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad-contract-empty-forbidden.json'
+            p.write_text(json.dumps(base))
+            proc = subprocess.run(
+                ['python', '-m', 'agialpha_rsi_governor', 'validate-autonomy-contract', '--contract', str(p)],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn('contract missing required forbidden_autonomous_actions policy entries', proc.stderr + proc.stdout)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure autonomous runs use a well-formed autonomy contract by validating schema version, experiment slug, required autonomous pre/post actions, and forbidden manual operator actions before execution. 
- Provide a canonical example contract at `config/rsi_governor_autonomy_contract.json` to document expected keys and allowed/forbidden actions.

### Description
- Add `validate_autonomy_contract` function to `agialpha_rsi_governor/cli.py` that loads a contract, enforces `schema_version` and `experiment_slug`, checks required `autonomous_pre_promotion_actions` and `autonomous_post_merge_actions`, and rejects forbidden `operator_required_actions` using clear exit messages. 
- Register a new CLI subcommand `validate-autonomy-contract` that accepts `--contract` and invokes `validate_autonomy_contract`. 
- Add `config/rsi_governor_autonomy_contract.json` as the default/autodoc contract containing `schema_version`, `experiment_slug`, `operator_required_actions`, `autonomous_pre_promotion_actions`, `autonomous_post_merge_actions`, and `forbidden_autonomous_actions` fields.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d5e1ae888333942e47703587a265)