### PR TITLE
Implement AGI-GA-FOUNDRY-001: α-AGI Sovereign Foundry for proof-gated open-ended evolution

### DIFF
--- a/agialpha_agiga_foundry/foundry_policy_rsi.py
+++ b/agialpha_agiga_foundry/foundry_policy_rsi.py
@@ -1,0 +1,5 @@
+"""FoundryPolicy RSI evaluation facade."""
+
+def foundry_policy_improvement(candidate_score: float, incumbent_score: float) -> float:
+    """Return policy advantage delta for held-out policy tasks."""
+    return candidate_score - incumbent_score

--- a/agialpha_agiga_foundry/metaproductivity.py
+++ b/agialpha_agiga_foundry/metaproductivity.py
@@ -1,0 +1,7 @@
+"""Lineage metaproductivity helpers for AGI-GA Foundry."""
+
+def lineage_metaproductivity(descendant_solved_niches_enabled_by_archive: int, accepted_parent_capabilities: int) -> float:
+    """Compute lineage metaproductivity as descendants solved per accepted parent capability."""
+    if accepted_parent_capabilities <= 0:
+        return 0.0
+    return descendant_solved_niches_enabled_by_archive / accepted_parent_capabilities

--- a/agialpha_agiga_foundry/promotion.py
+++ b/agialpha_agiga_foundry/promotion.py
@@ -1,0 +1,5 @@
+"""Promotion gate utilities for proof-gated persistence."""
+
+def promotion_allowed(*, evidence_docket_present: bool, replay_passed: bool, falsification_passed: bool, human_reviewed: bool) -> bool:
+    """Promotion is allowed only when all proof gates pass and human review exists."""
+    return all([evidence_docket_present, replay_passed, falsification_passed, human_reviewed])

--- a/config/agiga_foundry_policy_baseline.json
+++ b/config/agiga_foundry_policy_baseline.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "agialpha.agiga.foundry_policy.v1",
+  "policy_version": "0.1.0-baseline",
+  "governs": [
+    "insight_detection",
+    "nova_seed_generation",
+    "mark_allocation",
+    "sovereign_formation",
+    "niche_selection",
+    "validator_generation",
+    "local_evolution",
+    "archive_update",
+    "descendant_generation",
+    "promotion"
+  ],
+  "scoring_weights": {},
+  "safety_policy": {},
+  "claim_boundary_policy": {},
+  "promotion_policy": {
+    "autonomous_persistence_allowed": false,
+    "human_review_required": true,
+    "replay_required": true,
+    "falsification_required": true,
+    "heldout_descendant_test_required": true
+  }
+}

--- a/schemas/agiga_mark_allocation.schema.json
+++ b/schemas/agiga_mark_allocation.schema.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "AGIGA MARK Allocation",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://montrealai.github.io/agialpha-first-real-loop/schemas/agiga_mark_allocation.schema.json",
+  "title": "AGI-GA MARK Allocation",
   "type": "object",
   "required": [
     "schema_version",
@@ -17,50 +18,18 @@
     "rejection_reason_if_any"
   ],
   "properties": {
-    "schema_version": {
-      "const": "agialpha.agiga.mark_allocation.v1"
-    },
-    "allocation_id": {
-      "type": "string"
-    },
-    "nova_seed_id": {
-      "type": "string"
-    },
-    "allocated_budget_proxy": {
-      "type": "number"
-    },
-    "review_priority": {
-      "enum": [
-        "low",
-        "medium",
-        "high",
-        "critical"
-      ]
-    },
-    "risk_tier": {
-      "enum": [
-        "low",
-        "medium",
-        "high"
-      ]
-    },
-    "validator_required": {
-      "type": "boolean"
-    },
-    "replay_required": {
-      "type": "boolean"
-    },
-    "falsification_required": {
-      "type": "boolean"
-    },
-    "human_review_required_for_promotion": {
-      "type": "boolean"
-    },
-    "promotion_threshold": {
-      "type": "object"
-    },
-    "rejection_reason_if_any": {
-      "type": "string"
-    }
-  }
+    "schema_version": {"const": "agialpha.agiga.mark_allocation.v1"},
+    "allocation_id": {"type": "string", "minLength": 1},
+    "nova_seed_id": {"type": "string", "minLength": 1},
+    "allocated_budget_proxy": {"type": "number", "minimum": 0},
+    "review_priority": {"type": "string", "enum": ["low", "medium", "high", "critical"]},
+    "risk_tier": {"type": "string", "enum": ["low", "medium", "high"]},
+    "validator_required": {"type": "boolean"},
+    "replay_required": {"type": "boolean"},
+    "falsification_required": {"type": "boolean"},
+    "human_review_required_for_promotion": {"type": "boolean"},
+    "promotion_threshold": {"type": "object"},
+    "rejection_reason_if_any": {"type": "string"}
+  },
+  "additionalProperties": true
 }


### PR DESCRIPTION
### Motivation
- Provide an explicit baseline policy and enforceable allocation schema to make held-out FoundryPolicy comparisons and proof-gated promotion auditable and reproducible. 
- Expose compact helpers for lineage metaproductivity and FoundryPolicy RSI so held-out policy evaluation and metric computation have stable, testable interfaces. 
- Make promotion semantics explicit so persistence of capabilities/policies is gated by Evidence Docket presence, replay, falsification, and human review. 

### Description
- Added `config/agiga_foundry_policy_baseline.json` as an explicit incumbent FoundryPolicy baseline for K5-vs-K6/ incumbent-vs-candidate comparisons. 
- Added `schemas/agiga_mark_allocation.schema.json` to formalize the MARK allocation object (required fields, budget proxy, review priority, risk tier, replay/falsification/human-review gates). 
- Added three helper modules: `agialpha_agiga_foundry/metaproductivity.py` (lineage metaproductivity computation), `agialpha_agiga_foundry/foundry_policy_rsi.py` (policy improvement delta helper), and `agialpha_agiga_foundry/promotion.py` (proof-gated promotion predicate requiring Evidence Docket + replay + falsification + human review). 

### Testing
- Ran unit tests with `python -m unittest discover -s tests -p 'test_agiga_foundry*.py'`, which executed 21 tests and all passed. 
- Performed a quick lifecycle run with `python -m agialpha_agiga_foundry lifecycle --repo-root . --cycles 1 --candidate-niches 16 --evaluate-niches 6 --local-variants-per-niche 3 --out agiga-foundry-runs/test`, which completed successfully. 
- Executed replay and falsification audit with `python -m agialpha_agiga_foundry replay --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket` and `python -m agialpha_agiga_foundry falsification-audit --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63d2c0878833383e6961340353198)