### PR TITLE
Fix invalid RSI Forge vNext transfer workflow YAML

### DIFF
--- a/.github/workflows/rsi-forge-001-vnext-transfer.yml
+++ b/.github/workflows/rsi-forge-001-vnext-transfer.yml
@@ -1,21 +1,9 @@
-name: RSI Forge 001 VNext Transfer
 name: AGI ALPHA RSI-FORGE-001 / vNext Transfer
 
 on:
   workflow_dispatch:
     inputs:
       cycles:
-        description: "Cycle scope"
-        required: false
-        default: "1"
-permissions:
-  contents: read
-jobs:
-  transfer:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: echo "VNext transfer scaffold for RSI Forge 001"
         description: "Cycles to regenerate before vNext transfer"
         required: false
         default: "6"


### PR DESCRIPTION
### Motivation
- The GitHub Actions workflow file contained duplicated top-level blocks and misplaced step-level keys which produced an invalid workflow schema.

### Description
- Consolidated the workflow to a single top-level `name`, `on.workflow_dispatch` input `cycles`, `permissions`, and `jobs` in `.github/workflows/rsi-forge-001-vnext-transfer.yml`.
- Removed improperly placed keys (`description`, `required`, `default`) that had been incorrectly nested under a `run` step and ensured the `cycles` default lives under `workflow_dispatch`.
- Preserved the intended `vnext` job flow including checkout, Python setup, the generation/test commands, and artifact upload.

### Testing
- Parsed the updated YAML with Ruby using `YAML.load_file` which returned the expected top-level keys and succeeded.
- Attempted to parse with Python using `import yaml`, but the check failed because `PyYAML` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55bf27c1c83338007cca9dc477fc8)