### PR TITLE
Build AGI ALPHA Evidence Mission Control v3

### DIFF
--- a/agialpha_evidence_hub/cli.py
+++ b/agialpha_evidence_hub/cli.py
@@ -9,6 +9,7 @@ from .linkcheck import linkcheck
 from .discover import discover_to_file
 from .workflow_dispatch import parse_workflow_dispatch_inputs, workflow_gh_command
 from .needed_update import needed_update
+from .repair import generate_repair_plan
 
 def _default_manifest(args):
     return {
@@ -29,6 +30,7 @@ def main():
     l=sp.add_parser('linkcheck'); l.add_argument('--site',default='_site')
     wc=sp.add_parser('workflow-catalog'); wc.add_argument('--repo-root',default='.'); wc.add_argument('--registry',default='evidence_registry')
     nu=sp.add_parser('needed-update'); nu.add_argument('--registry',default='evidence_registry'); nu.add_argument('--repo-root',default='.'); nu.add_argument('--out')
+    rp=sp.add_parser('repair'); rp.add_argument('--registry',default='evidence_registry'); rp.add_argument('--repo-root',default='.'); rp.add_argument('--out')
     a=ap.parse_args()
     if a.cmd=='discover': print(json.dumps(discover_to_file(a.repo_root,a.out),indent=2))
     elif a.cmd=='register-run': m=load_input(a.input); validate_manifest(m); update_registry(a.registry,m)
@@ -50,6 +52,12 @@ def main():
     elif a.cmd=='needed-update':
         result=needed_update(a.registry, a.repo_root)
         out_path = Path(a.out) if a.out else Path(a.registry)/'needed_update.json'
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2))
+    elif a.cmd=='repair':
+        result=generate_repair_plan(a.registry, a.repo_root)
+        out_path = Path(a.out) if a.out else Path(a.registry)/'repair_plan.json'
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(json.dumps(result, indent=2))
         print(json.dumps(result, indent=2))

--- a/agialpha_evidence_hub/repair.py
+++ b/agialpha_evidence_hub/repair.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List
 
 def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str = ".") -> Dict[str, Any]:
     """Create a safe, non-destructive repair plan from known index/health files."""
-    reg = Path(registry_dir)
+    repo = Path(repo_root).resolve()
+    reg = (Path(registry_dir) if Path(registry_dir).is_absolute() else (repo / registry_dir)).resolve()
     idx = reg / "indexes"
 
     def _load(path: Path, default):
@@ -39,6 +40,6 @@ def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str
         "safe_only": True,
         "auto_merge": False,
         "registry": str(reg),
-        "repo_root": str(Path(repo_root)),
+        "repo_root": str(repo),
         "actions": actions,
     }

--- a/agialpha_evidence_hub/repair.py
+++ b/agialpha_evidence_hub/repair.py
@@ -1,0 +1,44 @@
+"""Conservative repair-plan generation for Evidence Hub registry/site health."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str = ".") -> Dict[str, Any]:
+    """Create a safe, non-destructive repair plan from known index/health files."""
+    reg = Path(registry_dir)
+    idx = reg / "indexes"
+
+    def _load(path: Path, default):
+        if path.exists():
+            try:
+                return json.loads(path.read_text())
+            except json.JSONDecodeError:
+                return default
+        return default
+
+    broken_routes = _load(idx / "broken_routes.json", [])
+    shallow_pages = _load(idx / "shallow_pages.json", [])
+    low_conf = _load(idx / "low_confidence_discoveries.json", [])
+
+    actions: List[Dict[str, str]] = []
+    if broken_routes:
+        actions.append({"action": "rebuild_legacy_routes", "reason": "broken_routes_detected"})
+    if shallow_pages:
+        actions.append({"action": "render_bounded_summaries", "reason": "shallow_pages_detected"})
+    if low_conf:
+        actions.append({"action": "surface_discoveries", "reason": "low_confidence_needs_manifest"})
+    if not actions:
+        actions.append({"action": "no_op", "reason": "no_defects_detected"})
+
+    return {
+        "status": "success",
+        "safe_only": True,
+        "auto_merge": False,
+        "registry": str(reg),
+        "repo_root": str(Path(repo_root)),
+        "actions": actions,
+    }


### PR DESCRIPTION
### Motivation
- Close the remaining autonomous-sentinel gap by adding a conservative, non-destructive repair-plan generator so the Evidence Hub can detect registry/site defects and produce safe repair proposals without auto-merging changes.

### Description
- Add `agialpha_evidence_hub/repair.py` with `generate_repair_plan()` that reads `evidence_registry/indexes/{broken_routes,shallow_pages,low_confidence_discoveries}.json` and returns a safe JSON repair plan (`safe_only: true`, `auto_merge: false`) describing suggested actions; and wire a new `repair` CLI command in `agialpha_evidence_hub/cli.py` that persists to `evidence_registry/repair_plan.json` by default and prints the plan.

### Testing
- Ran the unit test suite with `python -m unittest discover -s tests`, ran `python scripts/check_pages_architecture.py`, built the site with `python -m agialpha_evidence_hub build --registry evidence_registry --out _site`, validated with `python -m agialpha_evidence_hub validate --registry evidence_registry --site _site`, and ran `python -m agialpha_evidence_hub linkcheck --site _site`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51b6abf0c8333b6a1baa8fa25f08c)