### PR TITLE
Autonomously update AGI ALPHA Evidence Mission Control

### DIFF
--- a/tests/test_evidence_hub_experiment_pages_complete.py
+++ b/tests/test_evidence_hub_experiment_pages_complete.py
@@ -1,0 +1,22 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from agialpha_evidence_hub.build import build_site
+
+
+class T(unittest.TestCase):
+    def test_experiment_pages_include_claim_boundary_and_run_table(self):
+        with tempfile.TemporaryDirectory() as out:
+            build_site('evidence_registry', out)
+            exp_dir = Path(out, 'experiments')
+            pages = [p for p in exp_dir.glob('*/index.html') if p.parent.name != 'index.html']
+            self.assertTrue(pages, 'expected at least one generated experiment page')
+            sample = pages[0].read_text()
+            self.assertIn('claim boundary:', sample)
+            self.assertIn('Back to hub', sample)
+            self.assertIn('<table>', sample)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evidence_hub_needed_update.py
+++ b/tests/test_evidence_hub_needed_update.py
@@ -1,0 +1,29 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from agialpha_evidence_hub.needed_update import needed_update
+
+
+class T(unittest.TestCase):
+    def test_needed_update_detects_file_change_then_stabilizes(self):
+        with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as registry:
+            workflow = Path(repo) / '.github' / 'workflows'
+            workflow.mkdir(parents=True)
+            tracked = workflow / 'alpha.yml'
+            tracked.write_text('name: alpha\n')
+
+            first = needed_update(registry=registry, repo_root=repo)
+            self.assertTrue(first['needed'])
+            self.assertIn('.github/workflows/alpha.yml', first['changed_files'])
+
+            second = needed_update(registry=registry, repo_root=repo)
+            self.assertFalse(second['needed'])
+
+            tracked.write_text('name: alpha\non:\n  workflow_dispatch:\n')
+            third = needed_update(registry=registry, repo_root=repo)
+            self.assertTrue(third['needed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evidence_hub_no_raw_json_primary_ui.py
+++ b/tests/test_evidence_hub_no_raw_json_primary_ui.py
@@ -1,0 +1,19 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from agialpha_evidence_hub.build import build_site
+
+
+class T(unittest.TestCase):
+    def test_root_ui_is_html_shell_not_json_dump(self):
+        with tempfile.TemporaryDirectory() as out:
+            build_site('evidence_registry', out)
+            index_text = Path(out, 'index.html').read_text()
+            self.assertIn('<html', index_text)
+            self.assertIn('AGI ALPHA Evidence Mission Control', index_text)
+            self.assertNotIn('<pre>{', index_text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evidence_hub_source_priority.py
+++ b/tests/test_evidence_hub_source_priority.py
@@ -1,0 +1,15 @@
+import unittest
+
+from agialpha_evidence_hub.source_priority import rank
+
+
+class T(unittest.TestCase):
+    def test_manifest_beats_historical_backfill(self):
+        self.assertGreater(rank('manifest'), rank('historical_backfill'))
+
+    def test_unknown_source_is_lowest(self):
+        self.assertEqual(rank('unknown_source'), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The repository already contains the Evidence Hub implementation but several acceptance-test files required by the Autopublisher v2 specification were missing, leaving coverage gaps around source-priority invariants, update-trigger detection, root UI rendering, and experiment-page completeness. 
- Adding these tests strengthens the autonomous publishing safety net so the central publisher can reliably detect when a rebuild/deploy is required and prevents regression of UI, source-priority, and claim-boundary guarantees.

### Description
- Added four targeted regression tests under `tests/` to cover missing acceptance items: `test_evidence_hub_source_priority.py`, `test_evidence_hub_needed_update.py`, `test_evidence_hub_no_raw_json_primary_ui.py`, and `test_evidence_hub_experiment_pages_complete.py` which assert source-priority, `needed_update` behaviour, that the root UI is an HTML shell (not raw JSON), and that generated experiment pages include a visible claim boundary and run table. 
- These tests exercise existing modules (`agialpha_evidence_hub.source_priority`, `agialpha_evidence_hub.needed_update`, and `agialpha_evidence_hub.build`) without changing experiment logic or inventing metrics. 
- The change preserves the project’s claim-boundary policy and validation posture by explicitly checking for claim-boundary presence on generated experiment pages and reiterating the policy: "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not." 

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests`, which completed successfully (all tests passed). 
- Executed architecture and pipeline validation commands which passed: `python scripts/check_pages_architecture.py`, `python -m agialpha_evidence_hub validate-registry --registry evidence_registry`, `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`.
- The new tests run cleanly against the current Evidence Hub implementation and validate critical autopublisher v2 acceptance behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ffd4d9948333a0008ad64b834fac)