### PR TITLE
Harden RSI governor tests: use context-managed JSON reads

### DIFF
--- a/tests/test_rsi_governor_kernel_schema.py
+++ b/tests/test_rsi_governor_kernel_schema.py
@@ -1,5 +1,13 @@
-import json,unittest
-class T(unittest.TestCase):
- def test_schema(self): self.assertEqual(json.load(open('config/rsi_governance_kernel.json'))['schema_version'],'agialpha.rsi_governance_kernel.v1')
+import json
+import unittest
 
-if __name__=="__main__": unittest.main()
+
+class T(unittest.TestCase):
+    def test_schema(self):
+        with open("config/rsi_governance_kernel.json", "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        self.assertEqual(payload["schema_version"], "agialpha.rsi_governance_kernel.v1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rsi_governor_state_integrity.py
+++ b/tests/test_rsi_governor_state_integrity.py
@@ -1,5 +1,13 @@
-import json,unittest
-class T(unittest.TestCase):
- def test_state(self): self.assertIn('state_hash_chain',json.load(open('rsi_state/governance_kernel_state.json')))
+import json
+import unittest
 
-if __name__=="__main__": unittest.main()
+
+class T(unittest.TestCase):
+    def test_state(self):
+        with open("rsi_state/governance_kernel_state.json", "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        self.assertIn("state_hash_chain", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Eliminate unclosed-file `ResourceWarning`s and improve test hygiene by ensuring JSON fixtures are opened with context managers and explicit UTF-8 encoding.

### Description
- Refactored `tests/test_rsi_governor_kernel_schema.py` and `tests/test_rsi_governor_state_integrity.py` to use `with open(..., encoding="utf-8")` and expanded one-line tests into readable multi-line assertions without changing test logic or expectations.

### Testing
- Ran `python -m unittest discover -s tests`, `python scripts/check_pages_architecture.py`, `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and `python -m agialpha_evidence_hub linkcheck --site _site`, and all commands passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f512f539a08333924b96efe958255f)