### PR TITLE
Build AGI ALPHA Evidence Mission Control v3

### DIFF
--- a/.github/workflows/evidence-hub-canary.yml
+++ b/.github/workflows/evidence-hub-canary.yml
@@ -1,0 +1,44 @@
+name: Evidence Hub Canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Emit synthetic canary manifest
+        run: |
+          python -m agialpha_evidence_hub emit-manifest \
+            --experiment-slug evidence-hub-canary-001 \
+            --experiment-name "Evidence Hub Canary 001" \
+            --workflow-name "Evidence Hub Canary" \
+            --workflow-file .github/workflows/evidence-hub-canary.yml \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --commit "$GITHUB_SHA" \
+            --branch "$GITHUB_REF_NAME" \
+            --out evidence-run-manifest.json
+
+      - name: Upload canary manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-hub-canary-manifest
+          path: evidence-run-manifest.json
+
+      - name: Claim boundary note
+        run: |
+          echo "This canary tests Evidence Hub publication mechanics only. It does not claim experimental performance."

--- a/.github/workflows/evidence-hub-repair.yml
+++ b/.github/workflows/evidence-hub-repair.yml
@@ -1,0 +1,51 @@
+name: Evidence Hub Repair
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "41 3 * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Architecture guard
+        run: python scripts/check_pages_architecture.py
+
+      - name: Build and validate Evidence Hub
+        run: |
+          python -m agialpha_evidence_hub build --registry evidence_registry --out _site
+          python -m agialpha_evidence_hub validate --registry evidence_registry --site _site
+          python -m agialpha_evidence_hub linkcheck --site _site
+
+      - name: Create diagnostics issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Evidence Mission Control publisher validation failure';
+            const body = [
+              'Automated repair detected a validation failure.',
+              '',
+              'This workflow does not auto-merge and does not fabricate metrics.',
+              'Please inspect workflow logs and runbooks before manual remediation.'
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body
+            });

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -49,7 +49,9 @@ Current as of 2026-05-01.
 | `docs-audit.yml` | Internal CI workflow; no manual dispatch required. | no |
 | `cyber-sovereign-002-scaling.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `evidence-factory-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+| `evidence-hub-canary.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `evidence-hub-publish.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | yes |
+| `evidence-hub-repair.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `falsification-audit-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `frontier-external-review.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `frontier-usefulness-autonomous.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |

--- a/docs/evidence_mission_control_v3_audit.md
+++ b/docs/evidence_mission_control_v3_audit.md
@@ -1,0 +1,93 @@
+# Evidence Mission Control v3 Audit (2026-05-01)
+
+## Scope and method
+Repository inspected directly on 2026-05-01 using workflow/config/source tree inspection.
+
+## 1) Workflows in `.github/workflows/`
+Total detected: **79** workflow files.
+
+Key groups: autonomous, replay, falsification-audit, scaling, delayed-outcome, safe-pr, lifecycle, external-review, evidence-hub publish.
+
+## 2) Workflows currently deploying GitHub Pages
+- `evidence-hub-publish.yml` (contains Pages deploy actions).
+
+## 3) Workflows that emit artifacts
+Most experiment workflows include `actions/upload-artifact` (autonomous, replay, falsification, scaling, challenge packs, docs audit, etc.).
+
+## 4) Workflows with `workflow_dispatch`
+All detected workflow files currently include `workflow_dispatch`.
+
+## 5) Workflows that appear to be experiment producers
+Examples:
+- `*-autonomous.yml`
+- `seed-runner-autonomous.yml`
+- `evidence-factory-autonomous.yml`
+- `l4-l7-evidence-autopilot.yml`
+
+## 6) Replay/falsification/scaling/delayed-outcome/external-review/safe-PR/lifecycle workflows
+Detected by filename and YAML intent:
+- replay: `*replay*.yml`, `independent-replay-autonomous.yml`
+- falsification: `*falsification-audit*.yml`, `falsification-audit-autonomous.yml`
+- scaling: `*scaling*.yml`
+- delayed outcome: `*delayed-outcome*.yml`
+- external review: `frontier-external-review.yml`, `l4-external-reviewer-replay.yml`
+- safe PR: `*safe-pr*.yml`
+- lifecycle: `rsi-governor-001-lifecycle.yml`
+
+## 7) Existing evidence directories
+- `sample_outputs/`
+- `autonomous/evidence_runs/`
+- `rsi-governor-runs/`
+- `evidence_registry/`
+
+## 8) Existing docs / Pages output directories
+- `docs/`
+- `_site/` (generated in current architecture/tests)
+- legacy docs subtrees inside autonomous evidence outputs.
+
+## 9) Existing `evidence_registry` state
+Present:
+- top-level: `registry.json`, `experiments.json`, `runs.json`, `workflows.json`, `latest.json`, `discovered.json`, `CHANGELOG.md`
+- nested `evidence_registry/registry/*.json` mirror files.
+
+## 10) Broken routes
+No committed automated route-health snapshot found in this audit pass; route health should be produced by hub linkcheck/validation step.
+
+## 11) Shallow placeholder routes
+Legacy and discovered pages include shallow placeholders in historical content; must be progressively replaced by canonical summaries when manifest-grade evidence exists.
+
+## 12) High-confidence experiment pages
+High-confidence families already represented in repo content/workflows include:
+HELIOS, CYBER-SOVEREIGN, BENCHMARK-GAUNTLET, OMEGA-GAUNTLET, PHOENIX-HUB, RSI-GOVERNOR, RSI-FORGE, ASCENSION, EVIDENCE-FACTORY.
+
+## 13) Low-confidence discovered entries
+Seed/run subdirectories and historical partial directories exist and must remain segregated as low confidence unless upgraded by explicit manifest/docket evidence.
+
+## 14) Known experiment families
+- first-rsi-loop / coldchain-energy-loop
+- evidence-factory
+- helios
+- cyber-sovereign
+- benchmark-gauntlet
+- omega-gauntlet
+- omega-aegis
+- phoenix-hub
+- rsi-governor
+- rsi-forge
+- ascension
+- frontier/usefulness
+
+## 15) Unknown experiment families
+Anything not matching manifest evidence or known family prefixes should be treated as discovered/low-confidence until canonicalized.
+
+## 16) Current failure mode
+Primary systemic risk: potential drift between dynamic workflows/artifacts and persistent public pages unless central publisher + needed-update + repair + canary loops are continuously enforced.
+
+## 17) Proposed migration plan
+1. Enforce single Pages publisher architecture guard.
+2. Keep experiment workflows artifact-emitting only.
+3. Ensure evidence manifests are emitted and ingested.
+4. Normalize and persist registry for run/workflow/experiment state.
+5. Build validated static site from registry only.
+6. Add repair workflow for safe non-automerge fixes/issues.
+7. Add canary workflow proving autonomous new-manifest discovery and rendering.


### PR DESCRIPTION
### Motivation
- Provide institutional scaffolding and diagnostics for the Evidence Hub so the site can be autonomously discovered, validated, and repaired without promoting experimental claims. 
- Add a safe repair path that enforces the architecture guard and alerts maintainers rather than auto-merging fixes. 
- Add a lightweight canary to prove that emitted evidence manifests can be discovered and uploaded as artifacts without hardcoding experimental data.

### Description
- Add an initial repository audit at `docs/evidence_mission_control_v3_audit.md` summarizing workflows, evidence locations, confidence rules, and a migration plan. 
- Add `.github/workflows/evidence-hub-repair.yml` which runs `python scripts/check_pages_architecture.py`, builds the hub with `python -m agialpha_evidence_hub build`, validates with `python -m agialpha_evidence_hub validate`, runs `python -m agialpha_evidence_hub linkcheck`, and creates a diagnostics issue on failure without auto-merging. 
- Add `.github/workflows/evidence-hub-canary.yml` which emits a synthetic `evidence-run-manifest.json` for `evidence-hub-canary-001`, uploads it as an artifact, and includes an explicit claim-boundary note. 

### Testing
- Ran the architecture guard with `python scripts/check_pages_architecture.py` and it completed successfully. 
- Ran targeted unit tests with `python -m unittest tests.test_pages_architecture tests.test_evidence_hub_build tests.test_evidence_hub_needed_update` and all tests passed. 
- No automated test failures were observed for the added workflows and audit files in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f515f8c6f08333bec9772a18647b9f)