### PR TITLE
Implement AGI Alpha SecureRails: CYBER-GA-SOVEREIGN-001 proof-bound defensive remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ RSI-GOVERNOR-001 tests whether AGI ALPHA can modify the mechanism that governs f
 AGI-GA Foundry is a proof-gated open-ended directed evolution engine for sovereign work capabilities. Public page: `agiga-foundry/index.html`.
 
 
+
+## AGI Alpha SecureRails
+
+AGI Alpha SecureRails is the AI-agent security governance platform for proof-bound defensive remediation. It secures autonomous software work by converting agent actions, workflow changes, findings, and remediation proposals into replayable ProofBundles, Evidence Dockets, redacted safety ledgers, safe PRs, and reusable defensive capability — with human-governed promotion and no autonomous claim escalation. See `/securerails/`.
+
 ## α-AGI Protocol Cybersecurity Sovereign
 
 Defensive, proof-gated cybersecurity sovereign for repo-owned work. See `/cybersecurity-sovereign/`.

--- a/README_CYBER_GA_SOVEREIGN.md
+++ b/README_CYBER_GA_SOVEREIGN.md
@@ -1,3 +1,21 @@
 # CYBER-GA-SOVEREIGN-001
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+CYBER-GA-SOVEREIGN-001 is AGI ALPHA's bounded defensive security organ for repo-owned, sandbox-only remediation governance.
+
+## Protocol chain
+α-AGI Insight → Nova-Seeds → MARK → Cybersecurity Sovereigns → AGI Jobs → ProofBundles → Evidence Dockets → CyberSecurityCapabilityArchive → Descendant Defensive Tasks → CyberSovereignPolicy-vNext.
+
+## What is implemented
+- SecurityOpportunityIntermediates for defensive opportunity discovery.
+- Defensive Nova-Seeds for task/validator/replay/evidence/runbook/policy variants.
+- MARK allocations with bounded capacity, budget proxy, and review priority.
+- Cybersecurity Sovereign formation and defensive niche generation.
+- Co-design + local defensive evolution for validator/safe patch/capability variants.
+- QD archive, lineage, and cybersecurity capability archive updates.
+- Lock-then-reveal held-out descendant and policy RSI evaluation.
+- Replay + falsification audits + safe PR/policy PR gating (never auto-merge).
+
+## Claim boundary
+This system does not claim achieved AGI, achieved ASI, empirical SOTA cybersecurity, offensive cyber capability, real-world security certification, guaranteed security, safe autonomy, or civilization-scale capability.

--- a/README_SECURERAILS.md
+++ b/README_SECURERAILS.md
@@ -25,13 +25,7 @@ Use workflow dispatch for:
 
 ## Run with GitHub CLI
 ```bash
-gh workflow run cyber-ga-sovereign-001-lifecycle.yml \
-  -f cycles=3 \
-  -f candidate_niches=64 \
-  -f evaluate_niches=24 \
-  -f local_variants_per_niche=5 \
-  -f publish_securerails_tab=true \
-  -f publish_cyber_sovereign_tab=true \
-  -f open_safe_pr_if_passed=false \
-  -f open_policy_pr_if_passed=false
+gh workflow run cyber-ga-sovereign-001-lifecycle.yml
 ```
+
+Current repository workflow uses fixed lifecycle defaults in workflow code (cycles=3, candidate_niches=64, evaluate_niches=24, local_variants_per_niche=5).

--- a/README_SECURERAILS.md
+++ b/README_SECURERAILS.md
@@ -1,0 +1,37 @@
+# AGI Alpha SecureRails
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+AGI Alpha SecureRails is the AI-agent security governance platform for proof-bound defensive remediation. It secures autonomous software work by converting agent actions, workflow changes, findings, and remediation proposals into replayable ProofBundles, Evidence Dockets, redacted safety ledgers, safe PRs, and reusable defensive capability — with human-governed promotion and no autonomous claim escalation.
+
+## Why this exists
+AI-agent work must be safe to review, safe to replay, and safe to remediate before persistence. SecureRails focuses on bounded, repo-owned, defensive governance rather than offensive activity or autonomous claim promotion.
+
+## Core flow
+Finding → Validator → ProofBundle → Evidence Docket → Safety Ledger → Safe PR → Human Review → Capability Archive → vNext Defensive Task.
+
+## Hard boundaries
+This system does not claim achieved AGI, achieved ASI, empirical SOTA cybersecurity, offensive cyber capability, real-world security certification, guaranteed security, safe autonomy, or civilization-scale capability.
+
+## Run from GitHub UI
+Use workflow dispatch for:
+- `cyber-ga-sovereign-001-lifecycle.yml`
+- `cyber-ga-sovereign-001-replay.yml`
+- `cyber-ga-sovereign-001-falsification-audit.yml`
+- `cyber-ga-sovereign-001-safe-pr.yml`
+- `cyber-ga-sovereign-001-policy-pr.yml`
+- `cyber-ga-sovereign-001-delayed-outcome.yml`
+- `cyber-ga-sovereign-001-vnext.yml`
+
+## Run with GitHub CLI
+```bash
+gh workflow run cyber-ga-sovereign-001-lifecycle.yml \
+  -f cycles=3 \
+  -f candidate_niches=64 \
+  -f evaluate_niches=24 \
+  -f local_variants_per_niche=5 \
+  -f publish_securerails_tab=true \
+  -f publish_cyber_sovereign_tab=true \
+  -f open_safe_pr_if_passed=false \
+  -f open_policy_pr_if_passed=false
+```

--- a/docs/securerails/index.html
+++ b/docs/securerails/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AGI Alpha SecureRails</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem;line-height:1.5;color:#0f172a}
+    .panel{background:#f8fafc;border:1px solid #cbd5e1;border-radius:12px;padding:1rem;margin:1rem 0}
+    code{background:#e2e8f0;padding:.1rem .3rem;border-radius:6px}
+  </style>
+</head>
+<body>
+  <h1>AGI Alpha SecureRails</h1>
+  <p><strong>AI-agent security governance for proof-bound defensive remediation.</strong></p>
+  <div class="panel">
+    No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+  </div>
+  <p>SecureRails secures autonomous software work by converting findings and remediation proposals into replayable ProofBundles, Evidence Dockets, redacted safety ledgers, safe PRs, and reusable defensive capability.</p>
+  <p>Technical dashboard: <a href="/agialpha-first-real-loop/cybersecurity-sovereign/">/cybersecurity-sovereign/</a></p>
+  <p>Experiment page: <a href="/agialpha-first-real-loop/experiments/cyber-ga-sovereign-001/">/experiments/cyber-ga-sovereign-001/</a></p>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide operator-facing documentation and explicit claim/safety boundaries for the CYBER-GA-SOVEREIGN-001 SecureRails product so repo-owned defensive work is proof-bound, replayable, and human-promoted. 
- Surface the α-AGI Insight → Nova-Seeds → MARK → Cybersecurity Sovereigns lifecycle and operator runflows on the public site and in repo documentation. 
- Ensure clear non-claim language and workflow commands so automated generation cannot be promoted without Evidence Docket, replay, falsification, and human review.

### Description
- Add `README_SECURERAILS.md` containing SecureRails positioning, core flow, hard claim boundaries, and operator run instructions (UI + CLI). 
- Expand `README_CYBER_GA_SOVEREIGN.md` to document the protocol chain, implemented components (Insight, Nova-Seeds, MARK, sovereigns, co-design, lock-then-reveal, replay, falsification), and the explicit claim boundary. 
- Update root `README.md` to include an `AGI Alpha SecureRails` section linking to `/securerails/` while preserving the Cybersecurity Sovereign section and global non-claim language. 

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests`, which completed successfully (140 tests, OK). 
- Exercised the quick lifecycle run with `python -m agialpha_cyber_ga_sovereign lifecycle --repo-root . --cycles 1 --candidate-niches 16 --evaluate-niches 6 --local-variants-per-niche 3 --out cyber-ga-sovereign-runs/test`, which executed without error. 
- Ran replay and falsification audit commands `python -m agialpha_cyber_ga_sovereign replay --docket cyber-ga-sovereign-runs/test/cyber-ga-sovereign-evidence-docket` and `python -m agialpha_cyber_ga_sovereign falsification-audit --docket cyber-ga-sovereign-runs/test/cyber-ga-sovereign-evidence-docket`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66a9db1b883339e260e9bf6ad15f1)