### PR TITLE
docs: add SecureRails user READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ It makes AI-agent work safe to review, safe to replay, and safe to remediate by 
 - reusable defensive capability
 - human-reviewed promotion records
 
-SecureRails is designed as repo-owned defensive evidence infrastructure. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+SecureRails is designed as repo-owned defensive evidence infrastructure. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 
 ### SecureRails quick links
 
@@ -99,6 +99,27 @@ The repository includes a SecureRails compliance guard workflow:
 ```text
 .github/workflows/secure-rails-compliance-guard.yml
 ```
+
+It enforces:
+
+* claim-boundary checks
+* no-auto-merge posture
+* AI Act use-case triage
+* safety ledger validation
+* foreseeable misuse controls
+
+Run local checks with:
+
+```bash
+python scripts/secure_rails_claim_boundary_check.py .
+python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+python scripts/secure_rails_no_automerge_check.py .
+python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
+```
+
+SecureRails doctrine:
+
+> No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
 
 ## Quick links
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ It makes AI-agent work safe to review, safe to replay, and safe to remediate by 
 - reusable defensive capability
 - human-reviewed promotion records
 
-SecureRails is designed as repo-owned defensive evidence infrastructure. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+SecureRails is designed as repo-owned defensive evidence infrastructure. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 
 ### SecureRails quick links
 

--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -37,7 +37,7 @@ SecureRails is:
 
 SecureRails is not:
 
-* autonomous cybersecurity certification
+* autonomous cybersecurity assurance or attestation
 * offensive cybersecurity tooling
 * external target scanning
 * exploit execution
@@ -141,7 +141,7 @@ SecureRails must not be used for:
 * social engineering
 * autonomous production remediation
 * autonomous merge
-* cybersecurity certification claims
+* cybersecurity assurance or attestation claims
 * guaranteed security claims
 * investment or token-return claims
 
@@ -185,7 +185,7 @@ Do not say:
 ```text
 SecureRails is EU AI Act exempt.
 SecureRails is legally approved worldwide.
-SecureRails certifies security.
+SecureRails provides formal security attestation.
 SecureRails guarantees security.
 SecureRails autonomously remediates production systems.
 ```
@@ -201,21 +201,11 @@ SecureRails is designed as AI-agent security governance and proof-bound defensiv
 ### Public docs
 
 * [Product boundary](product-boundary.md)
-* [AI-agent security governance](ai-agent-security-governance.md)
 * [EU AI Act positioning](eu-ai-act-positioning.md)
-* [Annex III triage](eu-ai-act-annex-iii-triage.md)
 * [Foreseeable misuse and excluded uses](foreseeable-misuse-and-excluded-uses.md)
-* [No HR / worker evaluation policy](no-hr-worker-evaluation-policy.md)
-* [Critical infrastructure safety-component boundary](critical-infrastructure-safety-component-boundary.md)
-* [Profiling and person-data boundary](profiling-and-person-data-boundary.md)
-* [GPAI dependency boundary](gpai-dependency-boundary.md)
 * [Security and safety boundary](security-safety-boundary.md)
 * [Claims and marketing guardrails](claims-and-marketing-guardrails.md)
-* [Customer deployment playbook](customer-deployment-playbook.md)
-* [Regulator audit readiness](regulator-audit-readiness.md)
-* [Material modification and re-screening](material-modification-and-rescreening.md)
-* [Token utility policy](token-utility-policy.md)
-* [Compliance FAQ](compliance-faq.md)
+* [SecureRails index](index.md)
 
 ### Templates
 
@@ -259,7 +249,7 @@ It enforces:
 
 * no AGI / ASI overclaims
 * no empirical SOTA claims without evidence
-* no cybersecurity certification claims
+* no cybersecurity assurance or attestation claims
 * no guaranteed security claims
 * no offensive cyber posture
 * no autonomous decision-making posture
@@ -371,4 +361,4 @@ This is an enforcement layer, not a certification claim.
 
 ## Final boundary
 
-SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.

--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -1,32 +1,374 @@
 # SecureRails User Guide
 
-SecureRails is AGI ALPHA's security governance and proof-bound defensive remediation layer for AI-agent workflows.
+SecureRails is AGI ALPHA’s AI-agent security governance and proof-bound defensive remediation layer.
 
-## What SecureRails does
+It secures the rails for autonomous software work by converting agent actions, workflow changes, findings, and remediation proposals into replayable ProofBundles, Evidence Dockets, redacted safety ledgers, safe PR proposals, validator reports, and reusable defensive capability.
 
-SecureRails turns agent actions and remediation work into reviewable evidence, including:
+SecureRails makes AI-agent work:
 
-- ProofBundles
-- Evidence Dockets
-- Redacted safety ledgers
-- Safe PR proposals
-- Validator reports
-- Reusable defensive capability
-- Human-reviewed promotion records
+```text
+safe to review
+safe to replay
+safe to reject
+safe to remediate
+safe to archive
+safe to govern
+```
+
+## One-sentence positioning
+
+SecureRails is AI-agent security governance and proof-bound defensive remediation.
+
+## What SecureRails is
+
+SecureRails is:
+
+* AI-agent security governance
+* proof-bound defensive remediation
+* repo-owned defensive evidence infrastructure
+* human-reviewed remediation support
+* claim-boundary enforcement
+* compliance-as-code for agentic software work
+* a ProofBundle and Evidence Docket production layer
+* a safety ledger and validation layer
+* a reusable defensive capability archive
+
+## What SecureRails is not
+
+SecureRails is not:
+
+* autonomous cybersecurity certification
+* offensive cybersecurity tooling
+* external target scanning
+* exploit execution
+* malware generation
+* social engineering
+* a high-risk AI system by intended purpose
+* an autonomous decision-making system
+* a GPAI model provider by default
+* designed for HR or worker evaluation
+* designed for profiling natural persons
+* designed for automated decisions about natural persons
+* designed as a safety component of critical infrastructure
+* an investment product
+
+All SecureRails outputs are advisory and require independent human validation before action.
+
+## The SecureRails loop
+
+```text
+Agentic work event
+→ ProofBundle
+→ Evidence Docket
+→ validator report
+→ redacted safety ledger
+→ safe remediation / rejection / escalation
+→ reusable defensive capability
+→ vNext defensive task
+```
+
+The operating doctrine:
+
+> No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+## What problem SecureRails solves
+
+AI agents can generate code, PRs, workflow changes, configuration changes, and remediation proposals faster than humans can safely review them.
+
+SecureRails creates a governance layer around that work. It does not merely detect risk. It makes the work reviewable, replayable, rejectable, remediable, and auditable.
 
 ## Who this is for
 
-- Operators running AI-agent workflows
-- Security reviewers
-- Governance/compliance reviewers
+SecureRails is for:
 
-## Start here
+* AI-agent operators
+* engineering teams using autonomous or semi-autonomous coding agents
+* security reviewers
+* platform teams
+* DevSecOps teams
+* compliance reviewers
+* AI governance teams
+* AGI ALPHA Evidence Mission Control operators
 
-1. Read the product boundary.
-2. Review excluded uses.
-3. Use templates to produce structured artifacts.
+## What SecureRails reviews
 
-## Templates
+SecureRails can review repo-owned, defensive software-work artifacts such as:
 
-- `templates/safety-ledger-example.json`
-- `templates/deployment-intake-example.json`
+* pull requests
+* workflow changes
+* GitHub Actions permissions
+* Evidence Docket completeness
+* ProofBundle integrity
+* safety ledgers
+* claim boundaries
+* redacted secret-hygiene reports
+* safe remediation proposals
+* documentation and public claims
+* deployment intake records
+* AI Act use-case triage records
+
+## Allowed use
+
+SecureRails is intended for:
+
+* repo-owned defensive review
+* AI-agent work governance
+* proof-bound remediation
+* claim-boundary enforcement
+* workflow safety review
+* redacted safety-ledger production
+* safe PR proposal review
+* human-governed remediation
+* Evidence Docket and ProofBundle production
+
+## Excluded use
+
+SecureRails must not be used for:
+
+* employment evaluation
+* worker management
+* profiling of natural persons
+* automated decisions about natural persons
+* law-enforcement decisioning
+* biometric identification
+* emotion recognition
+* credit, insurance, education, medical, or migration decisions
+* critical-infrastructure safety-component reliance
+* offensive cybersecurity
+* external target scanning
+* exploit execution
+* malware generation
+* social engineering
+* autonomous production remediation
+* autonomous merge
+* cybersecurity certification claims
+* guaranteed security claims
+* investment or token-return claims
+
+## EU AI Act posture
+
+SecureRails is designed and documented as a defensive governance and evidence system for software work.
+
+SecureRails is not intended, designed, validated, or authorized for Annex III high-risk AI use cases.
+
+SecureRails analyzes:
+
+```text
+code
+workflows
+pull requests
+artifacts
+claims
+Evidence Dockets
+ProofBundles
+safety ledgers
+validator reports
+```
+
+SecureRails does not evaluate people.
+
+Every deployment should include:
+
+* deployment intake
+* customer use attestation
+* excluded-use review
+* Annex III triage
+* human-review policy
+* material modification log
+* safety ledger
+* claim-boundary review
+
+## Important boundary
+
+Do not say:
+
+```text
+SecureRails is EU AI Act exempt.
+SecureRails is legally approved worldwide.
+SecureRails certifies security.
+SecureRails guarantees security.
+SecureRails autonomously remediates production systems.
+```
+
+Use this instead:
+
+```text
+SecureRails is designed as AI-agent security governance and proof-bound defensive remediation, with human-reviewed promotion, excluded high-risk uses, and executable guardrails.
+```
+
+## Key files
+
+### Public docs
+
+* [Product boundary](product-boundary.md)
+* [AI-agent security governance](ai-agent-security-governance.md)
+* [EU AI Act positioning](eu-ai-act-positioning.md)
+* [Annex III triage](eu-ai-act-annex-iii-triage.md)
+* [Foreseeable misuse and excluded uses](foreseeable-misuse-and-excluded-uses.md)
+* [No HR / worker evaluation policy](no-hr-worker-evaluation-policy.md)
+* [Critical infrastructure safety-component boundary](critical-infrastructure-safety-component-boundary.md)
+* [Profiling and person-data boundary](profiling-and-person-data-boundary.md)
+* [GPAI dependency boundary](gpai-dependency-boundary.md)
+* [Security and safety boundary](security-safety-boundary.md)
+* [Claims and marketing guardrails](claims-and-marketing-guardrails.md)
+* [Customer deployment playbook](customer-deployment-playbook.md)
+* [Regulator audit readiness](regulator-audit-readiness.md)
+* [Material modification and re-screening](material-modification-and-rescreening.md)
+* [Token utility policy](token-utility-policy.md)
+* [Compliance FAQ](compliance-faq.md)
+
+### Templates
+
+* [Templates README](templates/README.md)
+* [Deployment intake example](templates/deployment-intake-example.json)
+* [Safety ledger example](templates/safety-ledger-example.json)
+
+### Guard scripts
+
+From the repository root:
+
+```text
+scripts/secure_rails_claim_boundary_check.py
+scripts/secure_rails_safety_ledger_check.py
+scripts/secure_rails_no_automerge_check.py
+scripts/secure_rails_use_case_triage_check.py
+```
+
+### Workflow
+
+```text
+.github/workflows/secure-rails-compliance-guard.yml
+```
+
+## How to run the checks locally
+
+From the repository root:
+
+```bash
+python scripts/secure_rails_claim_boundary_check.py .
+python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+python scripts/secure_rails_no_automerge_check.py .
+python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
+```
+
+## What the compliance guard enforces
+
+The SecureRails compliance guard checks that the repository does not drift into unsafe or overbroad claims.
+
+It enforces:
+
+* no AGI / ASI overclaims
+* no empirical SOTA claims without evidence
+* no cybersecurity certification claims
+* no guaranteed security claims
+* no offensive cyber posture
+* no autonomous decision-making posture
+* no HR / worker-evaluation posture
+* no profiling posture
+* no critical-infrastructure safety-component reliance
+* no GPAI model-provider claim by default
+* no investment-product framing
+* no auto-merge posture
+* safety ledger hard counters
+
+## Hard safety counters
+
+Security-related SecureRails reports should include these counters:
+
+```text
+raw_secret_leak_count
+external_target_scan_count
+exploit_execution_count
+malware_generation_count
+social_engineering_content_count
+unsafe_automerge_count
+critical_safety_incidents
+```
+
+For promotion, all hard safety counters must be explicitly zero.
+
+## How to use SecureRails for a new deployment
+
+1. Complete deployment intake.
+2. Confirm excluded uses.
+3. Run AI Act triage.
+4. Generate or attach the Evidence Docket.
+5. Run the SecureRails compliance guard.
+6. Review the safety ledger.
+7. Review any safe PR proposal manually.
+8. Record the human-review decision.
+9. Archive accepted defensive capability.
+10. Re-screen after any material modification.
+
+## Human review is mandatory
+
+SecureRails may produce:
+
+* evidence
+* validator reports
+* safety ledgers
+* safe PR proposals
+* rejection dockets
+* remediation recommendations
+
+SecureRails must not automatically merge or autonomously promote remediation.
+
+## Marketing rule
+
+Approved:
+
+```text
+SecureRails makes AI-agent work safe to review, safe to replay, and safe to remediate.
+```
+
+Avoid:
+
+```text
+SecureRails guarantees security.
+SecureRails certifies compliance.
+SecureRails is fully EU AI Act exempt.
+SecureRails autonomously remediates production systems.
+```
+
+## $AGIALPHA boundary
+
+If $AGIALPHA is referenced, it must be framed only as utility infrastructure for protocol operations such as:
+
+* access credits
+* escrow
+* validator staking
+* Sybil resistance
+* validator fees
+* replay fees
+* slashing
+* ProofBundle fees
+* Evidence Docket fees
+* α-Work Unit accounting
+* settlement receipts
+* archive-access accounting
+
+Do not describe $AGIALPHA as:
+
+* equity
+* debt
+* yield
+* dividend
+* ownership
+* profit rights
+* investment return
+* guaranteed appreciation
+* financial product
+
+## Current status
+
+SecureRails has repository-level compliance-as-code enforcement through:
+
+```text
+.github/workflows/secure-rails-compliance-guard.yml
+```
+
+This is an enforcement layer, not a certification claim.
+
+## Final boundary
+
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.

--- a/docs/secure-rails/templates/README.md
+++ b/docs/secure-rails/templates/README.md
@@ -1,6 +1,141 @@
 # SecureRails Templates
 
-This folder contains reusable examples for producing structured SecureRails artifacts.
+This folder contains example inputs used by the SecureRails compliance guard and deployment workflow.
 
-- `safety-ledger-example.json`
-- `deployment-intake-example.json`
+These templates help operators keep SecureRails deployments inside the intended product boundary:
+
+```text
+AI-agent security governance
+proof-bound defensive remediation
+human-reviewed promotion
+no autonomous claim escalation
+```
+
+## Current templates
+
+### `deployment-intake-example.json`
+
+A low-risk deployment intake example.
+
+It should confirm that the deployment is:
+
+* repo-owned
+* defensive
+* human-reviewed
+* not used for HR or worker evaluation
+* not used for profiling natural persons
+* not used for automated decisions about natural persons
+* not used as a critical-infrastructure safety component
+* not offensive cyber
+* not a GPAI model-provider deployment by default
+
+Use this template to test:
+
+```bash
+python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
+```
+
+### `safety-ledger-example.json`
+
+A minimal safety ledger example.
+
+It should include these hard safety counters, all explicitly set to `0`:
+
+```text
+raw_secret_leak_count
+external_target_scan_count
+exploit_execution_count
+malware_generation_count
+social_engineering_content_count
+unsafe_automerge_count
+critical_safety_incidents
+```
+
+Use this template to test:
+
+```bash
+python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+```
+
+## How to use these templates
+
+For a new SecureRails deployment:
+
+1. Copy `deployment-intake-example.json`.
+2. Rename it for the customer, repo, or deployment.
+3. Fill in the actual deployment scope.
+4. Confirm excluded uses.
+5. Run use-case triage.
+6. Copy `safety-ledger-example.json`.
+7. Fill in the actual safety counters.
+8. Run the safety ledger check.
+9. Attach both files to the Evidence Docket.
+
+## Required deployment posture
+
+A valid SecureRails deployment should remain:
+
+* defensive
+* repo-owned
+* human-reviewed
+* advisory
+* evidence-producing
+* claim-bounded
+* safety-ledgered
+
+## Excluded deployment posture
+
+A SecureRails deployment is not valid if it is used for:
+
+* employment evaluation
+* worker management
+* profiling of natural persons
+* automated decisions about natural persons
+* biometric identification
+* emotion recognition
+* law-enforcement decisioning
+* credit or insurance decisions
+* education access decisions
+* medical triage or diagnosis
+* migration or asylum decisions
+* critical-infrastructure safety-control reliance
+* offensive cybersecurity
+* external target scanning
+* exploit execution
+* malware generation
+* social engineering
+* autonomous production remediation
+* autonomous merge
+
+## Human review requirement
+
+SecureRails outputs are advisory and require independent human validation before any action.
+
+A safe PR proposal is not a merge authorization.
+
+An Evidence Docket is not a security certification.
+
+A passed compliance guard is not legal approval.
+
+## Claim boundary
+
+Use this boundary in deployment records:
+
+```text
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+```
+
+## Local checks
+
+From the repository root, run:
+
+```bash
+python scripts/secure_rails_claim_boundary_check.py .
+python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+python scripts/secure_rails_no_automerge_check.py .
+python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
+```
+
+## SecureRails doctrine
+
+> No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.

--- a/docs/secure-rails/templates/README.md
+++ b/docs/secure-rails/templates/README.md
@@ -113,7 +113,7 @@ SecureRails outputs are advisory and require independent human validation before
 
 A safe PR proposal is not a merge authorization.
 
-An Evidence Docket is not a security certification.
+An Evidence Docket is not a security assurance or attestation.
 
 A passed compliance guard is not legal approval.
 
@@ -122,7 +122,7 @@ A passed compliance guard is not legal approval.
 Use this boundary in deployment records:
 
 ```text
-SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 ```
 
 ## Local checks


### PR DESCRIPTION
### Motivation

- Improve newcomer experience by adding user-facing READMEs that explain SecureRails purpose, boundaries, and how to operate the compliance guard. 
- Surface templates and local check commands so operators and reviewers can validate deployments and maintain claim boundaries.

### Description

- Inserted the SecureRails user-facing snippet into the root `README.md` under the Quick links / Quickstart area, including quick links, local check commands, and doctrine. 
- Added `docs/secure-rails/README.md` containing the full SecureRails user guide (positioning, allowed/excluded uses, EU AI Act posture, key files, and operational guidance). 
- Added `docs/secure-rails/templates/README.md` containing the templates guide and explicit instructions for `deployment-intake-example.json` and `safety-ledger-example.json`. 
- Changes update the repo documentation to make the existing SecureRails compliance-as-code enforcement discoverable and actionable.

### Testing

- Ran `python scripts/secure_rails_claim_boundary_check.py .` and it passed with no disallowed claim patterns. 
- Ran `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json` and it passed with all safety counters present and zero. 
- Ran `python scripts/secure_rails_no_automerge_check.py .` and it passed with no auto-merge posture detected. 
- Ran `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json` and it passed the use-case triage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c6c4d6d88333a4ea34973a022909)