### PR TITLE
Add conservative repair-plan generator and `repair` CLI command

### DIFF
--- a/agialpha_evidence_hub/cli.py
+++ b/agialpha_evidence_hub/cli.py
@@ -9,7 +9,7 @@ from .linkcheck import linkcheck
 from .discover import discover_to_file
 from .workflow_dispatch import parse_workflow_dispatch_inputs, workflow_gh_command
 from .needed_update import needed_update
-from .repair import generate_repair_plan
+from .repair import generate_repair_plan, resolve_registry_path
 
 def _default_manifest(args):
     return {
@@ -57,7 +57,7 @@ def main():
         print(json.dumps(result, indent=2))
     elif a.cmd=='repair':
         result=generate_repair_plan(a.registry, a.repo_root)
-        out_path = Path(a.out) if a.out else Path(a.registry)/'repair_plan.json'
+        out_path = Path(a.out) if a.out else resolve_registry_path(a.registry, a.repo_root)/'repair_plan.json'
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(json.dumps(result, indent=2))
         print(json.dumps(result, indent=2))

--- a/agialpha_evidence_hub/cli.py
+++ b/agialpha_evidence_hub/cli.py
@@ -9,6 +9,7 @@ from .linkcheck import linkcheck
 from .discover import discover_to_file
 from .workflow_dispatch import parse_workflow_dispatch_inputs, workflow_gh_command
 from .needed_update import needed_update
+from .repair import generate_repair_plan
 
 def _default_manifest(args):
     return {
@@ -29,6 +30,7 @@ def main():
     l=sp.add_parser('linkcheck'); l.add_argument('--site',default='_site')
     wc=sp.add_parser('workflow-catalog'); wc.add_argument('--repo-root',default='.'); wc.add_argument('--registry',default='evidence_registry')
     nu=sp.add_parser('needed-update'); nu.add_argument('--registry',default='evidence_registry'); nu.add_argument('--repo-root',default='.'); nu.add_argument('--out')
+    rp=sp.add_parser('repair'); rp.add_argument('--registry',default='evidence_registry'); rp.add_argument('--repo-root',default='.'); rp.add_argument('--out')
     a=ap.parse_args()
     if a.cmd=='discover': print(json.dumps(discover_to_file(a.repo_root,a.out),indent=2))
     elif a.cmd=='register-run': m=load_input(a.input); validate_manifest(m); update_registry(a.registry,m)
@@ -50,6 +52,12 @@ def main():
     elif a.cmd=='needed-update':
         result=needed_update(a.registry, a.repo_root)
         out_path = Path(a.out) if a.out else Path(a.registry)/'needed_update.json'
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2))
+    elif a.cmd=='repair':
+        result=generate_repair_plan(a.registry, a.repo_root)
+        out_path = Path(a.out) if a.out else Path(a.registry)/'repair_plan.json'
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(json.dumps(result, indent=2))
         print(json.dumps(result, indent=2))

--- a/agialpha_evidence_hub/repair.py
+++ b/agialpha_evidence_hub/repair.py
@@ -1,0 +1,47 @@
+"""Conservative repair-plan generation for Evidence Hub registry/site health."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str = ".") -> Dict[str, Any]:
+    """Create a safe, non-destructive repair plan from known index/health files."""
+    root = Path(repo_root).resolve()
+    reg = Path(registry_dir)
+    if not reg.is_absolute():
+        reg = (root / reg).resolve()
+    idx = reg / "indexes"
+
+    def _load(path: Path, default):
+        if path.exists():
+            try:
+                return json.loads(path.read_text())
+            except json.JSONDecodeError:
+                return default
+        return default
+
+    broken_routes = _load(idx / "broken_routes.json", [])
+    shallow_pages = _load(idx / "shallow_pages.json", [])
+    low_conf = _load(idx / "low_confidence_discoveries.json", [])
+
+    actions: List[Dict[str, str]] = []
+    if broken_routes:
+        actions.append({"action": "rebuild_legacy_routes", "reason": "broken_routes_detected"})
+    if shallow_pages:
+        actions.append({"action": "render_bounded_summaries", "reason": "shallow_pages_detected"})
+    if low_conf:
+        actions.append({"action": "surface_discoveries", "reason": "low_confidence_needs_manifest"})
+    if not actions:
+        actions.append({"action": "no_op", "reason": "no_defects_detected"})
+
+    return {
+        "status": "success",
+        "safe_only": True,
+        "auto_merge": False,
+        "registry": str(reg),
+        "repo_root": str(Path(repo_root)),
+        "actions": actions,
+    }

--- a/agialpha_evidence_hub/repair.py
+++ b/agialpha_evidence_hub/repair.py
@@ -4,28 +4,36 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 
-def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str = ".") -> Dict[str, Any]:
-    """Create a safe, non-destructive repair plan from known index/health files."""
+def resolve_registry_path(registry_dir: str = "evidence_registry", repo_root: str = ".") -> Path:
     root = Path(repo_root).resolve()
     reg = Path(registry_dir)
     if not reg.is_absolute():
         reg = (root / reg).resolve()
+    return reg
+
+
+def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str = ".") -> Dict[str, Any]:
+    """Create a safe, non-destructive repair plan from known index/health files."""
+    reg = resolve_registry_path(registry_dir, repo_root)
     idx = reg / "indexes"
 
-    def _load(path: Path, default):
+    parse_errors: List[str] = []
+
+    def _load(path: Path, default) -> Tuple[Any, bool]:
         if path.exists():
             try:
-                return json.loads(path.read_text())
+                return json.loads(path.read_text()), False
             except json.JSONDecodeError:
-                return default
-        return default
+                parse_errors.append(str(path))
+                return default, True
+        return default, False
 
-    broken_routes = _load(idx / "broken_routes.json", [])
-    shallow_pages = _load(idx / "shallow_pages.json", [])
-    low_conf = _load(idx / "low_confidence_discoveries.json", [])
+    broken_routes, _ = _load(idx / "broken_routes.json", [])
+    shallow_pages, _ = _load(idx / "shallow_pages.json", [])
+    low_conf, _ = _load(idx / "low_confidence_discoveries.json", [])
 
     actions: List[Dict[str, str]] = []
     if broken_routes:
@@ -34,14 +42,17 @@ def generate_repair_plan(registry_dir: str = "evidence_registry", repo_root: str
         actions.append({"action": "render_bounded_summaries", "reason": "shallow_pages_detected"})
     if low_conf:
         actions.append({"action": "surface_discoveries", "reason": "low_confidence_needs_manifest"})
+    if parse_errors:
+        actions.append({"action": "investigate_registry_parse_failure", "reason": "malformed_index_json"})
     if not actions:
         actions.append({"action": "no_op", "reason": "no_defects_detected"})
 
     return {
-        "status": "success",
+        "status": "error" if parse_errors else "success",
         "safe_only": True,
         "auto_merge": False,
         "registry": str(reg),
         "repo_root": str(Path(repo_root)),
         "actions": actions,
+        "parse_errors": parse_errors,
     }


### PR DESCRIPTION
### Motivation
- Provide a safe, non-destructive way to surface repair actions for Evidence Hub based on existing index files.
- Expose the repair plan generator from the command line to allow workflows to produce a machine-readable `repair_plan.json` for automation.

### Description
- Add `agialpha_evidence_hub.repair.generate_repair_plan` which reads registry index files (`indexes/broken_routes.json`, `indexes/shallow_pages.json`, `indexes/low_confidence_discoveries.json`) and returns a conservative list of actions such as `rebuild_legacy_routes`, `render_bounded_summaries`, `surface_discoveries`, or `no_op` when nothing is found.
- Wire a new `repair` subcommand into the CLI (`agialpha_evidence_hub.cli`) that calls `generate_repair_plan`, writes the result to the provided `--out` path or to `evidence_registry/repair_plan.json`, and prints the JSON result.
- The generated plan is explicitly `safe_only` and sets `auto_merge` to `False` to avoid destructive automation.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51b6abf0c8333b6a1baa8fa25f08c)