### PR TITLE
docs: refresh evidence hub migration audit with workflow count

### DIFF
--- a/docs/evidence_hub_migration_audit.md
+++ b/docs/evidence_hub_migration_audit.md
@@ -4,7 +4,7 @@ Date: 2026-05-01
 
 ## 1) Workflows under `.github/workflows/`
 
-All workflow files were enumerated directly from repository state:
+All workflow files were enumerated directly from repository state (79 workflow definitions as of 2026-05-01):
 
 - `ascension-001-autonomous.yml`
 - `ascension-001-falsification-audit.yml`


### PR DESCRIPTION
### Motivation
- Record the current workflow inventory explicitly in the source-of-truth audit to tighten Evidence Hub governance and make the central-publisher checks auditable (`docs/evidence_hub_migration_audit.md`).

### Description
- Updated `docs/evidence_hub_migration_audit.md` to include the explicit workflow inventory size (79 workflow definitions as of 2026-05-01) and ensured the repository still enforces central Pages deployment via the existing publisher guard (`scripts/check_pages_architecture.py`).

### Testing
- Ran the automated verification suite: `python -m unittest discover -s tests`, `python scripts/check_pages_architecture.py`, `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50ecc0ea883338280027a5cdd3df9)