### PR TITLE
Fix invalid RSI Forge falsification audit workflow YAML

### DIFF
--- a/.github/workflows/rsi-forge-001-falsification-audit.yml
+++ b/.github/workflows/rsi-forge-001-falsification-audit.yml
@@ -1,21 +1,9 @@
-name: RSI Forge 001 Falsification Audit
 name: AGI ALPHA RSI-FORGE-001 / Falsification Audit
 
 on:
   workflow_dispatch:
     inputs:
       cycles:
-        description: "Cycle scope"
-        required: false
-        default: "1"
-permissions:
-  contents: read
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: echo "Bounded falsification audit scaffold for RSI Forge 001"
         description: "Cycles to regenerate for audit"
         required: false
         default: "6"


### PR DESCRIPTION
### Motivation
- The GitHub Actions workflow file `.github/workflows/rsi-forge-001-falsification-audit.yml` failed schema validation due to duplicated top-level keys and misplaced step-level input metadata. 
- The intent is to have a single canonical `workflow_dispatch` input for `cycles` and one audit job that runs the Python-based falsification audit and uploads artifacts.

### Description
- Removed duplicate top-level `name`, `permissions`, and `jobs` blocks and kept a single workflow `name` at the top. 
- Moved the `cycles` input metadata into `on.workflow_dispatch.inputs` and removed stray `description/required/default` fields that had appeared under a step. 
- Preserved the `audit` job which checks out the repository, sets up Python, runs `python -m agialpha_rsi_forge_001 run` and `audit`, and uploads the audit artifact.

### Testing
- Inspected the updated file with `sed -n '1,220p' .github/workflows/rsi-forge-001-falsification-audit.yml` to confirm the new structure, which completed successfully. 
- Displayed the file with `nl -ba .github/workflows/rsi-forge-001-falsification-audit.yml` to verify line-level layout, which completed successfully. 
- Verified repository status with `git status --short` to confirm there were pending changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55a1a8f50833389f6a88c986db455)