### PR TITLE
Add deterministic SecureRails Work Vault pipeline, schemas, sample, and tests

### DIFF
--- a/sample_outputs/secure_rails_work_vault/sample_work_vault_run.json
+++ b/sample_outputs/secure_rails_work_vault/sample_work_vault_run.json
@@ -1,12 +1,12 @@
 {
   "agi_job": {
-    "job_id": "job-8df8138ccc58efcf",
+    "job_id": "job-4e67b3be073dea4d",
     "job_type": "defensive_remediation",
     "status": "completed"
   },
   "evidence_docket": {
     "claim_boundary_statement": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.",
-    "docket_id": "dkt-8d30ba5fcae5cf1c"
+    "docket_id": "dkt-c7e6e6ad43298a88"
   },
   "human_review": {
     "decision": "safe_remediation",
@@ -15,12 +15,12 @@
   "mark_allocation": {
     "allocation_units": 42,
     "human_review_required": true,
-    "mark_id": "mark-85862719307b",
+    "mark_id": "mark-ea9bc0b7abbb",
     "replay_required": true
   },
   "proof_bundle": {
-    "proof_bundle_id": "pb-23d2e518af4d22e5",
-    "sha256": "85862719307bbbd88df8138ccc58efcf23d2e518af4d22e58d30ba5fcae5cf1c"
+    "proof_bundle_id": "pb-ce8df56c986d6f1fc",
+    "sha256": "c337a132f2f8d9f5f9074f3d4929fa3b27aaf7d7755654be3bce154bc00dc2d6"
   },
   "schema_version": "agialpha.securerails.work_vault_record.v1",
   "sovereign_assignment": {

--- a/schemas/secure_rails_evidence_docket.schema.json
+++ b/schemas/secure_rails_evidence_docket.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_evidence_docket.schema.json
+++ b/schemas/secure_rails_evidence_docket.schema.json
@@ -1,61 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails Evidence Docket",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "docket_id",
+    "claim_boundary_statement"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "docket_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
-    },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
-      }
-    },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    "claim_boundary_statement": {
+      "const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_job_record.schema.json
+++ b/schemas/secure_rails_job_record.schema.json
@@ -1,61 +1,33 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails AGI Job Record",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "job_id",
+    "job_type",
+    "status"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "job_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
+    "job_type": {
+      "type": "string",
+      "enum": [
+        "defensive_remediation",
+        "defensive_triage",
+        "defensive_validation"
+      ]
     },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
-      }
-    },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    "status": {
+      "type": "string",
+      "enum": [
+        "completed",
+        "rejected",
+        "escalated"
+      ]
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_job_record.schema.json
+++ b/schemas/secure_rails_job_record.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_mark_allocation.schema.json
+++ b/schemas/secure_rails_mark_allocation.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_mark_allocation.schema.json
+++ b/schemas/secure_rails_mark_allocation.schema.json
@@ -1,61 +1,28 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails MARK Allocation",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "mark_id",
+    "allocation_units",
+    "replay_required",
+    "human_review_required"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "mark_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
+    "allocation_units": {
+      "type": "integer",
+      "minimum": 0
     },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
-      }
+    "replay_required": {
+      "type": "boolean"
     },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    "human_review_required": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_proof_bundle.schema.json
+++ b/schemas/secure_rails_proof_bundle.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_proof_bundle.schema.json
+++ b/schemas/secure_rails_proof_bundle.schema.json
@@ -1,61 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails ProofBundle",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "proof_bundle_id",
+    "sha256"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "proof_bundle_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
-    },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
-      }
-    },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_settlement_receipt.schema.json
+++ b/schemas/secure_rails_settlement_receipt.schema.json
@@ -1,61 +1,23 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails Utility Settlement Receipt",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "receipt_id",
+    "mode",
+    "real_transfer"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
+    "mode": {
+      "const": "$AGIALPHA_UTILITY_ONLY"
     },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
-      }
-    },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    "real_transfer": {
+      "const": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_settlement_receipt.schema.json
+++ b/schemas/secure_rails_settlement_receipt.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_sovereign_assignment.schema.json
+++ b/schemas/secure_rails_sovereign_assignment.schema.json
@@ -1,61 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails Sovereign Assignment",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "sovereign_id",
+    "sovereign_policy",
+    "reviewers"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "sovereign_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
+    "sovereign_policy": {
+      "type": "string",
+      "minLength": 1
     },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+    "reviewers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
       }
-    },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_sovereign_assignment.schema.json
+++ b/schemas/secure_rails_sovereign_assignment.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_work_vault.schema.json
+++ b/schemas/secure_rails_work_vault.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_vault",
+    "mark_allocation",
+    "sovereign_assignment",
+    "agi_job",
+    "proof_bundle",
+    "evidence_docket",
+    "human_review",
+    "utility_settlement"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
+    "work_vault": {
+      "type": "object",
+      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
+      "properties": {
+        "vault_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+        "defensive_scope": {"type": "string", "minLength": 1}
+      }
+    },
+    "mark_allocation": {
+      "type": "object",
+      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
+      "properties": {
+        "mark_id": {"type": "string", "minLength": 1},
+        "allocation_units": {"type": "integer", "minimum": 0},
+        "replay_required": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"}
+      }
+    },
+    "sovereign_assignment": {
+      "type": "object",
+      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
+      "properties": {
+        "sovereign_id": {"type": "string", "minLength": 1},
+        "sovereign_policy": {"type": "string", "minLength": 1},
+        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      }
+    },
+    "agi_job": {
+      "type": "object",
+      "required": ["job_id", "job_type", "status"],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
+      }
+    },
+    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
+    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
+    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
+    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
+  }
+}

--- a/schemas/secure_rails_work_vault.schema.json
+++ b/schemas/secure_rails_work_vault.schema.json
@@ -1,61 +1,30 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "SecureRails Work Vault Record",
+  "title": "SecureRails Work Vault",
   "type": "object",
   "required": [
-    "schema_version",
-    "work_vault",
-    "mark_allocation",
-    "sovereign_assignment",
-    "agi_job",
-    "proof_bundle",
-    "evidence_docket",
-    "human_review",
-    "utility_settlement"
+    "vault_id",
+    "run_id",
+    "created_at",
+    "defensive_scope"
   ],
   "properties": {
-    "schema_version": {"const": "agialpha.securerails.work_vault_record.v1"},
-    "work_vault": {
-      "type": "object",
-      "required": ["vault_id", "run_id", "created_at", "defensive_scope"],
-      "properties": {
-        "vault_id": {"type": "string", "minLength": 1},
-        "run_id": {"type": "string", "minLength": 1},
-        "created_at": {"type": "string", "format": "date-time"},
-        "defensive_scope": {"type": "string", "minLength": 1}
-      }
+    "vault_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "mark_allocation": {
-      "type": "object",
-      "required": ["mark_id", "allocation_units", "replay_required", "human_review_required"],
-      "properties": {
-        "mark_id": {"type": "string", "minLength": 1},
-        "allocation_units": {"type": "integer", "minimum": 0},
-        "replay_required": {"type": "boolean"},
-        "human_review_required": {"type": "boolean"}
-      }
+    "run_id": {
+      "type": "string",
+      "minLength": 1
     },
-    "sovereign_assignment": {
-      "type": "object",
-      "required": ["sovereign_id", "sovereign_policy", "reviewers"],
-      "properties": {
-        "sovereign_id": {"type": "string", "minLength": 1},
-        "sovereign_policy": {"type": "string", "minLength": 1},
-        "reviewers": {"type": "array", "items": {"type": "string"}, "minItems": 1}
-      }
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
     },
-    "agi_job": {
-      "type": "object",
-      "required": ["job_id", "job_type", "status"],
-      "properties": {
-        "job_id": {"type": "string", "minLength": 1},
-        "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
-        "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]}
-      }
-    },
-    "proof_bundle": {"type": "object", "required": ["proof_bundle_id", "sha256"], "properties": {"proof_bundle_id": {"type": "string"}, "sha256": {"type": "string", "minLength": 64}}},
-    "evidence_docket": {"type": "object", "required": ["docket_id", "claim_boundary_statement"], "properties": {"docket_id": {"type": "string"}, "claim_boundary_statement": {"const": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."}}},
-    "human_review": {"type": "object", "required": ["decision", "reviewed_by"], "properties": {"decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]}, "reviewed_by": {"type": "string"}}},
-    "utility_settlement": {"type": "object", "required": ["receipt_id", "mode", "real_transfer"], "properties": {"receipt_id": {"type": "string"}, "mode": {"const": "$AGIALPHA_UTILITY_ONLY"}, "real_transfer": {"const": false}}}
-  }
+    "defensive_scope": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/secure_rails_work_vault_request.schema.json
+++ b/schemas/secure_rails_work_vault_request.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Request",
+  "type": "object",
+  "required": [
+    "vault_id",
+    "defensive_scope",
+    "job_type",
+    "mark_units",
+    "sovereign_id",
+    "reviewers",
+    "status",
+    "decision",
+    "reviewed_by"
+  ],
+  "properties": {
+    "vault_id": {"type": "string", "minLength": 1, "pattern": ".*\\S.*"},
+    "defensive_scope": {"type": "string", "minLength": 1, "pattern": ".*\\S.*"},
+    "job_type": {"type": "string", "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]},
+    "mark_units": {"type": "integer", "minimum": 0},
+    "sovereign_id": {"type": "string", "minLength": 1, "pattern": ".*\\S.*"},
+    "reviewers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1, "pattern": ".*\\S.*"}
+    },
+    "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]},
+    "decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]},
+    "reviewed_by": {"type": "string", "minLength": 1, "pattern": ".*\\S.*"},
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -1,82 +1,48 @@
 #!/usr/bin/env python3
-"""Deterministic SecureRails Work Vault record generator."""
+"""Deterministic SecureRails Work Vault pipeline generator."""
+
+from __future__ import annotations
+
 import argparse
 import hashlib
 import json
-from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
 
-CLAIM_BOUNDARY = "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
-
-ALLOWED_JOB_TYPES = {"defensive_remediation", "defensive_triage", "defensive_validation"}
-ALLOWED_JOB_STATUS = {"completed", "rejected", "escalated"}
-ALLOWED_DECISIONS = {"safe_remediation", "reject", "escalate"}
-
-
-def _stable_hash(payload: dict) -> str:
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+CLAIM_BOUNDARY = (
+    "No Evidence Docket, no empirical SOTA claim. "
+    "Autonomous evidence production is allowed; autonomous claim promotion is not."
+)
+SCHEMA_VERSION = "agialpha.securerails.work_vault_record.v1"
 
 
-def _require_non_empty_string(payload: dict, field: str) -> None:
-    value = payload[field]
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{field} must be a non-empty string")
+def canonical_json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
-def _validate_created_at(value: str) -> None:
-    if not isinstance(value, str):
-        raise ValueError("created_at must be a string in RFC3339 date-time format")
-    normalized = value.replace("Z", "+00:00")
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError as exc:
-        raise ValueError(f"Invalid created_at date-time: {value}") from exc
-    if parsed.tzinfo is None:
-        raise ValueError("created_at must include timezone offset (RFC3339)")
+def _short(prefix: str, material: str, length: int = 16) -> str:
+    return f"{prefix}-{material[:length]}"
 
 
-def _validate_payload(payload: dict) -> None:
-    _require_non_empty_string(payload, "vault_id")
-    _require_non_empty_string(payload, "defensive_scope")
-    _require_non_empty_string(payload, "sovereign_id")
-    _require_non_empty_string(payload, "reviewed_by")
-    if payload["job_type"] not in ALLOWED_JOB_TYPES:
-        raise ValueError(f"Invalid job_type: {payload['job_type']}")
-    if payload["status"] not in ALLOWED_JOB_STATUS:
-        raise ValueError(f"Invalid status: {payload['status']}")
-    if payload["decision"] not in ALLOWED_DECISIONS:
-        raise ValueError(f"Invalid decision: {payload['decision']}")
-    mark_units = payload["mark_units"]
-    if isinstance(mark_units, bool) or not isinstance(mark_units, int):
-        raise ValueError("mark_units must be an integer (boolean is not allowed)")
-    if mark_units < 0:
-        raise ValueError(f"mark_units must be non-negative: {mark_units}")
-    _validate_created_at(payload.get("created_at", "1970-01-01T00:00:00+00:00"))
+def generate_record(payload: Dict[str, Any]) -> Dict[str, Any]:
+    canonical_input = canonical_json(payload)
+    digest = hashlib.sha256(canonical_input.encode("utf-8")).hexdigest()
 
-    reviewers = payload["reviewers"]
-    if not isinstance(reviewers, list) or len(reviewers) < 1:
-        raise ValueError("reviewers must be a non-empty list of strings")
-    if any(not isinstance(r, str) or not r for r in reviewers):
-        raise ValueError("reviewers entries must be non-empty strings")
+    mark_hash = hashlib.sha256(f"mark:{digest}".encode("utf-8")).hexdigest()
+    job_hash = hashlib.sha256(f"job:{digest}".encode("utf-8")).hexdigest()
+    bundle_hash = hashlib.sha256(f"proof:{digest}".encode("utf-8")).hexdigest()
+    docket_hash = hashlib.sha256(f"docket:{digest}".encode("utf-8")).hexdigest()
 
-
-def build_record(payload: dict) -> dict:
-    _validate_payload(payload)
-    digest = _stable_hash(payload)
-    run_id = f"svr-{digest[:16]}"
-    job_id = f"job-{digest[16:32]}"
-    proof_id = f"pb-{digest[32:48]}"
-    docket_id = f"dkt-{digest[48:64]}"
-    record = {
-        "schema_version": "agialpha.securerails.work_vault_record.v1",
+    return {
+        "schema_version": SCHEMA_VERSION,
         "work_vault": {
             "vault_id": payload["vault_id"],
-            "run_id": run_id,
-            "created_at": payload.get("created_at", "1970-01-01T00:00:00+00:00"),
+            "run_id": _short("svr", digest),
+            "created_at": payload["created_at"],
             "defensive_scope": payload["defensive_scope"],
         },
         "mark_allocation": {
-            "mark_id": f"mark-{digest[:12]}",
+            "mark_id": _short("mark", mark_hash, 12),
             "allocation_units": payload["mark_units"],
             "replay_required": True,
             "human_review_required": True,
@@ -86,28 +52,44 @@ def build_record(payload: dict) -> dict:
             "sovereign_policy": "defensive-remediation-only",
             "reviewers": payload["reviewers"],
         },
-        "agi_job": {"job_id": job_id, "job_type": payload["job_type"], "status": payload["status"]},
-        "proof_bundle": {"proof_bundle_id": proof_id, "sha256": digest},
-        "evidence_docket": {"docket_id": docket_id, "claim_boundary_statement": CLAIM_BOUNDARY},
-        "human_review": {"decision": payload["decision"], "reviewed_by": payload["reviewed_by"]},
-        "utility_settlement": {"receipt_id": f"util-{digest[:20]}", "mode": "$AGIALPHA_UTILITY_ONLY", "real_transfer": False},
+        "agi_job": {
+            "job_id": _short("job", job_hash),
+            "job_type": payload["job_type"],
+            "status": payload["status"],
+        },
+        "proof_bundle": {
+            "proof_bundle_id": _short("pb", bundle_hash, 17),
+            "sha256": hashlib.sha256(
+                f"{mark_hash}:{job_hash}:{bundle_hash}:{docket_hash}".encode("utf-8")
+            ).hexdigest(),
+        },
+        "evidence_docket": {
+            "docket_id": _short("dkt", docket_hash),
+            "claim_boundary_statement": CLAIM_BOUNDARY,
+        },
+        "human_review": {
+            "decision": payload["decision"],
+            "reviewed_by": payload["reviewed_by"],
+        },
+        "utility_settlement": {
+            "receipt_id": _short("util", digest, 20),
+            "mode": "$AGIALPHA_UTILITY_ONLY",
+            "real_transfer": False,
+        },
     }
-    return record
 
 
-def main() -> int:
-    p = argparse.ArgumentParser()
-    p.add_argument("--input", required=True)
-    p.add_argument("--output", required=True)
-    args = p.parse_args()
-    with open(args.input, "r", encoding="utf-8") as f:
-        payload = json.load(f)
-    record = build_record(payload)
-    with open(args.output, "w", encoding="utf-8") as f:
-        json.dump(record, f, indent=2, sort_keys=True)
-        f.write("\n")
-    return 0
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    record = generate_record(payload)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -38,7 +38,8 @@ def _require_non_empty_string(payload: Dict[str, Any], key: str) -> str:
 
 def _validate_created_at(value: str) -> str:
     try:
-        parsed = datetime.fromisoformat(value)
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
     except ValueError as exc:
         raise ValueError("created_at must be an ISO 8601 date-time string") from exc
     if parsed.tzinfo is None:

--- a/scripts/secure_rails_work_vault_pipeline.py
+++ b/scripts/secure_rails_work_vault_pipeline.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
@@ -14,6 +15,10 @@ CLAIM_BOUNDARY = (
     "Autonomous evidence production is allowed; autonomous claim promotion is not."
 )
 SCHEMA_VERSION = "agialpha.securerails.work_vault_record.v1"
+DEFAULT_CREATED_AT = "1970-01-01T00:00:00+00:00"
+JOB_TYPES = {"defensive_remediation", "defensive_triage", "defensive_validation"}
+JOB_STATUSES = {"completed", "rejected", "escalated"}
+REVIEW_DECISIONS = {"safe_remediation", "reject", "escalate"}
 
 
 def canonical_json(data: Dict[str, Any]) -> str:
@@ -24,10 +29,70 @@ def _short(prefix: str, material: str, length: int = 16) -> str:
     return f"{prefix}-{material[:length]}"
 
 
+def _require_non_empty_string(payload: Dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _validate_created_at(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("created_at must be an ISO 8601 date-time string") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("created_at must include timezone offset")
+    return value
+
+
+def validate_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    validated = {
+        "vault_id": _require_non_empty_string(payload, "vault_id"),
+        "defensive_scope": _require_non_empty_string(payload, "defensive_scope"),
+        "sovereign_id": _require_non_empty_string(payload, "sovereign_id"),
+        "reviewed_by": _require_non_empty_string(payload, "reviewed_by"),
+    }
+
+    created_at = payload.get("created_at", DEFAULT_CREATED_AT)
+    if not isinstance(created_at, str):
+        raise ValueError("created_at must be a string when provided")
+    validated["created_at"] = _validate_created_at(created_at)
+
+    mark_units = payload.get("mark_units")
+    if isinstance(mark_units, bool) or not isinstance(mark_units, int) or mark_units < 0:
+        raise ValueError("mark_units must be an integer >= 0")
+    validated["mark_units"] = mark_units
+
+    job_type = payload.get("job_type")
+    if job_type not in JOB_TYPES:
+        raise ValueError(f"job_type must be one of {sorted(JOB_TYPES)}")
+    validated["job_type"] = job_type
+
+    status = payload.get("status")
+    if status not in JOB_STATUSES:
+        raise ValueError(f"status must be one of {sorted(JOB_STATUSES)}")
+    validated["status"] = status
+
+    decision = payload.get("decision")
+    if decision not in REVIEW_DECISIONS:
+        raise ValueError(f"decision must be one of {sorted(REVIEW_DECISIONS)}")
+    validated["decision"] = decision
+
+    reviewers = payload.get("reviewers")
+    if not isinstance(reviewers, list) or not reviewers:
+        raise ValueError("reviewers must be a non-empty list")
+    if not all(isinstance(r, str) and r.strip() for r in reviewers):
+        raise ValueError("reviewers entries must be non-empty strings")
+    validated["reviewers"] = reviewers
+
+    return validated
+
+
 def generate_record(payload: Dict[str, Any]) -> Dict[str, Any]:
+    payload = validate_payload(payload)
     canonical_input = canonical_json(payload)
     digest = hashlib.sha256(canonical_input.encode("utf-8")).hexdigest()
-
     mark_hash = hashlib.sha256(f"mark:{digest}".encode("utf-8")).hexdigest()
     job_hash = hashlib.sha256(f"job:{digest}".encode("utf-8")).hexdigest()
     bundle_hash = hashlib.sha256(f"proof:{digest}".encode("utf-8")).hexdigest()
@@ -52,30 +117,14 @@ def generate_record(payload: Dict[str, Any]) -> Dict[str, Any]:
             "sovereign_policy": "defensive-remediation-only",
             "reviewers": payload["reviewers"],
         },
-        "agi_job": {
-            "job_id": _short("job", job_hash),
-            "job_type": payload["job_type"],
-            "status": payload["status"],
-        },
+        "agi_job": {"job_id": _short("job", job_hash), "job_type": payload["job_type"], "status": payload["status"]},
         "proof_bundle": {
             "proof_bundle_id": _short("pb", bundle_hash, 17),
-            "sha256": hashlib.sha256(
-                f"{mark_hash}:{job_hash}:{bundle_hash}:{docket_hash}".encode("utf-8")
-            ).hexdigest(),
+            "sha256": hashlib.sha256(f"{mark_hash}:{job_hash}:{bundle_hash}:{docket_hash}".encode("utf-8")).hexdigest(),
         },
-        "evidence_docket": {
-            "docket_id": _short("dkt", docket_hash),
-            "claim_boundary_statement": CLAIM_BOUNDARY,
-        },
-        "human_review": {
-            "decision": payload["decision"],
-            "reviewed_by": payload["reviewed_by"],
-        },
-        "utility_settlement": {
-            "receipt_id": _short("util", digest, 20),
-            "mode": "$AGIALPHA_UTILITY_ONLY",
-            "real_transfer": False,
-        },
+        "evidence_docket": {"docket_id": _short("dkt", docket_hash), "claim_boundary_statement": CLAIM_BOUNDARY},
+        "human_review": {"decision": payload["decision"], "reviewed_by": payload["reviewed_by"]},
+        "utility_settlement": {"receipt_id": _short("util", digest, 20), "mode": "$AGIALPHA_UTILITY_ONLY", "real_transfer": False},
     }
 
 

--- a/tests/test_secure_rails_work_vault.py
+++ b/tests/test_secure_rails_work_vault.py
@@ -1,0 +1,31 @@
+import json
+
+from scripts.secure_rails_work_vault_pipeline import CLAIM_BOUNDARY, generate_record
+
+
+def test_work_vault_pipeline_is_deterministic(tmp_path):
+    payload = {
+        "vault_id": "vault-defensive-001",
+        "defensive_scope": "repo-owned defensive remediation planning",
+        "job_type": "defensive_remediation",
+        "mark_units": 42,
+        "sovereign_id": "sovereign-defensive-alpha",
+        "reviewers": ["human.security.reviewer"],
+        "status": "completed",
+        "decision": "safe_remediation",
+        "reviewed_by": "human.security.reviewer",
+        "created_at": "2026-05-03T00:00:00+00:00",
+    }
+
+    first = generate_record(payload)
+    second = generate_record(dict(payload))
+
+    assert first == second
+    assert first["evidence_docket"]["claim_boundary_statement"] == CLAIM_BOUNDARY
+    assert first["utility_settlement"]["real_transfer"] is False
+
+
+def test_sample_output_matches_generator():
+    payload = json.loads(open("sample_outputs/secure_rails_work_vault/sample_input.json", encoding="utf-8").read())
+    expected = json.loads(open("sample_outputs/secure_rails_work_vault/sample_work_vault_run.json", encoding="utf-8").read())
+    assert generate_record(payload) == expected

--- a/tests/test_secure_rails_work_vault_pipeline.py
+++ b/tests/test_secure_rails_work_vault_pipeline.py
@@ -132,6 +132,30 @@ class TestSecureRailsWorkVaultPipeline(unittest.TestCase):
             ], capture_output=True, text=True)
             self.assertNotEqual(res.returncode, 0)
 
+
+    def test_accepts_created_at_with_z_timezone(self):
+        payload = {
+            "vault_id": "vault-z",
+            "defensive_scope": "scope",
+            "job_type": "defensive_validation",
+            "mark_units": 1,
+            "sovereign_id": "sovereign-z",
+            "reviewers": ["r1"],
+            "status": "completed",
+            "decision": "safe_remediation",
+            "reviewed_by": "r1",
+            "created_at": "2026-05-03T00:00:00Z",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            inp = Path(td) / "in.json"
+            out = Path(td) / "out.json"
+            inp.write_text(json.dumps(payload), encoding="utf-8")
+            res = subprocess.run([
+                "python", "scripts/secure_rails_work_vault_pipeline.py",
+                "--input", str(inp), "--output", str(out),
+            ], capture_output=True, text=True)
+            self.assertEqual(res.returncode, 0)
+
     def test_rejects_invalid_created_at(self):
         payload = {
             "vault_id": "vault-x",


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable pipeline that converts Work Vault inputs into a full SecureRails governance record (MARK allocation, Sovereign assignment, AGI Job, ProofBundle, Evidence Docket, human review, and a utility-only settlement receipt) so runs are replayable and reviewable.
- Make SecureRails visible and executable as the AI-agent security governance layer while preserving claim boundaries and safety constraints (no token/blockchain behavior, no offensive cyber actions, and $AGIALPHA framed as utility-only).

### Description
- Added `scripts/secure_rails_work_vault_pipeline.py` which canonicalizes input JSON, computes stable hashes, and generates a full work-vault record including `work_vault`, `mark_allocation`, `sovereign_assignment`, `agi_job`, `proof_bundle`, `evidence_docket`, `human_review`, and `utility_settlement` fields.
- Added schema files for the protocol entities under `schemas/` (including `secure_rails_work_vault.schema.json` and related per-entity schema stubs) and updated the sample artifact `sample_outputs/secure_rails_work_vault/sample_work_vault_run.json` to match deterministic output.
- Added tests `tests/test_secure_rails_work_vault.py` that validate determinism (repeated generation yields identical records) and that the generator reproduces the sample artifact exactly.
- Preserved and enforced the claim boundary text and utility-only settlement mode (`$AGIALPHA_UTILITY_ONLY` with `real_transfer: false`) in generated records and schemas.

### Testing
- Ran the pipeline to generate the sample output with `python scripts/secure_rails_work_vault_pipeline.py --input sample_outputs/secure_rails_work_vault/sample_input.json --output sample_outputs/secure_rails_work_vault/sample_work_vault_run.json` which completed successfully.
- Executed `pytest -q tests/test_secure_rails_work_vault.py` and the tests passed (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f784cd0fac8333a767a471e4cf232c)