### PR TITLE
Fix Pages deploy artifact handoff in evidence-hub-publish workflow

### DIFF
--- a/.github/workflows/evidence-hub-publish.yml
+++ b/.github/workflows/evidence-hub-publish.yml
@@ -156,6 +156,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - name: Download built site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: evidence-hub-site-preview
+          path: _site
       - uses: actions/upload-pages-artifact@v4
         with:
           path: _site


### PR DESCRIPTION
### Motivation
- The `deploy` job expected a locally-present `_site` directory but runs on a fresh runner, causing `tar: _site: Cannot open: No such file or directory` when `actions/upload-pages-artifact@v4` was invoked.

### Description
- Add a `Download built site artifact` step using `actions/download-artifact@v4` with `name: evidence-hub-site-preview` and `path: _site` immediately before `actions/upload-pages-artifact@v4` in `.github/workflows/evidence-hub-publish.yml` so the built site produced in `build_validate` is available to the `deploy` job.

### Testing
- Ran `git diff` to verify the workflow change, `python -m py_compile agialpha_evidence_hub/__init__.py` to ensure no import syntax errors, and committed the workflow update; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f558575cc8833398d0f0a5d4cda841)