### PR TITLE
docs: improve README clarity and add non-technical onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
 # AGIAlpha First Real Loop
 
-A research-oriented monorepo for deterministic, test-first AGIAlpha subsystems, including:
+A research-oriented monorepo for deterministic, test-first AGIAlpha subsystems.
 
-- **AGIGA Foundry** lifecycle orchestration and evidence generation.
-- **Cyber GA Sovereign** safety/evaluation artifacts.
-- **RSI Governor** checks for overclaim boundaries, lifecycle controls, and run integrity.
-- **Evidence Hub/Registry** static artifacts and machine-readable run outputs.
+If you're non-technical, start with **"5-minute quick check"** below. It is safe and read-only.
 
-## Quickstart
+## What this repository does (plain English)
+
+This project is a toolkit for running repeatable AI research workflows with strict safety and evidence rules:
+
+- It generates candidate ideas/workflows.
+- It evaluates those candidates against held-out tasks.
+- It records results in structured "Evidence Dockets."
+- It prevents unsupported capability claims.
+
+In short: **we separate what the system can *show* from what anyone is allowed to *claim*.**
+
+## 5-minute quick check (non-technical)
+
+> Goal: confirm your local copy is healthy.
+
+1. Open a terminal in this folder.
+2. Run the commands below exactly.
+3. If you see `passed` at the end, your copy is working.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip pytest
+pytest -q
+```
+
+## Quickstart (technical)
 
 ### 1) Create a virtual environment
 
@@ -31,6 +54,15 @@ python -m agialpha_seed_runner --help
 python -m omega_aegis_001 --help
 ```
 
+## Common issues and fixes
+
+- **"command not found: python"**
+  - Try `python3` instead of `python`.
+- **Permission errors inside virtual environment**
+  - Delete `.venv` and recreate it.
+- **A test fails unexpectedly**
+  - Re-run once with `pytest -q`.
+  - If it still fails, include the failing test name and full output in your issue.
 
 ## Quick links
 
@@ -38,6 +70,7 @@ python -m omega_aegis_001 --help
 - [Workflow launchpad](WORKFLOW_LAUNCHPAD.md)
 - [Evidence docket standard](EVIDENCE_DOCKET_STANDARD.md)
 - [AGIGA Foundry README](README_AGIGA_FOUNDRY.md)
+- [RSI Governor README](README_RSI_GOVERNOR.md)
 
 ## How to run from GitHub UI
 
@@ -48,14 +81,7 @@ If you prefer not to run commands locally:
 3. Inspect artifacts and logs for validation outputs (tests, docs audits, and evidence checks).
 4. Use repository scripts documented in `scripts/README_UPLOAD_WITH_GITHUB_WEB_UI.md` when preparing web-only updates.
 
-## Experiment families
-
-- **Foundry lifecycle experiments**: orchestration, generation, and promotion in `agialpha_agiga_foundry/`.
-- **Safety and sovereign evaluations**: policy, held-out, and falsification validations.
-- **Benchmark and gauntlet tracks**: repeatable benchmark execution and scoring.
-- **Evidence registry workflows**: inventory and provenance updates in `evidence_registry/`.
-
-## Repository Guide
+## Repository guide
 
 - `agialpha_agiga_foundry/` – core foundry modules and CLI.
 - `agialpha_benchmark_gauntlet/` – benchmark harness.
@@ -64,14 +90,14 @@ If you prefer not to run commands locally:
 - `evidence_registry/` – canonical JSON registries.
 - `scripts/` – helper and policy-check scripts.
 
-## Engineering Practices
+## Engineering practices
 
 - Keep claims conservative and evidence-linked.
 - Add/adjust tests in `tests/` with every behavior change.
 - Prefer deterministic outputs and schema-validated artifacts.
 - Use relative documentation links and keep README files scoped to their subsystem.
 
-## Documentation Index
+## Documentation index
 
 - `CONTRIBUTING.md`
 - `EVIDENCE_DOCKET_STANDARD.md`

--- a/README.md
+++ b/README.md
@@ -64,6 +64,42 @@ python -m omega_aegis_001 --help
   - Re-run once with `pytest -q`.
   - If it still fails, include the failing test name and full output in your issue.
 
+
+## SecureRails
+
+SecureRails is AGI ALPHA’s AI-agent security governance and proof-bound defensive remediation layer.
+
+It makes AI-agent work safe to review, safe to replay, and safe to remediate by converting agent actions, workflow changes, findings, and remediation proposals into:
+
+- ProofBundles
+- Evidence Dockets
+- redacted safety ledgers
+- safe PR proposals
+- validator reports
+- reusable defensive capability
+- human-reviewed promotion records
+
+SecureRails is designed as repo-owned defensive evidence infrastructure. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+
+### SecureRails quick links
+
+- [SecureRails user guide](docs/secure-rails/README.md)
+- [SecureRails public docs page](docs/secure-rails/index.md)
+- [Product boundary](docs/secure-rails/product-boundary.md)
+- [EU AI Act positioning](docs/secure-rails/eu-ai-act-positioning.md)
+- [Foreseeable misuse and excluded uses](docs/secure-rails/foreseeable-misuse-and-excluded-uses.md)
+- [Security and safety boundary](docs/secure-rails/security-safety-boundary.md)
+- [Claims and marketing guardrails](docs/secure-rails/claims-and-marketing-guardrails.md)
+- [Templates](docs/secure-rails/templates/README.md)
+
+### SecureRails compliance guard
+
+The repository includes a SecureRails compliance guard workflow:
+
+```text
+.github/workflows/secure-rails-compliance-guard.yml
+```
+
 ## Quick links
 
 - [Contributing guide](CONTRIBUTING.md)
@@ -80,6 +116,14 @@ If you prefer not to run commands locally:
 2. Select a workflow run relevant to your branch or pull request.
 3. Inspect artifacts and logs for validation outputs (tests, docs audits, and evidence checks).
 4. Use repository scripts documented in `scripts/README_UPLOAD_WITH_GITHUB_WEB_UI.md` when preparing web-only updates.
+
+
+## Experiment families
+
+- **Foundry lifecycle experiments**: orchestration, generation, and promotion in `agialpha_agiga_foundry/`.
+- **Safety and sovereign evaluations**: policy, held-out, and falsification validations.
+- **Benchmark and gauntlet tracks**: repeatable benchmark execution and scoring.
+- **Evidence registry workflows**: inventory and provenance updates in `evidence_registry/`.
 
 ## Repository guide
 

--- a/README_AGIGA_FOUNDRY.md
+++ b/README_AGIGA_FOUNDRY.md
@@ -1,12 +1,56 @@
-# AGI-GA-FOUNDRY-001
+# AGIGA Foundry
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
 
-AGI-GA Foundry implements global opportunity generation, co-design, local evolution, proof gates, archives, and descendant generation for proof-bound work niches.
+## What this is (plain English)
 
-Includes OpportunityIntermediates, validators, Evidence Dockets, QD archive, CapabilityArchive, replay, falsification, and workflow commands.
+AGIGA Foundry is a controlled pipeline that:
 
-Run:
-- `python -m agialpha_agiga_foundry lifecycle --repo-root . --cycles 1 --candidate-niches 16 --evaluate-niches 6 --local-variants-per-niche 3 --out agiga-foundry-runs/test`
-- `python -m agialpha_agiga_foundry replay --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket`
-- `python -m agialpha_agiga_foundry falsification-audit --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket`
+1. Generates candidate opportunities.
+2. Evaluates them with reproducible tasks.
+3. Stores artifacts and scores in an Evidence Docket.
+4. Requires explicit proof gates before any promotion decision.
+
+This design reduces overclaim risk and keeps results auditable.
+
+## Who should use this
+
+- **Researchers/engineers**: run lifecycle and replay workflows.
+- **Reviewers/governance**: inspect docket artifacts and falsification reports.
+- **Non-technical stakeholders**: verify that claims are tied to concrete evidence.
+
+## Typical commands
+
+```bash
+python -m agialpha_agiga_foundry lifecycle \
+  --repo-root . \
+  --cycles 1 \
+  --candidate-niches 16 \
+  --evaluate-niches 6 \
+  --local-variants-per-niche 3 \
+  --out agiga-foundry-runs/test
+
+python -m agialpha_agiga_foundry replay \
+  --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket
+
+python -m agialpha_agiga_foundry falsification-audit \
+  --docket agiga-foundry-runs/test/agiga-foundry-evidence-docket
+```
+
+## Expected outputs
+
+After `lifecycle`, expect:
+
+- candidate/kernel artifacts,
+- evaluation results,
+- promotion dossier,
+- replay/falsification audit outputs,
+- summary score tables.
+
+If these are missing, treat the run as incomplete.
+
+## Safety and claims policy
+
+- Do **not** claim SOTA or capability uplift without a complete Evidence Docket.
+- Do **not** skip held-out or falsification stages.
+- Preserve run manifests for reproducibility and audit traceability.

--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -1,0 +1,32 @@
+# SecureRails User Guide
+
+SecureRails is AGI ALPHA's security governance and proof-bound defensive remediation layer for AI-agent workflows.
+
+## What SecureRails does
+
+SecureRails turns agent actions and remediation work into reviewable evidence, including:
+
+- ProofBundles
+- Evidence Dockets
+- Redacted safety ledgers
+- Safe PR proposals
+- Validator reports
+- Reusable defensive capability
+- Human-reviewed promotion records
+
+## Who this is for
+
+- Operators running AI-agent workflows
+- Security reviewers
+- Governance/compliance reviewers
+
+## Start here
+
+1. Read the product boundary.
+2. Review excluded uses.
+3. Use templates to produce structured artifacts.
+
+## Templates
+
+- `templates/safety-ledger-example.json`
+- `templates/deployment-intake-example.json`

--- a/docs/secure-rails/claims-and-marketing-guardrails.md
+++ b/docs/secure-rails/claims-and-marketing-guardrails.md
@@ -1,0 +1,5 @@
+# Claims and Marketing Guardrails
+
+- Do not claim autonomous certification.
+- Do not claim capabilities beyond reproducible evidence.
+- Keep external claims aligned to Evidence Dockets and validator outputs.

--- a/docs/secure-rails/eu-ai-act-positioning.md
+++ b/docs/secure-rails/eu-ai-act-positioning.md
@@ -1,0 +1,5 @@
+# SecureRails EU AI Act Positioning
+
+SecureRails is positioned as governance, evidence, and defensive remediation infrastructure.
+
+This documentation supports internal policy mapping and review preparation; it is not legal advice.

--- a/docs/secure-rails/foreseeable-misuse-and-excluded-uses.md
+++ b/docs/secure-rails/foreseeable-misuse-and-excluded-uses.md
@@ -1,0 +1,13 @@
+# Foreseeable Misuse and Excluded Uses
+
+## Foreseeable misuse
+
+- Treating generated evidence as autonomous certification.
+- Using outputs as approval for offensive cyber actions.
+- Marketing claims that exceed documented evidence.
+
+## Excluded uses
+
+- Offensive cybersecurity operations.
+- Autonomous high-risk decisions without human review.
+- Any use that bypasses governance and safety controls.

--- a/docs/secure-rails/index.md
+++ b/docs/secure-rails/index.md
@@ -1,0 +1,13 @@
+# SecureRails Documentation
+
+Welcome to the SecureRails public docs page.
+
+Use this index to navigate core policy and safety documents for defensive, proof-bound AI-agent governance.
+
+- [User guide](README.md)
+- [Product boundary](product-boundary.md)
+- [EU AI Act positioning](eu-ai-act-positioning.md)
+- [Foreseeable misuse and excluded uses](foreseeable-misuse-and-excluded-uses.md)
+- [Security and safety boundary](security-safety-boundary.md)
+- [Claims and marketing guardrails](claims-and-marketing-guardrails.md)
+- [Templates](templates/README.md)

--- a/docs/secure-rails/product-boundary.md
+++ b/docs/secure-rails/product-boundary.md
@@ -1,0 +1,11 @@
+# SecureRails Product Boundary
+
+SecureRails is repo-owned defensive evidence infrastructure for AI-agent governance and remediation.
+
+It is **not**:
+
+- autonomous cybersecurity assurance or attestation,
+- offensive cyber tooling,
+- a high-risk decision system by intended purpose,
+- a GPAI model provider by default,
+- an investment product.

--- a/docs/secure-rails/security-safety-boundary.md
+++ b/docs/secure-rails/security-safety-boundary.md
@@ -1,0 +1,5 @@
+# Security and Safety Boundary
+
+SecureRails provides defensive governance artifacts and review support.
+
+Security and safety decisions must remain human-reviewed, policy-bound, and evidence-backed.

--- a/docs/secure-rails/templates/README.md
+++ b/docs/secure-rails/templates/README.md
@@ -1,0 +1,6 @@
+# SecureRails Templates
+
+This folder contains reusable examples for producing structured SecureRails artifacts.
+
+- `safety-ledger-example.json`
+- `deployment-intake-example.json`


### PR DESCRIPTION
### Motivation

- Make the project more approachable for non-technical users by providing a safe, read-only "5-minute quick check" and plain-English overview. 
- Reduce onboarding friction for engineers and reviewers by clarifying typical workflows, expected outputs, and where to find subsystem docs. 
- Emphasize evidence-first safety and claims policy so reviewers and governance can easily verify that promotions require complete Evidence Dockets. 

### Description

- Rewrote the top-level `README.md` to include a plain-English project overview, a non-technical `5-minute quick check`, common troubleshooting, and clearer navigation to subsystem docs. 
- Added a short technical Quickstart with `python -m venv .venv`, `pytest -q`, and example entry-point commands for quick inspection. 
- Expanded `README_AGIGA_FOUNDRY.md` with audience guidance, typical commands (`python -m agialpha_agiga_foundry lifecycle`, `replay`, `falsification-audit`), expected outputs, and an explicit safety/claims policy section. 
- This changeset is documentation-only and does not modify runtime code paths or behavior. 

### Testing

- Ran the full test suite with `pytest -q`, which completed successfully (`148 passed`).
- Re-ran `pytest -q` after documentation updates to confirm no regressions (`148 passed`).
- No automated code tests failed and no behavior changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c2711b748333be3a916dc3caf432)