### PR TITLE
Add Strong RSI control room and RSI-GOVERNOR-001 experiment page to site build

### DIFF
--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -20,8 +20,9 @@ def _load(base):
 
 def build_site(registry='evidence_registry', out='_site'):
     runs,exps,wfs=_load(registry)
+    repo_root = Path(registry).resolve().parent
     o=Path(out); o.mkdir(parents=True,exist_ok=True)
-    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets']:
+    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets','strong-rsi']:
         (o/d).mkdir(exist_ok=True)
 
     o.joinpath('.nojekyll').write_text('')
@@ -42,12 +43,29 @@ def build_site(registry='evidence_registry', out='_site'):
 
     launch_rows=''.join([f"<tr><td>{w.get('name') or w.get('workflow_name') or Path(w.get('workflow_file','')).name}</td><td>{w.get('workflow_file')}</td><td><a href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/{Path(w.get('workflow_file','')).name}'>{w.get('workflow_file')}</a></td><td><code>{w.get('gh_command') or 'workflow_dispatch not enabled'}</code></td></tr>" for w in wfs])
     o.joinpath('launchpad/index.html').write_text(page('Workflow Launchpad', f"<p>Click the button, then click Run workflow on GitHub.</p><table>{launch_rows}</table>"))
+    strong_rsi_source = repo_root / 'strong-rsi' / 'index.html'
+    if strong_rsi_source.exists():
+        o.joinpath('strong-rsi/index.html').write_text(
+            strong_rsi_source.read_text(encoding='utf-8'),
+            encoding='utf-8',
+        )
 
     for exp,runs_exp in by_exp.items():
         ep=o/'experiments'/exp; (ep/'runs').mkdir(parents=True,exist_ok=True)
         latest=runs_exp[0]
         run_rows=''.join([f"<tr><td>{r['run_id']}</td><td>{r.get('status')}</td><td><a href='{r.get('run_url','#')}'>actions</a></td></tr>" for r in runs_exp])
-        ep.joinpath('index.html').write_text(page(exp,f"<div>claim boundary: {html.escape(latest.get('claim_boundary','missing'))}</div><div>latest status: {latest.get('status')}</div><div>safety incidents: {latest.get('metrics',{}).get('safety_incidents','not_reported')}</div><table>{run_rows}</table><a href='/agialpha-first-real-loop/'>Back to hub</a>"))
+        extra = ""
+        if exp == 'rsi-governor-001':
+            extra = "<p><a href='/agialpha-first-real-loop/strong-rsi/'>Open Strong RSI control room</a></p>"
+        ep.joinpath('index.html').write_text(page(exp,f"<div>claim boundary: {html.escape(latest.get('claim_boundary','missing'))}</div><div>latest status: {latest.get('status')}</div><div>safety incidents: {latest.get('metrics',{}).get('safety_incidents','not_reported')}</div><table>{run_rows}</table>{extra}<a href='/agialpha-first-real-loop/'>Back to hub</a>"))
+    custom_experiment_source = repo_root / 'experiments' / 'rsi-governor-001' / 'index.html'
+    if custom_experiment_source.exists() and 'rsi-governor-001' not in by_exp:
+        exp_dir = o / 'experiments' / 'rsi-governor-001'
+        exp_dir.mkdir(parents=True, exist_ok=True)
+        exp_dir.joinpath('index.html').write_text(
+            custom_experiment_source.read_text(encoding='utf-8'),
+            encoding='utf-8',
+        )
 
     for r in runs:
         rp=o/'runs'/r['run_id']; rp.mkdir(parents=True,exist_ok=True)

--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -20,7 +20,7 @@ def _load(base):
 
 def build_site(registry='evidence_registry', out='_site'):
     runs,exps,wfs=_load(registry)
-    repo_root = Path(registry).resolve().parent
+    repo_root = Path(__file__).resolve().parent.parent
     o=Path(out); o.mkdir(parents=True,exist_ok=True)
     for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets','strong-rsi']:
         (o/d).mkdir(exist_ok=True)

--- a/agialpha_evidence_hub/render.py
+++ b/agialpha_evidence_hub/render.py
@@ -18,6 +18,7 @@ def page(title,body):
       <a href="/agialpha-first-real-loop/workflows/">Workflows</a>
       <a href="/agialpha-first-real-loop/runs/">Runs</a>
       <a href="/agialpha-first-real-loop/launchpad/">Launchpad</a>
+      <a href="/agialpha-first-real-loop/strong-rsi/">Strong RSI</a>
     </nav>
   </header>
   <main class="container">

--- a/experiments/rsi-governor-001/index.html
+++ b/experiments/rsi-governor-001/index.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><meta charset="utf-8"><title>RSI-GOVERNOR-001</title></head><body>
+<h1>RSI-GOVERNOR-001</h1>
+<p>This experiment modifies the executable governance kernel and evaluates B6 against B5 on held-out tasks.</p>
+<div>claim boundary: No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</div>
+<table><tr><th>run_id</th><th>status</th><th>actions</th></tr><tr><td>pending-human-review</td><td>pre_review</td><td>human-gated</td></tr></table>
+<p><strong>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</strong></p>
+<p>See <a href="/agialpha-first-real-loop/strong-rsi/">Strong RSI control room</a>.</p>
+<p><a href="/agialpha-first-real-loop/">Back to hub</a></p>
+</body></html>

--- a/rsi_governor_tasks/vnext_canary/README.md
+++ b/rsi_governor_tasks/vnext_canary/README.md
@@ -1,0 +1,3 @@
+# vNext Canary Tasks
+
+This directory contains post-merge canary tasks for RSI-GOVERNOR-001.

--- a/strong-rsi/index.html
+++ b/strong-rsi/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Strong RSI Control Room</title></head>
+<body>
+<h1>Strong RSI</h1>
+<p><strong>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</strong></p>
+<section><h2>Lifecycle</h2><ol><li>Candidate lock</li><li>Held-out evaluation</li><li>Replay</li><li>Falsification</li><li>Human-review PR gate</li></ol></section>
+<section><h2>Status Cards</h2><ul><li>B5 vs B6 comparison</li><li>Promotion gate</li><li>PR review state</li></ul></section>
+<section><h2>Actions</h2><p><a href="https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/rsi-governor-001-lifecycle-orchestrator.yml">Lifecycle Orchestrator Workflow</a></p></section>
+<section><h2>CLI</h2><pre>gh workflow run rsi-governor-001-lifecycle-orchestrator.yml -f mode=pre_review -f candidate_count=6 -f open_promotion_pr=true</pre></section>
+<p><a href="/agialpha-first-real-loop/experiments/rsi-governor-001/">Experiment page</a></p>
+</body></html>


### PR DESCRIPTION
### Motivation

- Expose a new "Strong RSI" control room and a custom experiment page for `rsi-governor-001` in the generated static site so operators can view and launch RSI lifecycle workflows. 

### Description

- Add `repo_root` detection and include `strong-rsi` in the output directory creation list inside `build.py` so the build can emit a `strong-rsi` subpage. 
- Copy `strong-rsi/index.html` from the repository into the generated site if it exists and preserve UTF-8 encoding. 
- Add a special-case link and optional inclusion for the `rsi-governor-001` experiment by injecting an extra link on the experiment listing page and by copying `experiments/rsi-governor-001/index.html` into the site when the experiment isn't present in the runtime data. 
- Add a navigation link for `Strong RSI` in `render.py` and introduce new static content files: `strong-rsi/index.html`, `experiments/rsi-governor-001/index.html`, and `rsi_governor_tasks/vnext_canary/README.md`. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f574af74e483338945bd603f0ff911)