### PR TITLE
Add Strong RSI control room & static RSI-GOVERNOR-001 experiment page

### DIFF
--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -20,6 +20,7 @@ def _load(base):
 
 def build_site(registry='evidence_registry', out='_site'):
     runs,exps,wfs=_load(registry)
+    repo_root = Path(__file__).resolve().parent.parent
     o=Path(out); o.mkdir(parents=True,exist_ok=True)
     for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets','strong-rsi']:
         (o/d).mkdir(exist_ok=True)
@@ -42,7 +43,7 @@ def build_site(registry='evidence_registry', out='_site'):
 
     launch_rows=''.join([f"<tr><td>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>{w.get('gh_command') or 'workflow_dispatch not enabled'}</code></td></tr>" for w in wfs])
     o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
-    strong_rsi_source = Path('strong-rsi/index.html')
+    strong_rsi_source = repo_root / 'strong-rsi' / 'index.html'
     if strong_rsi_source.exists():
         o.joinpath('strong-rsi/index.html').write_text(
             strong_rsi_source.read_text(encoding='utf-8'),
@@ -54,8 +55,8 @@ def build_site(registry='evidence_registry', out='_site'):
         latest=runs_exp[0]
         run_rows=''.join([f"<tr><td>{r['run_id']}</td><td>{r.get('status')}</td><td><a href='{r.get('run_url','#')}'>actions</a></td></tr>" for r in runs_exp])
         ep.joinpath('index.html').write_text(page(exp,f"<div>claim boundary: {html.escape(latest.get('claim_boundary','missing'))}</div><div>latest status: {latest.get('status')}</div><div>safety incidents: {latest.get('metrics',{}).get('safety_incidents','not_reported')}</div><table>{run_rows}</table><a href='/agialpha-first-real-loop/'>Back to hub</a>"))
-    custom_experiment_source = Path('experiments/rsi-governor-001/index.html')
-    if custom_experiment_source.exists():
+    custom_experiment_source = repo_root / 'experiments' / 'rsi-governor-001' / 'index.html'
+    if custom_experiment_source.exists() and 'rsi-governor-001' not in by_exp:
         exp_dir = o / 'experiments' / 'rsi-governor-001'
         exp_dir.mkdir(parents=True, exist_ok=True)
         exp_dir.joinpath('index.html').write_text(

--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -21,7 +21,7 @@ def _load(base):
 def build_site(registry='evidence_registry', out='_site'):
     runs,exps,wfs=_load(registry)
     o=Path(out); o.mkdir(parents=True,exist_ok=True)
-    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets']:
+    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets','strong-rsi']:
         (o/d).mkdir(exist_ok=True)
 
     o.joinpath('.nojekyll').write_text('')
@@ -42,12 +42,26 @@ def build_site(registry='evidence_registry', out='_site'):
 
     launch_rows=''.join([f"<tr><td>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>{w.get('gh_command') or 'workflow_dispatch not enabled'}</code></td></tr>" for w in wfs])
     o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
+    strong_rsi_source = Path('strong-rsi/index.html')
+    if strong_rsi_source.exists():
+        o.joinpath('strong-rsi/index.html').write_text(
+            strong_rsi_source.read_text(encoding='utf-8'),
+            encoding='utf-8',
+        )
 
     for exp,runs_exp in by_exp.items():
         ep=o/'experiments'/exp; (ep/'runs').mkdir(parents=True,exist_ok=True)
         latest=runs_exp[0]
         run_rows=''.join([f"<tr><td>{r['run_id']}</td><td>{r.get('status')}</td><td><a href='{r.get('run_url','#')}'>actions</a></td></tr>" for r in runs_exp])
         ep.joinpath('index.html').write_text(page(exp,f"<div>claim boundary: {html.escape(latest.get('claim_boundary','missing'))}</div><div>latest status: {latest.get('status')}</div><div>safety incidents: {latest.get('metrics',{}).get('safety_incidents','not_reported')}</div><table>{run_rows}</table><a href='/agialpha-first-real-loop/'>Back to hub</a>"))
+    custom_experiment_source = Path('experiments/rsi-governor-001/index.html')
+    if custom_experiment_source.exists():
+        exp_dir = o / 'experiments' / 'rsi-governor-001'
+        exp_dir.mkdir(parents=True, exist_ok=True)
+        exp_dir.joinpath('index.html').write_text(
+            custom_experiment_source.read_text(encoding='utf-8'),
+            encoding='utf-8',
+        )
 
     for r in runs:
         rp=o/'runs'/r['run_id']; rp.mkdir(parents=True,exist_ok=True)

--- a/agialpha_evidence_hub/render.py
+++ b/agialpha_evidence_hub/render.py
@@ -18,6 +18,7 @@ def page(title,body):
       <a href="/agialpha-first-real-loop/workflows/">Workflows</a>
       <a href="/agialpha-first-real-loop/runs/">Runs</a>
       <a href="/agialpha-first-real-loop/launchpad/">Launchpad</a>
+      <a href="/agialpha-first-real-loop/strong-rsi/">Strong RSI</a>
     </nav>
   </header>
   <main class="container">

--- a/experiments/rsi-governor-001/index.html
+++ b/experiments/rsi-governor-001/index.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><meta charset="utf-8"><title>RSI-GOVERNOR-001</title></head><body>
+<h1>RSI-GOVERNOR-001</h1>
+<p>This experiment modifies the executable governance kernel and evaluates B6 against B5 on held-out tasks.</p>
+<div>claim boundary: No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</div>
+<table><tr><th>run_id</th><th>status</th><th>actions</th></tr><tr><td>pending-human-review</td><td>pre_review</td><td>human-gated</td></tr></table>
+<p><strong>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</strong></p>
+<p>See <a href="/agialpha-first-real-loop/strong-rsi/">Strong RSI control room</a>.</p>
+<p><a href="/agialpha-first-real-loop/">Back to hub</a></p>
+</body></html>

--- a/rsi_governor_tasks/vnext_canary/README.md
+++ b/rsi_governor_tasks/vnext_canary/README.md
@@ -1,0 +1,3 @@
+# vNext Canary Tasks
+
+This directory contains post-merge canary tasks for RSI-GOVERNOR-001.

--- a/strong-rsi/index.html
+++ b/strong-rsi/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Strong RSI Control Room</title></head>
+<body>
+<h1>Strong RSI</h1>
+<p><strong>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</strong></p>
+<section><h2>Lifecycle</h2><ol><li>Candidate lock</li><li>Held-out evaluation</li><li>Replay</li><li>Falsification</li><li>Human-review PR gate</li></ol></section>
+<section><h2>Status Cards</h2><ul><li>B5 vs B6 comparison</li><li>Promotion gate</li><li>PR review state</li></ul></section>
+<section><h2>Actions</h2><p><a href="https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/rsi-governor-001-lifecycle-orchestrator.yml">Lifecycle Orchestrator Workflow</a></p></section>
+<section><h2>CLI</h2><pre>gh workflow run rsi-governor-001-lifecycle-orchestrator.yml -f mode=pre_review -f candidate_count=6 -f open_promotion_pr=true</pre></section>
+<p><a href="/agialpha-first-real-loop/experiments/rsi-governor-001/">Experiment page</a></p>
+</body></html>


### PR DESCRIPTION
### Motivation

- Surface a new Strong RSI control room and a dedicated experiment page for `rsi-governor-001` in the static site output. 
- Provide a static control room and experiment landing pages that can be copied into the generated `_site` when present. 
- Add a small canary README for post-merge tasks related to the RSI governor experiment.

### Description

- Updated `build.py` to create an output `strong-rsi` directory and to copy `strong-rsi/index.html` into the site when the source file exists, and to similarly copy `experiments/rsi-governor-001/index.html` into the generated `experiments` output directory when present. 
- Updated `render.py` to add a navigation link to the Strong RSI page (`<a href="/agialpha-first-real-loop/strong-rsi/">Strong RSI</a>`). 
- Added static content files `strong-rsi/index.html` and `experiments/rsi-governor-001/index.html`, and a `rsi_governor_tasks/vnext_canary/README.md` describing post-merge canary tasks.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f574af74e483338945bd603f0ff911)