### PR TITLE
docs: add audit command trace to evidence hub migration audit

### DIFF
--- a/docs/evidence_hub_migration_audit.md
+++ b/docs/evidence_hub_migration_audit.md
@@ -143,3 +143,12 @@ Resolver can discover emergent families from workflow filenames, manifests, arti
 ## 14) Current architectural failure mode
 
 Historically, distributed per-workflow publishing and shallow backfill routing caused partial/overwritten public views. The required fix is strict central publishing, persistent registry normalization, confidence-ranked discovery, and conservative low-confidence isolation.
+
+
+## Audit command trace
+
+- `rg --files .github/workflows`
+- `rg -n "workflow_dispatch|upload-artifact|upload-pages-artifact|deploy-pages|peaceiris/actions-gh-pages|github-pages-deploy-action|JamesIves/github-pages-deploy-action|git push origin gh-pages" .github/workflows/*.yml`
+- `python scripts/check_pages_architecture.py`
+
+Result: central publisher guard is active and only `evidence-hub-publish.yml` is allowed to deploy Pages.


### PR DESCRIPTION
### Motivation
- Provide an auditable, reproducible source-of-truth trace proving the workflow inventory and that only the central publisher can deploy GitHub Pages.

### Description
- Appended an "Audit command trace" section to `docs/evidence_hub_migration_audit.md` documenting the exact verification commands used to inspect workflows and Pages-deploy patterns.
- The new section lists the commands `rg --files .github/workflows`, `rg -n "workflow_dispatch|upload-artifact|upload-pages-artifact|deploy-pages|peaceiris/actions-gh-pages|github-pages-deploy-action|JamesIves/github-pages-deploy-action|git push origin gh-pages" .github/workflows/*.yml`, and `python scripts/check_pages_architecture.py`, and records the verification result that only `evidence-hub-publish.yml` is allowed to deploy Pages.

### Testing
- Ran `python scripts/check_pages_architecture.py` and it succeeded.
- Ran `python -m unittest tests.test_pages_architecture tests.test_evidence_hub_build tests.test_evidence_hub_workflow_launchpad` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5057527648333b0645d455785e745)