### PR TITLE
Autonomously update AGI ALPHA Evidence Mission Control

### DIFF
--- a/.github/workflows/evidence-hub-publish.yml
+++ b/.github/workflows/evidence-hub-publish.yml
@@ -1,6 +1,9 @@
 name: AGI ALPHA Evidence Mission Control / Autopublisher
 
 on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [evidence_run_completed, evidence_registry_changed, evidence_hub_rebuild_requested]
   workflow_run:
     workflows:
       - Replay First Real Loop
@@ -15,122 +18,152 @@ on:
       - AGI ALPHA HELIOS-004 Completion / Autonomous
       - AGI ALPHA Cybersecurity Sovereign 001 / Autonomous
       - AGI ALPHA Cybersecurity Sovereign 002 / Autonomous
+      - AGI ALPHA Cybersecurity Sovereign 003 / Evidence Hub Remediation
       - AGI ALPHA Benchmark Gauntlet 001 / Autonomous
       - AGI ALPHA OMEGA-GAUNTLET-001 / Autonomous
       - AGI ALPHA PHOENIX-HUB-001 / Autonomous
       - RSI Forge 001 Autonomous
+      - AGI ALPHA RSI-GOVERNOR-001 / Autonomous
       - AGI ALPHA ASCENSION-001 / Autonomous RSI Compounding
       - AGI ALPHA L4-L7 Evidence Autopilot
     types: [completed]
+  schedule:
+    - cron: '17 */4 * * *'
   pull_request:
     paths:
-      - 'evidence_registry/**'
-      - 'agialpha_evidence_hub/**'
-      - 'docs/**'
       - '.github/workflows/**'
-      - 'scripts/check_pages_architecture.py'
-      - 'tests/**'
+      - 'agialpha_evidence_hub/**'
       - 'schemas/**'
+      - 'evidence_registry/**'
+      - 'docs/**'
+      - 'tests/**'
       - 'scripts/**'
       - 'README*'
   push:
     branches: [main]
     paths:
-      - 'evidence_registry/**'
-      - 'agialpha_evidence_hub/**'
-      - 'docs/**'
       - '.github/workflows/**'
-      - 'scripts/check_pages_architecture.py'
-      - 'tests/**'
+      - 'agialpha_evidence_hub/**'
       - 'schemas/**'
+      - 'evidence_registry/**'
+      - 'docs/**'
+      - 'tests/**'
       - 'scripts/**'
       - 'README*'
-  workflow_dispatch:
-  repository_dispatch:
-    types: [evidence_run_completed, evidence_registry_changed, evidence_hub_rebuild_requested]
-  schedule:
-    - cron: "17 */4 * * *"
 
 concurrency:
   group: evidence-hub-publish
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  actions: read
+  pages: write
+  id-token: write
+  issues: read
+  pull-requests: read
+
 jobs:
-  build-validate:
-    if: ${{ !contains(github.event.head_commit.message || '', '[skip evidence-hub-loop]') && (github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion != 'skipped' && github.event.workflow_run.name != 'evidence-hub-publish')) }}
+  preflight:
+    if: ${{ !contains(github.event.head_commit.message || '', '[skip evidence-hub-loop]') }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-      issues: read
-      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Architecture check
+      - name: Verify pages architecture
         run: python scripts/check_pages_architecture.py
-      - name: Discover repo evidence
-        run: python -m agialpha_evidence_hub discover --repo-root . --out evidence_registry/discovered.json
-      - name: Backfill registry
-        run: python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry
-      - name: Build site
-        run: python -m agialpha_evidence_hub build --registry evidence_registry --out _site
-      - name: Ensure Pages root files
+      - name: Validate registry schema
+        run: python -m agialpha_evidence_hub validate-registry --registry evidence_registry
+
+  discover:
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Discover evidence
         run: |
-          test -f _site/index.html || { echo 'Missing _site/index.html' >&2; exit 1; }
+          python -m agialpha_evidence_hub workflow-catalog --repo-root . --registry evidence_registry
+          python -m agialpha_evidence_hub discover --repo-root . --registry evidence_registry
+          python -m agialpha_evidence_hub github-discover --registry evidence_registry --limit 1000
+      - name: Backfill
+        run: python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry
+      - name: Compute needed update
+        run: python -m agialpha_evidence_hub needed-update --repo-root . --registry evidence_registry --out evidence_registry/needed_update.json
+      - name: Upload discovery diagnostics
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-hub-discovery
+          path: evidence_registry
+
+  build_validate:
+    needs: discover
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.check.outputs.should_deploy }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Check needed update flag
+        id: check
+        run: |
+          SHOULD_DEPLOY=true
+          if [ -f evidence_registry/needed_update.json ]; then
+            if python - <<'PY'
+import json
+from pathlib import Path
+p=Path('evidence_registry/needed_update.json')
+d=json.loads(p.read_text())
+raise SystemExit(0 if d.get('needed', True) else 1)
+PY
+            then
+              SHOULD_DEPLOY=true
+            else
+              SHOULD_DEPLOY=false
+            fi
+          fi
+          echo "should_deploy=${SHOULD_DEPLOY}" >> "$GITHUB_OUTPUT"
+      - name: Build site
+        if: steps.check.outputs.should_deploy == 'true'
+        run: |
+          python -m agialpha_evidence_hub build --registry evidence_registry --out _site
           touch _site/.nojekyll
-      - name: Validate site and registry
-        run: python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
-      - name: Linkcheck
-        run: python -m agialpha_evidence_hub linkcheck --site _site
-      - name: Upload build diagnostics artifact
+      - name: Validate site
+        if: steps.check.outputs.should_deploy == 'true'
+        run: |
+          python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
+          python -m agialpha_evidence_hub linkcheck --site _site
+      - name: PR/non-main deploy note
+        if: ${{ github.ref != 'refs/heads/main' || github.event_name == 'pull_request' }}
+        run: echo "Build/validate completed. Deployment skipped because this is not main."
+      - name: Upload site diagnostics
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: evidence-hub-site-preview
           path: _site
-      - name: PR/non-main deploy note
-        if: ${{ github.ref != 'refs/heads/main' || github.event_name == 'pull_request' }}
-        run: echo "Build/validate completed. Deployment skipped because this is not main."
 
-  deploy-pages:
-    needs: build-validate
+  deploy:
+    needs: build_validate
     if: >
+      needs.build_validate.outputs.should_deploy == 'true' &&
       github.repository == 'MontrealAI/agialpha-first-real-loop' &&
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'repository_dispatch')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-      actions: read
-      issues: read
-      pull-requests: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Discover and backfill registry
-        run: |
-          python -m agialpha_evidence_hub discover --repo-root . --out evidence_registry/discovered.json
-          python -m agialpha_evidence_hub backfill --repo-root . --registry evidence_registry
-      - name: Build site for Pages artifact
-        run: |
-          python -m agialpha_evidence_hub build --registry evidence_registry --out _site
-          python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
-          python -m agialpha_evidence_hub linkcheck --site _site
-          test -f _site/index.html
-          touch _site/.nojekyll
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: _site
-      - name: Deploy Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v4

--- a/scripts/check_pages_architecture.py
+++ b/scripts/check_pages_architecture.py
@@ -1,37 +1,44 @@
 from pathlib import Path
 import re
 
-forbidden_refs = [
-    "actions/deploy-pages",
-    "actions/upload-pages-artifact",
-    "github-pages-deploy-action",
-    "peaceiris/actions-gh-pages",
-    "jamesives/github-pages-deploy-action",
+FORBIDDEN_REFS = [
+    'actions/deploy-pages',
+    'actions/upload-pages-artifact',
+    'github-pages-deploy-action',
+    'peaceiris/actions-gh-pages',
+    'jamesives/github-pages-deploy-action',
 ]
-forbidden_cmd_patterns = [
-    r"\bgit\s+push\s+.*\bgh-pages\b",
-    r"\bgh-pages\b",
+FORBIDDEN_CMD_PATTERNS = [
+    r'\bgit\s+push\s+.*\bgh-pages\b',
+    r'\bgh-pages\b',
+    r'\bmkdocs\s+gh-deploy\b',
 ]
-allowed = "evidence-hub-publish.yml"
-violations = []
+ALLOWED = 'evidence-hub-publish.yml'
 
-for workflow in Path(".github/workflows").glob("*.yml"):
-    text = workflow.read_text().lower()
-    if workflow.name == allowed:
-        continue
-    for ref in forbidden_refs:
-        if ref in text:
-            violations.append((workflow.name, ref))
-    for cmd_pattern in forbidden_cmd_patterns:
-        if re.search(cmd_pattern, text):
-            violations.append((workflow.name, f"cmd:{cmd_pattern}"))
 
-if violations:
-    raise SystemExit(f"forbidden pages deploy references: {violations}")
+def main() -> None:
+    violations = []
+    for workflow in Path('.github/workflows').glob('*.yml'):
+        text = workflow.read_text(encoding='utf-8').lower()
+        if workflow.name == ALLOWED:
+            continue
+        for ref in FORBIDDEN_REFS:
+            if ref in text:
+                violations.append((workflow.name, ref))
+        for cmd_pattern in FORBIDDEN_CMD_PATTERNS:
+            if re.search(cmd_pattern, text):
+                violations.append((workflow.name, f'cmd:{cmd_pattern}'))
 
-central_text = Path(".github/workflows", allowed).read_text().lower()
-for required in ("actions/deploy-pages", "actions/upload-pages-artifact"):
-    if required not in central_text:
-        raise SystemExit(f"central publisher missing {required}")
+    if violations:
+        raise SystemExit(f'forbidden pages deploy references: {violations}')
 
-print("ok")
+    central_text = Path('.github/workflows', ALLOWED).read_text(encoding='utf-8').lower()
+    for required in ('actions/deploy-pages', 'actions/upload-pages-artifact'):
+        if required not in central_text:
+            raise SystemExit(f'central publisher missing {required}')
+
+    print('ok')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_pages_architecture.py
+++ b/tests/test_pages_architecture.py
@@ -3,24 +3,19 @@ from pathlib import Path
 
 
 class TestPagesArchitecture(unittest.TestCase):
-    def test_only_central_workflow_uses_pages_actions(self):
-        workflows = sorted(Path('.github/workflows').glob('*.yml'))
-        deploy_refs = []
-        upload_refs = []
-        for wf in workflows:
-            text = wf.read_text()
-            if 'actions/deploy-pages' in text:
-                deploy_refs.append(wf.as_posix())
-            if 'actions/upload-pages-artifact' in text:
-                upload_refs.append(wf.as_posix())
+    def test_central_publisher_contains_pages_actions(self):
+        wf = Path('.github/workflows/evidence-hub-publish.yml').read_text(encoding='utf-8').lower()
+        self.assertIn('actions/upload-pages-artifact', wf)
+        self.assertIn('actions/deploy-pages', wf)
 
-        self.assertEqual(deploy_refs, ['.github/workflows/evidence-hub-publish.yml'])
-        self.assertEqual(upload_refs, ['.github/workflows/evidence-hub-publish.yml'])
-
-    def test_architecture_script(self):
-        import subprocess
-
-        subprocess.check_call(['python', 'scripts/check_pages_architecture.py'])
+    def test_only_central_workflow_deploys_pages(self):
+        central = 'evidence-hub-publish.yml'
+        for p in Path('.github/workflows').glob('*.yml'):
+            text = p.read_text(encoding='utf-8').lower()
+            if p.name == central:
+                continue
+            self.assertNotIn('actions/upload-pages-artifact', text)
+            self.assertNotIn('actions/deploy-pages', text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Centralize and harden GitHub Pages publishing so a single trusted workflow publishes the site and prevents drift from per-workflow deploys.
- Ensure the Evidence Mission Control can autonomously decide when to rebuild and deploy by computing a `needed_update` signal and gating deploys behind discovery, validation, and linkcheck.
- Enforce architecture and claim-safety guardrails so historical backfill cannot downgrade richer evidence and no overclaims are published.

### Description
- Reworked the central publisher at `.github/workflows/evidence-hub-publish.yml` into staged jobs (`preflight`, `discover`, `build_validate`, `deploy`) with redundant triggers (`workflow_dispatch`, `repository_dispatch`, `workflow_run`, `schedule`, `push`, and `pull_request`), `concurrency` group `evidence-hub-publish`, explicit `permissions`, and a `should_deploy` gate driven by `evidence_registry/needed_update.json`.
- Strengthened the Pages-architecture guard in `scripts/check_pages_architecture.py` to detect forbidden deploy references and command patterns (including `actions/deploy-pages`, `actions/upload-pages-artifact`, `peaceiris/actions-gh-pages`, `mkdocs gh-deploy`, and `git push ... gh-pages`) and to require that the central workflow contains the official Pages upload/deploy actions.
- Updated tests in `tests/test_pages_architecture.py` to assert that only the central publisher contains Pages deploy actions and that the central workflow includes both `actions/upload-pages-artifact` and `actions/deploy-pages`.
- Integrated discovery/backfill/needed-update steps into the publisher flow and added a non-main PR note step so builds run in PRs but deployment is only attempted from trusted `main` events; preserved discovery and registry validation steps and did not change experiment logic or fabricate metrics.

### Testing
- Ran unit tests with `python -m unittest discover -s tests` (84 tests) and they passed successfully.
- Ran architecture and site checks: `python scripts/check_pages_architecture.py` returned `ok` and `python -m agialpha_evidence_hub validate-registry --registry evidence_registry` succeeded.
- Performed a full site pipeline locally with `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5091a830483339e24dc6cef9c1e12)