### PR TITLE
Harden RSI-FORGE-001 safe PR workflow commit step

### DIFF
--- a/.github/workflows/rsi-forge-001-safe-pr.yml
+++ b/.github/workflows/rsi-forge-001-safe-pr.yml
@@ -60,6 +60,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add accepted_capabilities/rsi-forge-001 docs/rsi-forge-001
+          if git diff --cached --quiet; then
+            echo "No safe proposal changes to commit."
+            exit 0
+          fi
           git commit -m "Add RSI-FORGE-001 accepted Evidence Kernel proposal"
           git push --set-upstream origin "$BRANCH"
           gh pr create \


### PR DESCRIPTION
### Motivation
- Prevent the RSI-FORGE-001 workflow from failing when it attempts a `git commit` with no staged changes by exiting cleanly if there is nothing to commit.

### Description
- Add a staged-diff guard to `.github/workflows/rsi-forge-001-safe-pr.yml` that runs `if git diff --cached --quiet; then echo "No safe proposal changes to commit."; exit 0; fi` before the `git commit` step.

### Testing
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/rsi-forge-001-safe-pr.yml')"` which returned successfully; inspected `git diff` to confirm only the intended block was added; and ran `git add` + `git commit` locally which produced a new commit hash, indicating the change applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55f8eaef88333bd60d41cb6bfe976)