### PR TITLE
Expose lifecycle dispatch inputs and gate RSI-GOVERNOR-001 workflow; pass candidate_count to autonomous runner

### DIFF
--- a/.github/workflows/rsi-governor-001-autonomous.yml
+++ b/.github/workflows/rsi-governor-001-autonomous.yml
@@ -7,12 +7,21 @@ on:
         required: false
         default: rsi-governor-runs/test
         type: string
+      candidate_count:
+        description: Number of governance-kernel candidates
+        required: false
+        default: "6"
+        type: string
   workflow_call:
     inputs:
       out_dir:
         required: false
         type: string
         default: rsi-governor-runs/lifecycle
+      candidate_count:
+        required: false
+        type: string
+        default: "6"
     outputs:
       artifact_name:
         value: ${{ jobs.run.outputs.artifact_name }}
@@ -36,7 +45,7 @@ jobs:
           python-version: '3.11'
       - id: cfg
         run: echo "out_dir=${{ inputs.out_dir || 'rsi-governor-runs/test' }}" >> $GITHUB_OUTPUT
-      - run: python -m agialpha_rsi_governor run --repo-root . --out "${{ steps.cfg.outputs.out_dir }}"
+      - run: python -m agialpha_rsi_governor run --repo-root . --out "${{ steps.cfg.outputs.out_dir }}" --candidate-count "${{ inputs.candidate_count || '6' }}"
       - id: meta
         run: |
           echo "artifact_name=rsi-governor-autonomous-${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rsi-governor-001-lifecycle.yml
+++ b/.github/workflows/rsi-governor-001-lifecycle.yml
@@ -1,6 +1,29 @@
 name: AGI ALPHA RSI-GOVERNOR-001 / Lifecycle Orchestrator
 on:
   workflow_dispatch:
+    inputs:
+      candidate_count:
+        description: "Number of governance-kernel candidates"
+        required: false
+        default: "6"
+      open_promotion_pr:
+        description: "Open safe promotion PR if candidate passes"
+        required: false
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+      run_replay:
+        description: "Run replay after autonomous evaluation"
+        required: false
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+      run_falsification:
+        description: "Run falsification audit after replay"
+        required: false
+        default: "true"
+        type: choice
+        options: ["true", "false"]
   repository_dispatch:
     types: [rsi_governor_cycle_requested]
   schedule:
@@ -18,27 +41,35 @@ jobs:
     uses: ./.github/workflows/rsi-governor-001-autonomous.yml
     with:
       out_dir: rsi-governor-runs/lifecycle
+      candidate_count: ${{ inputs.candidate_count || '6' }}
+
   replay:
+    if: ${{ inputs.run_replay != 'false' }}
     needs: autonomous_candidate_evolution
     uses: ./.github/workflows/rsi-governor-001-replay.yml
     with:
       autonomous_artifact: ${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}
       out_dir: rsi-governor-runs/lifecycle
+
   falsification_audit:
+    if: ${{ inputs.run_falsification != 'false' }}
     needs: [autonomous_candidate_evolution, replay]
     uses: ./.github/workflows/rsi-governor-001-falsification-audit.yml
     with:
       autonomous_artifact: ${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}
       out_dir: rsi-governor-runs/lifecycle
+
   safe_pr:
+    if: ${{ inputs.open_promotion_pr != 'false' }}
     needs: [autonomous_candidate_evolution, falsification_audit]
     uses: ./.github/workflows/rsi-governor-001-safe-pr.yml
     with:
       autonomous_artifact: ${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}
+
   evidence_hub_notify:
     needs: [autonomous_candidate_evolution, replay, falsification_audit, safe_pr]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - run: |
-          echo '{"promotion_status":"pending_human_review","artifact":"${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}"}' > lifecycle_status.json
+          echo '{"promotion_status":"pending_human_review","artifact":"${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}","doctrine":"No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}' > lifecycle_status.json


### PR DESCRIPTION
### Motivation
- Make the RSI lifecycle explicit and operator-controlled by exposing dispatch inputs so replay/falsification/PR stages are not implicit defaults.  
- Ensure deterministic plumbing where `candidate_count` is passed from the lifecycle orchestrator into the autonomous candidate generator.  
- Surface the non-negotiable doctrine in lifecycle outputs to prevent accidental claim promotion and preserve the human review gate.  

### Description
- Added `workflow_dispatch` inputs to the lifecycle orchestrator: `candidate_count`, `open_promotion_pr`, `run_replay`, and `run_falsification`, and wired them to job gating logic in `/.github/workflows/rsi-governor-001-lifecycle.yml`.  
- Propagated `candidate_count` into the autonomous workflow call and added the same input to `/.github/workflows/rsi-governor-001-autonomous.yml`.  
- Updated the autonomous workflow to pass `--candidate-count` through to the runner invocation (`python -m agialpha_rsi_governor run`).  
- Emit the doctrine string (`No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.`) in the lifecycle status output to make the claim-boundary explicit.  

### Testing
- Unit test discovery for RSI governor tests passed: `python -m unittest discover -s tests -p 'test_rsi_governor*py'` (24 tests ran and all passed).  
- End-to-end runner exercised: `python -m agialpha_rsi_governor run --repo-root . --out rsi-governor-runs/test --candidate-count 3` completed and produced run metadata.  
- Replay step ran and returned success via `python -m agialpha_rsi_governor replay --docket rsi-governor-runs/test/rsi-governor-evidence-docket`.  
- Falsification audit ran and returned success via `python -m agialpha_rsi_governor falsification-audit --docket rsi-governor-runs/test/rsi-governor-evidence-docket`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53f2d7c988333b09a8cf09acef360)