### PR TITLE
Add SecureRails compliance guard workflow and checks

### DIFF
--- a/.github/workflows/secure-rails-compliance-guard.yml
+++ b/.github/workflows/secure-rails-compliance-guard.yml
@@ -1,0 +1,26 @@
+name: SecureRails Compliance Guard
+
+on:
+  pull_request:
+    paths:
+      - 'docs/secure-rails/**'
+      - 'scripts/**'
+      - '.github/workflows/secure-rails-compliance-guard.yml'
+  workflow_dispatch:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Claim boundary check
+        run: python scripts/secure_rails_claim_boundary_check.py .
+      - name: Safety ledger check
+        run: python scripts/secure_rails_claim_boundary_check.py . --check safety-ledger
+      - name: No auto-merge check
+        run: python scripts/secure_rails_claim_boundary_check.py . --check no-auto-merge
+      - name: Default use-case triage check
+        run: python scripts/secure_rails_claim_boundary_check.py . --check default-use-case-triage

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -131,3 +131,5 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 | `agiga-foundry-001-foundry-kernel-safe-pr.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `agiga-foundry-001-policy-pr.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `agiga-foundry-001-safe-policy-pr.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
+
+| `secure-rails-compliance-guard.yml` | SecureRails guard checks for claim boundary, safety ledger, no auto-merge, and default use-case triage. | no |

--- a/scripts/secure_rails_claim_boundary_check.py
+++ b/scripts/secure_rails_claim_boundary_check.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Checks SecureRails docs for core guardrail statements."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+CHECKS = {
+    "claim-boundary": "claim boundary",
+    "safety-ledger": "safety ledger",
+    "no-auto-merge": "no auto-merge",
+    "default-use-case-triage": "default use-case triage",
+}
+
+
+def scan_text(root: Path) -> str:
+    docs_dir = root / "docs" / "secure-rails"
+    if not docs_dir.exists():
+        return ""
+    parts: list[str] = []
+    for p in sorted(docs_dir.rglob("*.md")):
+        parts.append(p.read_text(encoding="utf-8", errors="ignore").lower())
+    return "\n".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repo_root", nargs="?", default=".")
+    parser.add_argument("--check", default="claim-boundary", choices=sorted(CHECKS))
+    args = parser.parse_args()
+
+    root = Path(args.repo_root).resolve()
+    haystack = scan_text(root)
+    needle = CHECKS[args.check]
+
+    if needle not in haystack:
+        print(f"missing required phrase for {args.check!r}: {needle!r}", file=sys.stderr)
+        return 1
+
+    print(f"ok: found {needle!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Fix CI failures where a SecureRails guard workflow was undocumented and its enforcement script was missing, causing `audit-workflows` and tests to fail.
- Enforce SecureRails guardrails (claim boundary, safety ledger, no auto-merge, default-use-case triage) against `docs/secure-rails/*.md` on PRs.

### Description
- Add `.github/workflows/secure-rails-compliance-guard.yml` that triggers on `pull_request` (and `workflow_dispatch`) and runs the four guard checks.
- Add `scripts/secure_rails_claim_boundary_check.py` that scans `docs/secure-rails/*.md` for required phrases and supports `--check` options for each guard.
- Update `docs/WORKFLOW_CATALOG.md` to document `secure-rails-compliance-guard.yml` so docs audits map to the workflow files.
- The workflow invokes the script via `python scripts/secure_rails_claim_boundary_check.py .` and uses `--check` flags for the other checks.

### Testing
- Ran `python -m agialpha_docs audit-workflows --repo-root .` and it reported no undocumented or missing workflow files, indicating the catalog update succeeded.
- Ran `python -m unittest discover -s tests` which executed the test suite (140 tests) and completed with `OK`.
- Both automated checks completed successfully (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6bac46b90833398707093f4ddca97)