### PR TITLE
Add FoundryPolicy RSI, promotion gates, and metaproductivity helpers (AGI-GA-FOUNDRY-001)

### DIFF
--- a/agialpha_agiga_foundry/foundry_policy_rsi.py
+++ b/agialpha_agiga_foundry/foundry_policy_rsi.py
@@ -1,0 +1,16 @@
+"""FoundryPolicy RSI candidate evaluation helpers."""
+
+from __future__ import annotations
+
+
+def compare_policies(incumbent_score: float, candidate_score: float) -> dict:
+    """Return promotion-safe policy comparison payload."""
+    delta = round(candidate_score - incumbent_score, 6)
+    return {
+        "incumbent_score": incumbent_score,
+        "candidate_score": candidate_score,
+        "FoundryPolicy_advantage_delta": delta,
+        "FoundryPolicy_vnext_beats_incumbent": delta > 0,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+    }

--- a/agialpha_agiga_foundry/metaproductivity.py
+++ b/agialpha_agiga_foundry/metaproductivity.py
@@ -1,0 +1,9 @@
+"""Lineage metaproductivity helpers for AGI-GA Foundry."""
+
+from __future__ import annotations
+
+def lineage_metaproductivity(descendant_solved_niches_enabled_by_archive: int, accepted_parent_capabilities: int):
+    """Compute lineage metaproductivity ratio or return 'unavailable'."""
+    if accepted_parent_capabilities <= 0:
+        return "unavailable"
+    return descendant_solved_niches_enabled_by_archive / accepted_parent_capabilities

--- a/agialpha_agiga_foundry/promotion.py
+++ b/agialpha_agiga_foundry/promotion.py
@@ -1,0 +1,14 @@
+"""Promotion gates for Foundry outputs and policy updates."""
+
+from __future__ import annotations
+
+
+def promotion_gate(*, replay_passed: bool, falsification_passed: bool, evidence_docket_present: bool, human_review: bool) -> dict:
+    """Evaluate non-autonomous promotion constraints."""
+    approved = bool(replay_passed and falsification_passed and evidence_docket_present and human_review)
+    return {
+        "eligible_for_pr": approved,
+        "persisted": False,
+        "autonomous_persistence_allowed": False,
+        "reason": "human_review_required" if not human_review else "ready_for_manual_pr" if approved else "failed_gates",
+    }


### PR DESCRIPTION
### Motivation
- Complete the small but required module surface for AGI-GA-FOUNDRY-001 so the Foundry runtime can compute lineage metaproductivity and enforce non-autonomous, proof-gated policy promotion semantics without fabricating metrics or enabling automatic persistence.

### Description
- Add `metaproductivity.py` with `lineage_metaproductivity` that returns a safe "unavailable" sentinel when the parent-capability denominator is zero, add `foundry_policy_rsi.py` with `compare_policies` that emits a deterministic delta and explicit non-autonomous promotion flags, and add `promotion.py` with `promotion_gate` that requires replay, falsification, an evidence docket, and human review before PR eligibility.

### Testing
- Ran `python -m unittest discover -s tests` and executed the lifecycle and verification commands (`python -m agialpha_agiga_foundry lifecycle --repo-root . --cycles 1 --candidate-niches 16 --evaluate-niches 6 --local-variants-per-niche 3 --out agiga-foundry-runs/test`, `python -m agialpha_agiga_foundry replay --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket`, and `python -m agialpha_agiga_foundry falsification-audit --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket`) and all tests/commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63d2c0878833383e6961340353198)