### PR TITLE
Add RSI-GOVERNOR-001 helper modules and unit tests

### DIFF
--- a/agialpha_rsi_governor/adversarial.py
+++ b/agialpha_rsi_governor/adversarial.py
@@ -1,0 +1,13 @@
+"""Adversarial evaluation helpers for RSI-GOVERNOR-001."""
+
+from __future__ import annotations
+
+from .evaluator import eval_kernel
+
+
+def evaluate_adversarial_tasks(kernel: dict, tasks: list[dict]) -> list[dict]:
+    """Evaluate candidate kernel against adversarial task fixtures."""
+    return [eval_kernel(kernel, [task]) for task in tasks]
+
+
+__all__ = ["evaluate_adversarial_tasks"]

--- a/agialpha_rsi_governor/baselines.py
+++ b/agialpha_rsi_governor/baselines.py
@@ -1,0 +1,20 @@
+"""Baseline ladder helpers for RSI-GOVERNOR-001."""
+
+from __future__ import annotations
+
+
+def compute_baseline_ladder(b5_score: float, b6_score: float) -> dict:
+    """Return explicit B0..B7 representation with B5/B6 scores."""
+    return {
+        "B0": {"name": "no governance kernel", "score": "not_reported"},
+        "B1": {"name": "static checklist governance", "score": "not_reported"},
+        "B2": {"name": "current simple publisher", "score": "not_reported"},
+        "B3": {"name": "heuristic hub repair", "score": "not_reported"},
+        "B4": {"name": "unstructured self-modification", "score": "not_reported"},
+        "B5": {"name": "incumbent kernel", "score": b5_score},
+        "B6": {"name": "candidate kernel", "score": b6_score},
+        "B7": {"name": "human-governed promoted kernel", "score": "pending"},
+    }
+
+
+__all__ = ["compute_baseline_ladder"]

--- a/agialpha_rsi_governor/candidate_lock.py
+++ b/agialpha_rsi_governor/candidate_lock.py
@@ -1,0 +1,38 @@
+"""Candidate lock helpers for RSI-GOVERNOR-001."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+class CandidateLockError(ValueError):
+    """Raised when required candidate lock artifacts are missing."""
+
+
+def build_candidate_lock_manifest(candidate_dirs: Iterable[Path]) -> dict:
+    """Build deterministic lock manifest for candidate kernel directories."""
+    entries = []
+    for cdir in sorted((Path(p) for p in candidate_dirs), key=lambda p: p.name):
+        policy = cdir / "candidate_kernel.json"
+        patch = cdir / "candidate.patch"
+        missing = [str(p.name) for p in (policy, patch) if not p.exists()]
+        if missing:
+            raise CandidateLockError(f"{cdir}: missing required artifacts: {', '.join(missing)}")
+
+        policy_bytes = policy.read_bytes()
+        patch_bytes = patch.read_bytes()
+        entries.append(
+            {
+                "candidate_id": cdir.name,
+                "policy_sha256": hashlib.sha256(policy_bytes).hexdigest(),
+                "patch_sha256": hashlib.sha256(patch_bytes).hexdigest(),
+            }
+        )
+    root = hashlib.sha256(json.dumps(entries, sort_keys=True).encode("utf-8")).hexdigest()
+    return {"candidates": entries, "lock_hash": root}
+
+
+__all__ = ["CandidateLockError", "build_candidate_lock_manifest"]

--- a/agialpha_rsi_governor/safe_pr.py
+++ b/agialpha_rsi_governor/safe_pr.py
@@ -1,0 +1,28 @@
+"""Safe PR planning helpers for RSI-GOVERNOR-001."""
+
+from __future__ import annotations
+
+from .promotion import MINIMUM_ADVANTAGE_DELTA, promotion_gate
+
+
+def prepare_safe_pr_plan(metrics: dict) -> dict:
+    """Prepare safe-PR decision artifact without creating or merging a PR."""
+    raw_delta = metrics.get("B6_advantage_delta_vs_B5", metrics.get("Governance Compounding Advantage", 0.0))
+    delta = float(raw_delta)
+    eci = str(metrics.get("ECI_level", ""))
+    passes = promotion_gate(delta, eci, minimum_advantage_delta=MINIMUM_ADVANTAGE_DELTA)
+    return {
+        "open_pr": passes,
+        "automerge": False,
+        "promotion_gate": {
+            "pass": passes,
+            "delta": delta,
+            "eci": eci,
+            "minimum_advantage_delta": MINIMUM_ADVANTAGE_DELTA,
+            "minimum_eci_for_promotion": "E3_REPLAYED",
+        },
+        "required_title": "RSI-GOVERNOR-001: propose executable governance-kernel promotion",
+    }
+
+
+__all__ = ["prepare_safe_pr_plan"]

--- a/tests/test_rsi_governor_helpers.py
+++ b/tests/test_rsi_governor_helpers.py
@@ -1,0 +1,53 @@
+import unittest
+
+from agialpha_rsi_governor.adversarial import evaluate_adversarial_tasks
+from agialpha_rsi_governor.safe_pr import prepare_safe_pr_plan
+from agialpha_rsi_governor.candidate_lock import CandidateLockError, build_candidate_lock_manifest
+
+
+class TestRsiGovernorHelpers(unittest.TestCase):
+    def test_adversarial_task_count_is_single_per_fixture(self):
+        kernel = {
+            "scoring_weights": {},
+            "future_work_recommendation_policy": {},
+            "safety_policy": {
+                "raw_secret_leak_count": 0,
+                "external_target_scan_count": 0,
+                "exploit_execution_count": 0,
+                "malware_generation_count": 0,
+                "social_engineering_content_count": 0,
+                "unsafe_automerge_count": 0,
+                "critical_safety_incidents": 0,
+            },
+        }
+        tasks = [{"a": 1, "b": 2}, {"x": 3, "y": 4, "z": 5}]
+        results = evaluate_adversarial_tasks(kernel, tasks)
+        self.assertEqual([r["task_count"] for r in results], [1, 1])
+
+
+    def test_candidate_lock_fails_on_missing_required_artifacts(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as td:
+            candidate = Path(td) / "candidate-001"
+            candidate.mkdir()
+            (candidate / "candidate_kernel.json").write_text("{}", encoding="utf-8")
+            with self.assertRaises(CandidateLockError):
+                build_candidate_lock_manifest([candidate])
+
+
+    def test_prepare_safe_pr_plan_accepts_scoreboard_delta_field(self):
+        plan = prepare_safe_pr_plan({"Governance Compounding Advantage": 0.2, "ECI_level": "E3_REPLAYED"})
+        self.assertTrue(plan["open_pr"])
+        self.assertEqual(plan["promotion_gate"]["delta"], 0.2)
+
+    def test_prepare_safe_pr_plan_uses_boolean_promotion_gate(self):
+        plan = prepare_safe_pr_plan({"B6_advantage_delta_vs_B5": 0.2, "ECI_level": "E3_REPLAYED"})
+        self.assertTrue(plan["open_pr"])
+        self.assertFalse(plan["automerge"])
+        self.assertTrue(plan["promotion_gate"]["pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide reusable helper utilities to support RSI-GOVERNOR-001 workflows including adversarial evaluation, baseline ladder construction, candidate locking, and safe PR planning.
- Ensure deterministic candidate manifests and clear promotion decision logic to reduce manual work during governance evaluations.

### Description
- Add `adversarial.py` with `evaluate_adversarial_tasks(kernel, tasks)` which wraps the existing `eval_kernel` evaluator for adversarial fixtures.
- Add `baselines.py` with `compute_baseline_ladder(b5_score, b6_score)` to produce an explicit B0..B7 baseline representation including provided B5/B6 scores.
- Add `candidate_lock.py` with `build_candidate_lock_manifest(candidate_dirs)` and `CandidateLockError`, which validates required artifacts, computes SHA256 of `candidate_kernel.json` and `candidate.patch`, and returns a deterministic `lock_hash` over entries.
- Add `safe_pr.py` with `prepare_safe_pr_plan(metrics)` which derives promotion decisions using `promotion_gate` and `MINIMUM_ADVANTAGE_DELTA` and produces a safe-PR decision artifact.
- Add unit tests in `tests/test_rsi_governor_helpers.py` covering adversarial task evaluation counts, candidate lock failure on missing artifacts, and `prepare_safe_pr_plan` behavior regarding delta fields and automerge.

### Testing
- Ran the unit tests in `tests/test_rsi_governor_helpers.py` using the project test suite via `unittest` and observed success for all tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f560dc232c8333bf490251248e36d2)