### PR TITLE
Add lifecycle `phase` selector and phase-gated jobs to RSI governor workflow

### DIFF
--- a/.github/workflows/rsi-governor-001-lifecycle.yml
+++ b/.github/workflows/rsi-governor-001-lifecycle.yml
@@ -62,11 +62,21 @@ jobs:
     with:
       autonomous_artifact: ${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}
 
-  delayed_outcome:
-    if: ${{ inputs.phase == 'post_merge' || inputs.phase == 'full_if_allowed' }}
+  delayed_outcome_post_merge:
+    if: ${{ inputs.phase == 'post_merge' }}
     uses: ./.github/workflows/rsi-governor-001-delayed-outcome.yml
 
-  vnext_canary:
-    if: ${{ inputs.phase == 'post_merge' || inputs.phase == 'full_if_allowed' }}
-    needs: delayed_outcome
+  vnext_canary_post_merge:
+    if: ${{ inputs.phase == 'post_merge' }}
+    needs: delayed_outcome_post_merge
+    uses: ./.github/workflows/rsi-governor-001-vnext-canary.yml
+
+  delayed_outcome_full_if_allowed:
+    if: ${{ inputs.phase == 'full_if_allowed' }}
+    needs: safe_pr
+    uses: ./.github/workflows/rsi-governor-001-delayed-outcome.yml
+
+  vnext_canary_full_if_allowed:
+    if: ${{ inputs.phase == 'full_if_allowed' }}
+    needs: delayed_outcome_full_if_allowed
     uses: ./.github/workflows/rsi-governor-001-vnext-canary.yml

--- a/.github/workflows/rsi-governor-001-lifecycle.yml
+++ b/.github/workflows/rsi-governor-001-lifecycle.yml
@@ -2,49 +2,45 @@ name: AGI ALPHA RSI-GOVERNOR-001 / Lifecycle Orchestrator
 on:
   workflow_dispatch:
     inputs:
+      phase:
+        description: "Lifecycle phase selector"
+        required: false
+        default: "pre_promotion"
+        type: choice
+        options: ["pre_promotion", "post_merge", "full_if_allowed"]
       candidate_count:
         description: "Number of governance-kernel candidates"
         required: false
         default: "6"
-      open_promotion_pr:
-        description: "Open safe promotion PR if candidate passes"
-        required: false
-        default: "true"
-        type: choice
-        options: ["true", "false"]
-      run_replay:
-        description: "Run replay after autonomous evaluation"
-        required: false
-        default: "true"
-        type: choice
-        options: ["true", "false"]
-      run_falsification:
-        description: "Run falsification audit after replay"
+      open_pr_if_passes:
+        description: "Open safe promotion PR if and only if all gates pass"
         required: false
         default: "true"
         type: choice
         options: ["true", "false"]
   repository_dispatch:
     types: [rsi_governor_cycle_requested]
-  schedule:
-    - cron: "17 */12 * * *"
+
 concurrency:
   group: rsi-governor-001-lifecycle
   cancel-in-progress: false
+
 permissions:
   contents: write
   actions: read
   pull-requests: write
   issues: write
+
 jobs:
   autonomous_candidate_evolution:
+    if: ${{ inputs.phase == 'pre_promotion' || inputs.phase == 'full_if_allowed' || inputs.phase == '' }}
     uses: ./.github/workflows/rsi-governor-001-autonomous.yml
     with:
       out_dir: rsi-governor-runs/lifecycle
       candidate_count: ${{ inputs.candidate_count || '6' }}
 
   replay:
-    if: ${{ inputs.run_replay != 'false' }}
+    if: ${{ inputs.phase == 'pre_promotion' || inputs.phase == 'full_if_allowed' || inputs.phase == '' }}
     needs: autonomous_candidate_evolution
     uses: ./.github/workflows/rsi-governor-001-replay.yml
     with:
@@ -52,7 +48,7 @@ jobs:
       out_dir: rsi-governor-runs/lifecycle
 
   falsification_audit:
-    if: ${{ inputs.run_falsification != 'false' }}
+    if: ${{ inputs.phase == 'pre_promotion' || inputs.phase == 'full_if_allowed' || inputs.phase == '' }}
     needs: [autonomous_candidate_evolution, replay]
     uses: ./.github/workflows/rsi-governor-001-falsification-audit.yml
     with:
@@ -60,16 +56,17 @@ jobs:
       out_dir: rsi-governor-runs/lifecycle
 
   safe_pr:
-    if: ${{ inputs.open_promotion_pr != 'false' }}
+    if: ${{ inputs.open_pr_if_passes != 'false' && (inputs.phase == 'pre_promotion' || inputs.phase == 'full_if_allowed' || inputs.phase == '') }}
     needs: [autonomous_candidate_evolution, falsification_audit]
     uses: ./.github/workflows/rsi-governor-001-safe-pr.yml
     with:
       autonomous_artifact: ${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}
 
-  evidence_hub_notify:
-    needs: [autonomous_candidate_evolution, replay, falsification_audit, safe_pr]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - run: |
-          echo '{"promotion_status":"pending_human_review","artifact":"${{ needs.autonomous_candidate_evolution.outputs.artifact_name }}","doctrine":"No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}' > lifecycle_status.json
+  delayed_outcome:
+    if: ${{ inputs.phase == 'post_merge' || inputs.phase == 'full_if_allowed' }}
+    uses: ./.github/workflows/rsi-governor-001-delayed-outcome.yml
+
+  vnext_canary:
+    if: ${{ inputs.phase == 'post_merge' || inputs.phase == 'full_if_allowed' }}
+    needs: delayed_outcome
+    uses: ./.github/workflows/rsi-governor-001-vnext-canary.yml


### PR DESCRIPTION
### Motivation

- Introduce a lifecycle `phase` selector to control which parts of the governance lifecycle run for a dispatch/trigger. 
- Clarify promotion PR semantics and add post-merge follow-up stages to support delayed outcomes and a vnext canary flow while removing the scheduled cron run.

### Description

- Add a `phase` workflow input with options `pre_promotion`, `post_merge`, and `full_if_allowed` and default `pre_promotion` to drive conditional execution of jobs. 
- Replace `open_promotion_pr` with `open_pr_if_passes` and tighten its description to require all gates to pass before opening a promotion PR. 
- Remove the `run_replay` and `run_falsification` boolean inputs and convert the `replay`, `falsification_audit`, and `autonomous_candidate_evolution` jobs to be gated by the new `phase` input via `if` expressions. 
- Remove the scheduled cron trigger and add explicit `concurrency` and `permissions` blocks; remove `evidence_hub_notify` and add `delayed_outcome` and `vnext_canary` jobs for `post_merge`/`full_if_allowed` phases. 

### Testing

- No automated runtime tests were executed because this change only modifies GitHub Actions workflow configuration. 
- Basic YAML/workflow syntax was validated to ensure the file parses and the `if` expressions and inputs are well-formed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54f008398833385f3544baaf8d10a)