### PR TITLE
Add SecureRails Work Vaults + ALPHA AGI MARK/Sovereign docs, schema, deterministic pipeline, and tests

### DIFF
--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -205,6 +205,7 @@ SecureRails is designed as AI-agent security governance and proof-bound defensiv
 * [Foreseeable misuse and excluded uses](foreseeable-misuse-and-excluded-uses.md)
 * [Security and safety boundary](security-safety-boundary.md)
 * [Claims and marketing guardrails](claims-and-marketing-guardrails.md)
+* [Work Vaults, MARK, and Sovereigns](work-vaults-mark-sovereigns.md)
 * [SecureRails index](index.md)
 
 ### Templates

--- a/docs/secure-rails/index.md
+++ b/docs/secure-rails/index.md
@@ -11,3 +11,5 @@ Use this index to navigate core policy and safety documents for defensive, proof
 - [Security and safety boundary](security-safety-boundary.md)
 - [Claims and marketing guardrails](claims-and-marketing-guardrails.md)
 - [Templates](templates/README.md)
+
+- [Work Vaults, MARK, and Sovereigns](work-vaults-mark-sovereigns.md)

--- a/docs/secure-rails/work-vaults-mark-sovereigns.md
+++ b/docs/secure-rails/work-vaults-mark-sovereigns.md
@@ -1,0 +1,81 @@
+# SecureRails Work Vaults, ALPHA AGI MARK, and ALPHA AGI Sovereigns
+
+SecureRails Work Vaults are the protocol boundary that converts AI-agent defensive work into auditable, human-governed remediation decisions.
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+## Scope and boundary
+
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+
+All outputs are advisory and require independent human validation before action.
+
+$AGIALPHA in this protocol is utility infrastructure for protocol operations only. It is not investment, equity, yield, dividend, appreciation, ownership, or a financial product claim.
+
+## Lifecycle
+
+```text
+SecureRails Work Vault
+→ ALPHA AGI MARK allocation
+→ ALPHA AGI Sovereign assignment
+→ AGI Job execution
+→ ProofBundle production
+→ Evidence Docket assembly
+→ Human review decision
+→ Safe remediation / rejection / escalation
+→ $AGIALPHA utility settlement receipt
+→ Reusable defensive capability archive
+→ vNext defensive work
+```
+
+## Core entities
+
+- **Work Vault**: isolated, deterministic job context with pinned inputs, policy controls, and immutable run IDs.
+- **ALPHA AGI MARK allocation**: governance allocation record that authorizes a bounded defensive job under explicit replay/validator requirements.
+- **ALPHA AGI Sovereign assignment**: assignment of accountable defensive operating policy and reviewers to a vault run.
+- **AGI Job**: deterministic task run that emits artifacts and logs.
+- **ProofBundle**: reproducible evidence package (inputs, outputs, checksums, commands).
+- **Evidence Docket**: claim-bound, reviewer-readable evidence summary and decision record.
+- **Settlement receipt**: protocol utility accounting receipt for operations tracking only (no real transfer).
+
+## Deterministic execution requirements
+
+1. Stable job ID derived from normalized JSON inputs.
+2. Stable ordering for all list/object serialization.
+3. No network or external target scanning required for pipeline validation.
+4. Replay output must hash-identical for identical input.
+5. Human review gates must remain explicit before promotion.
+
+## Safety requirements
+
+- Defensive-only remediation recommendations.
+- No exploit execution, malware creation, secret disclosure, or social engineering.
+- No autonomous merge.
+- No autonomous claim promotion.
+- Reject if Evidence Docket is missing or incomplete.
+
+## Evidence Mission Control integration
+
+Mission Control operators should register each Work Vault run using generated run IDs and docket IDs, then link the docket and ProofBundle in evidence index pages.
+
+Suggested integration fields:
+
+- `work_vault.vault_id`
+- `mark_allocation.mark_id`
+- `sovereign_assignment.sovereign_id`
+- `proof_bundle.proof_bundle_id`
+- `evidence_docket.docket_id`
+- `human_review.decision`
+- `utility_settlement.receipt_id`
+
+## Reference artifacts
+
+- `schemas/secure_rails_work_vault.schema.json`
+- `schemas/secure_rails_mark_allocation.schema.json`
+- `schemas/secure_rails_sovereign_assignment.schema.json`
+- `schemas/secure_rails_job_record.schema.json`
+- `schemas/secure_rails_proof_bundle.schema.json`
+- `schemas/secure_rails_evidence_docket.schema.json`
+- `schemas/secure_rails_settlement_receipt.schema.json`
+- `sample_outputs/secure_rails_work_vault/sample_work_vault_run.json`
+- `scripts/secure_rails_work_vault_pipeline.py`

--- a/docs/secure-rails/work-vaults-mark-sovereigns.md
+++ b/docs/secure-rails/work-vaults-mark-sovereigns.md
@@ -6,7 +6,7 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 
 ## Scope and boundary
 
-SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 
 All outputs are advisory and require independent human validation before action.
 

--- a/sample_outputs/secure_rails_work_vault/sample_input.json
+++ b/sample_outputs/secure_rails_work_vault/sample_input.json
@@ -1,0 +1,11 @@
+{
+  "vault_id": "vault-defensive-001",
+  "defensive_scope": "repo-owned defensive remediation planning",
+  "job_type": "defensive_remediation",
+  "mark_units": 42,
+  "sovereign_id": "sovereign-defensive-alpha",
+  "reviewers": ["human.security.reviewer"],
+  "status": "completed",
+  "decision": "safe_remediation",
+  "reviewed_by": "human.security.reviewer"
+}

--- a/sample_outputs/secure_rails_work_vault/sample_input.json
+++ b/sample_outputs/secure_rails_work_vault/sample_input.json
@@ -4,8 +4,11 @@
   "job_type": "defensive_remediation",
   "mark_units": 42,
   "sovereign_id": "sovereign-defensive-alpha",
-  "reviewers": ["human.security.reviewer"],
+  "reviewers": [
+    "human.security.reviewer"
+  ],
   "status": "completed",
   "decision": "safe_remediation",
-  "reviewed_by": "human.security.reviewer"
+  "reviewed_by": "human.security.reviewer",
+  "created_at": "2026-05-03T00:00:00+00:00"
 }

--- a/sample_outputs/secure_rails_work_vault/sample_work_vault_run.json
+++ b/sample_outputs/secure_rails_work_vault/sample_work_vault_run.json
@@ -36,7 +36,7 @@
     "receipt_id": "util-075ed342dc63422ddad6"
   },
   "work_vault": {
-    "created_at": "2026-05-03T12:18:57+00:00",
+    "created_at": "2026-05-03T00:00:00+00:00",
     "defensive_scope": "repo-owned defensive remediation planning",
     "run_id": "svr-075ed342dc63422d",
     "vault_id": "vault-defensive-001"

--- a/sample_outputs/secure_rails_work_vault/sample_work_vault_run.json
+++ b/sample_outputs/secure_rails_work_vault/sample_work_vault_run.json
@@ -1,0 +1,44 @@
+{
+  "agi_job": {
+    "job_id": "job-dad60e20d2faf013",
+    "job_type": "defensive_remediation",
+    "status": "completed"
+  },
+  "evidence_docket": {
+    "claim_boundary_statement": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.",
+    "docket_id": "dkt-d985db8e89feb1c3"
+  },
+  "human_review": {
+    "decision": "safe_remediation",
+    "reviewed_by": "human.security.reviewer"
+  },
+  "mark_allocation": {
+    "allocation_units": 42,
+    "human_review_required": true,
+    "mark_id": "mark-075ed342dc63",
+    "replay_required": true
+  },
+  "proof_bundle": {
+    "proof_bundle_id": "pb-8559167668e50b5d",
+    "sha256": "075ed342dc63422ddad60e20d2faf0138559167668e50b5dd985db8e89feb1c3"
+  },
+  "schema_version": "agialpha.securerails.work_vault_record.v1",
+  "sovereign_assignment": {
+    "reviewers": [
+      "human.security.reviewer"
+    ],
+    "sovereign_id": "sovereign-defensive-alpha",
+    "sovereign_policy": "defensive-remediation-only"
+  },
+  "utility_settlement": {
+    "mode": "$AGIALPHA_UTILITY_ONLY",
+    "real_transfer": false,
+    "receipt_id": "util-075ed342dc63422ddad6"
+  },
+  "work_vault": {
+    "created_at": "2026-05-03T12:18:57+00:00",
+    "defensive_scope": "repo-owned defensive remediation planning",
+    "run_id": "svr-075ed342dc63422d",
+    "vault_id": "vault-defensive-001"
+  }
+}

--- a/schemas/secure_rails_work_vault_record.schema.json
+++ b/schemas/secure_rails_work_vault_record.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -3,6 +3,7 @@
 import argparse
 import hashlib
 import json
+from datetime import datetime
 
 CLAIM_BOUNDARY = "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
 
@@ -16,6 +17,16 @@ def _stable_hash(payload: dict) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _validate_created_at(value: str) -> None:
+    if not isinstance(value, str):
+        raise ValueError("created_at must be a string in RFC3339 date-time format")
+    normalized = value.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Invalid created_at date-time: {value}") from exc
+
+
 def _validate_payload(payload: dict) -> None:
     if payload["job_type"] not in ALLOWED_JOB_TYPES:
         raise ValueError(f"Invalid job_type: {payload['job_type']}")
@@ -24,10 +35,11 @@ def _validate_payload(payload: dict) -> None:
     if payload["decision"] not in ALLOWED_DECISIONS:
         raise ValueError(f"Invalid decision: {payload['decision']}")
     mark_units = payload["mark_units"]
-    if not isinstance(mark_units, int):
-        raise ValueError("mark_units must be an integer")
+    if isinstance(mark_units, bool) or not isinstance(mark_units, int):
+        raise ValueError("mark_units must be an integer (boolean is not allowed)")
     if mark_units < 0:
         raise ValueError(f"mark_units must be non-negative: {mark_units}")
+    _validate_created_at(payload.get("created_at", "1970-01-01T00:00:00+00:00"))
 
 
 def build_record(payload: dict) -> dict:

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Deterministic SecureRails Work Vault record generator."""
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+
+CLAIM_BOUNDARY = "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
+
+
+def _stable_hash(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_record(payload: dict) -> dict:
+    seed = {
+        "vault_id": payload["vault_id"],
+        "defensive_scope": payload["defensive_scope"],
+        "job_type": payload["job_type"],
+        "mark_units": payload["mark_units"],
+        "sovereign_id": payload["sovereign_id"],
+    }
+    digest = _stable_hash(seed)
+    run_id = f"svr-{digest[:16]}"
+    job_id = f"job-{digest[16:32]}"
+    proof_id = f"pb-{digest[32:48]}"
+    docket_id = f"dkt-{digest[48:64]}"
+    record = {
+        "schema_version": "agialpha.securerails.work_vault_record.v1",
+        "work_vault": {
+            "vault_id": payload["vault_id"],
+            "run_id": run_id,
+            "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "defensive_scope": payload["defensive_scope"],
+        },
+        "mark_allocation": {
+            "mark_id": f"mark-{digest[:12]}",
+            "allocation_units": payload["mark_units"],
+            "replay_required": True,
+            "human_review_required": True,
+        },
+        "sovereign_assignment": {
+            "sovereign_id": payload["sovereign_id"],
+            "sovereign_policy": "defensive-remediation-only",
+            "reviewers": payload["reviewers"],
+        },
+        "agi_job": {"job_id": job_id, "job_type": payload["job_type"], "status": payload["status"]},
+        "proof_bundle": {"proof_bundle_id": proof_id, "sha256": digest},
+        "evidence_docket": {"docket_id": docket_id, "claim_boundary_statement": CLAIM_BOUNDARY},
+        "human_review": {"decision": payload["decision"], "reviewed_by": payload["reviewed_by"]},
+        "utility_settlement": {"receipt_id": f"util-{digest[:20]}", "mode": "$AGIALPHA_UTILITY_ONLY", "real_transfer": False},
+    }
+    return record
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True)
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+    with open(args.input, "r", encoding="utf-8") as f:
+        payload = json.load(f)
+    record = build_record(payload)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(record, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -22,9 +22,11 @@ def _validate_created_at(value: str) -> None:
         raise ValueError("created_at must be a string in RFC3339 date-time format")
     normalized = value.replace("Z", "+00:00")
     try:
-        datetime.fromisoformat(normalized)
+        parsed = datetime.fromisoformat(normalized)
     except ValueError as exc:
         raise ValueError(f"Invalid created_at date-time: {value}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("created_at must include timezone offset (e.g. Z or +00:00)")
 
 
 def _validate_payload(payload: dict) -> None:
@@ -40,6 +42,12 @@ def _validate_payload(payload: dict) -> None:
     if mark_units < 0:
         raise ValueError(f"mark_units must be non-negative: {mark_units}")
     _validate_created_at(payload.get("created_at", "1970-01-01T00:00:00+00:00"))
+
+    reviewers = payload["reviewers"]
+    if not isinstance(reviewers, list) or len(reviewers) < 1:
+        raise ValueError("reviewers must be a non-empty array of strings")
+    if any(not isinstance(reviewer, str) or not reviewer for reviewer in reviewers):
+        raise ValueError("reviewers entries must be non-empty strings")
 
 
 def build_record(payload: dict) -> dict:

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -3,7 +3,6 @@
 import argparse
 import hashlib
 import json
-from datetime import datetime, timezone
 
 CLAIM_BOUNDARY = "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
 
@@ -31,7 +30,7 @@ def build_record(payload: dict) -> dict:
         "work_vault": {
             "vault_id": payload["vault_id"],
             "run_id": run_id,
-            "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "created_at": payload.get("created_at", "1970-01-01T00:00:00+00:00"),
             "defensive_scope": payload["defensive_scope"],
         },
         "mark_allocation": {

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -6,13 +6,32 @@ import json
 
 CLAIM_BOUNDARY = "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
 
+ALLOWED_JOB_TYPES = {"defensive_remediation", "defensive_triage", "defensive_validation"}
+ALLOWED_JOB_STATUS = {"completed", "rejected", "escalated"}
+ALLOWED_DECISIONS = {"safe_remediation", "reject", "escalate"}
+
 
 def _stable_hash(payload: dict) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _validate_payload(payload: dict) -> None:
+    if payload["job_type"] not in ALLOWED_JOB_TYPES:
+        raise ValueError(f"Invalid job_type: {payload['job_type']}")
+    if payload["status"] not in ALLOWED_JOB_STATUS:
+        raise ValueError(f"Invalid status: {payload['status']}")
+    if payload["decision"] not in ALLOWED_DECISIONS:
+        raise ValueError(f"Invalid decision: {payload['decision']}")
+    mark_units = payload["mark_units"]
+    if not isinstance(mark_units, int):
+        raise ValueError("mark_units must be an integer")
+    if mark_units < 0:
+        raise ValueError(f"mark_units must be non-negative: {mark_units}")
+
+
 def build_record(payload: dict) -> dict:
+    _validate_payload(payload)
     seed = {
         "vault_id": payload["vault_id"],
         "defensive_scope": payload["defensive_scope"],

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -27,6 +27,22 @@ class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
         self.assertEqual(data["utility_settlement"]["mode"], "$AGIALPHA_UTILITY_ONLY")
         self.assertFalse(data["utility_settlement"]["real_transfer"])
 
+    def test_deterministic_replay_for_identical_input(self):
+        fixture = Path("sample_outputs/secure_rails_work_vault/sample_input.json")
+        with tempfile.TemporaryDirectory() as td:
+            out1 = Path(td) / "out1.json"
+            out2 = Path(td) / "out2.json"
+            cmd = [
+                "python",
+                "scripts/secure_rails_work_vault_pipeline.py",
+                "--input",
+                str(fixture),
+            ]
+            subprocess.run(cmd + ["--output", str(out1)], check=True)
+            subprocess.run(cmd + ["--output", str(out2)], check=True)
+            self.assertEqual(out1.read_text(), out2.read_text())
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -1,0 +1,32 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
+    def test_generates_claim_boundary_and_utility_only_receipt(self):
+        fixture = Path("sample_outputs/secure_rails_work_vault/sample_input.json")
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "out.json"
+            subprocess.run([
+                "python",
+                "scripts/secure_rails_work_vault_pipeline.py",
+                "--input",
+                str(fixture),
+                "--output",
+                str(out),
+            ], check=True)
+            data = json.loads(out.read_text())
+        self.assertEqual(data["schema_version"], "agialpha.securerails.work_vault_record.v1")
+        self.assertEqual(
+            data["evidence_docket"]["claim_boundary_statement"],
+            "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.",
+        )
+        self.assertEqual(data["utility_settlement"]["mode"], "$AGIALPHA_UTILITY_ONLY")
+        self.assertFalse(data["utility_settlement"]["real_transfer"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -155,6 +155,56 @@ class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
             ], capture_output=True, text=True)
             self.assertNotEqual(res.returncode, 0)
 
+    def test_rejects_created_at_without_timezone(self):
+        payload = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": 1,
+            "sovereign_id": "sovereign-x",
+            "reviewers": ["r1"],
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+            "created_at": "2026-05-03T00:00:00",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            res = subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+
+    def test_rejects_empty_or_non_string_reviewers(self):
+        base = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": 1,
+            "sovereign_id": "sovereign-x",
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+        }
+        bad_payloads = [
+            {**base, "reviewers": []},
+            {**base, "reviewers": [123]},
+            {**base, "reviewers": [""]},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            for i, payload in enumerate(bad_payloads):
+                inp = Path(td) / f"in_{i}.json"
+                out = Path(td) / f"out_{i}.json"
+                inp.write_text(json.dumps(payload), encoding="utf-8")
+                res = subprocess.run([
+                    "python", "scripts/secure_rails_work_vault_pipeline.py",
+                    "--input", str(inp), "--output", str(out),
+                ], capture_output=True, text=True)
+                self.assertNotEqual(res.returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -43,6 +43,29 @@ class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
             self.assertEqual(out1.read_text(), out2.read_text())
 
 
+    def test_default_created_at_is_stable(self):
+        payload = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": 1,
+            "sovereign_id": "sovereign-x",
+            "reviewers": ["r1"],
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], check=True)
+            data = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(data["work_vault"]["created_at"], "1970-01-01T00:00:00+00:00")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -110,6 +110,51 @@ class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
             ], capture_output=True, text=True)
             self.assertNotEqual(res.returncode, 0)
 
+    def test_rejects_boolean_mark_units(self):
+        payload = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": True,
+            "sovereign_id": "sovereign-x",
+            "reviewers": ["r1"],
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            res = subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+
+    def test_rejects_invalid_created_at(self):
+        payload = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": 1,
+            "sovereign_id": "sovereign-x",
+            "reviewers": ["r1"],
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+            "created_at": "yesterday",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            res = subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -66,6 +66,50 @@ class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
             data = json.loads(out.read_text(encoding="utf-8"))
         self.assertEqual(data["work_vault"]["created_at"], "1970-01-01T00:00:00+00:00")
 
+    def test_rejects_invalid_enums(self):
+        payload = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "oops",
+            "mark_units": 1,
+            "sovereign_id": "sovereign-x",
+            "reviewers": ["r1"],
+            "status": "running",
+            "decision": "auto",
+            "reviewed_by": "r1",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            res = subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+
+    def test_rejects_negative_mark_units(self):
+        payload = {
+            "vault_id": "vault-x",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": -3,
+            "sovereign_id": "sovereign-x",
+            "reviewers": ["r1"],
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            res = subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation

- Implement the next SecureRails protocol layer to make Work Vaults, ALPHA AGI MARK allocation, and ALPHA AGI Sovereign assignment visible, auditable, and executable as the repo-owned AI-agent security governance layer.
- Provide deterministic tooling and sample artifacts so runs are replayable and proof-bound for human review and Evidence Mission Control integration.
- Preserve safety and compliance boundaries by enforcing the claim-boundary doctrine and framing `$AGIALPHA` as a utility-only settlement without real token transfers or blockchain connections.

### Description

- Added new documentation `docs/secure-rails/work-vaults-mark-sovereigns.md` describing lifecycle, entities, deterministic and safety requirements, and Evidence Mission Control integration.
- Added a JSON Schema `schemas/secure_rails_work_vault_record.schema.json` that defines a unified Work Vault record including explicit claim-boundary text and `utility_settlement` constraints (`mode: "$AGIALPHA_UTILITY_ONLY"`, `real_transfer: false`).
- Added a deterministic Python pipeline `scripts/secure_rails_work_vault_pipeline.py` that stable-hashes normalized inputs to generate stable IDs and produces replayable Work Vault records containing `work_vault`, `mark_allocation`, `sovereign_assignment`, `agi_job`, `proof_bundle`, `evidence_docket`, `human_review`, and `utility_settlement` fields. 
- Added sample input/output artifacts under `sample_outputs/secure_rails_work_vault/`, a unit test `tests/test_secure_rails_work_vault_pipeline.py`, and integrated the new doc into `docs/secure-rails/index.md` and `docs/secure-rails/README.md` navigation.  

### Testing

- Ran `python -m pytest -q tests/test_secure_rails_work_vault_pipeline.py tests/test_docs_relative_links.py` and both tests passed (`2 passed`).
- The unit test verifies the produced record uses the expected `schema_version`, includes the mandatory claim-boundary statement, and preserves the utility-only settlement framing with `real_transfer: false`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73cad658483339f9f4f1464debdb5)