### PR TITLE
Add SecureRails Work Vault request schema and Mission Control ingest guidance

### DIFF
--- a/docs/EVIDENCE_MISSION_CONTROL.md
+++ b/docs/EVIDENCE_MISSION_CONTROL.md
@@ -23,5 +23,23 @@ Current as of 2026-05-01.
 - [Workflow Launchpad](../WORKFLOW_LAUNCHPAD.md)
 - [Claim boundary](../CLAIM_BOUNDARY.md)
 
+## SecureRails Work Vault ingest
+
+When a SecureRails Work Vault run is produced, ingest the deterministic output record into Mission Control with these pointers:
+
+- Work Vault run: `work_vault.run_id`
+- Vault scope: `work_vault.defensive_scope`
+- MARK allocation: `mark_allocation.mark_id`
+- Sovereign assignment: `sovereign_assignment.sovereign_id`
+- AGI job + state: `agi_job.job_id`, `agi_job.status`
+- Proof reference: `proof_bundle.proof_bundle_id`, `proof_bundle.sha256`
+- Evidence docket reference: `evidence_docket.docket_id`
+- Human review gate: `human_review.decision`, `human_review.reviewed_by`
+- Utility receipt: `utility_settlement.receipt_id`
+
+Operator rule: if `evidence_docket` is absent or malformed, reject ingest and do not promote remediation.
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.

--- a/docs/secure-rails/work-vaults-mark-sovereigns.md
+++ b/docs/secure-rails/work-vaults-mark-sovereigns.md
@@ -70,12 +70,9 @@ Suggested integration fields:
 
 ## Reference artifacts
 
-- `schemas/secure_rails_work_vault.schema.json`
-- `schemas/secure_rails_mark_allocation.schema.json`
-- `schemas/secure_rails_sovereign_assignment.schema.json`
-- `schemas/secure_rails_job_record.schema.json`
-- `schemas/secure_rails_proof_bundle.schema.json`
-- `schemas/secure_rails_evidence_docket.schema.json`
-- `schemas/secure_rails_settlement_receipt.schema.json`
+- `schemas/secure_rails_work_vault_record.schema.json`
+- `schemas/secure_rails_work_vault_request.schema.json`
+- `sample_outputs/secure_rails_work_vault/sample_input.json`
 - `sample_outputs/secure_rails_work_vault/sample_work_vault_run.json`
 - `scripts/secure_rails_work_vault_pipeline.py`
+- `tests/test_secure_rails_work_vault_pipeline.py`

--- a/schemas/secure_rails_work_vault_request.schema.json
+++ b/schemas/secure_rails_work_vault_request.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SecureRails Work Vault Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "vault_id",
+    "defensive_scope",
+    "job_type",
+    "mark_units",
+    "sovereign_id",
+    "reviewers",
+    "status",
+    "decision",
+    "reviewed_by"
+  ],
+  "properties": {
+    "vault_id": {"type": "string", "minLength": 1},
+    "defensive_scope": {"type": "string", "minLength": 1},
+    "job_type": {
+      "type": "string",
+      "enum": ["defensive_remediation", "defensive_triage", "defensive_validation"]
+    },
+    "mark_units": {"type": "integer", "minimum": 0},
+    "sovereign_id": {"type": "string", "minLength": 1},
+    "reviewers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "status": {"type": "string", "enum": ["completed", "rejected", "escalated"]},
+    "decision": {"type": "string", "enum": ["safe_remediation", "reject", "escalate"]},
+    "reviewed_by": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "format": "date-time"}
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a formal, deterministic input schema for SecureRails Work Vault runs so pipeline inputs (MARK allocation, Sovereign assignment, AGI job metadata, human-review gates) are auditable and machine-validated. 
- Bridge SecureRails outputs into Evidence Mission Control so operators can ingest run IDs, MARKs, Sovereigns, ProofBundles, Evidence Dockets, human-review decisions, and utility receipts for evidence indexing and operator workflows. 
- Preserve the SecureRails claim/boundary constraints and the `$AGIALPHA` utility-only framing to avoid any financial or overclaim semantics. 

### Description
- Add `schemas/secure_rails_work_vault_request.schema.json` to formalize required request fields, defensive-only enums, non-negative `mark_units`, reviewer lists, and optional RFC3339 `created_at` timestamp. 
- Update `docs/secure-rails/work-vaults-mark-sovereigns.md` to reference the actual implemented artifacts in-repo (work vault record schema, request schema, sample input, pipeline script, and pipeline tests) and remove references to non-existent schema names. 
- Extend `docs/EVIDENCE_MISSION_CONTROL.md` with explicit SecureRails Work Vault ingest guidance mapping keys such as `work_vault.run_id`, `mark_allocation.mark_id`, `sovereign_assignment.sovereign_id`, `proof_bundle.proof_bundle_id`, `evidence_docket.docket_id`, `human_review.decision`, and `utility_settlement.receipt_id`, and add an operator rule to reject ingest if the evidence docket is absent/malformed. 
- No runtime token transfers, blockchain connections, offensive capabilities, automated merges, or claim-promotion behaviors were added. 

### Testing
- Ran `pytest -q tests/test_secure_rails_work_vault_pipeline.py tests/test_docs_relative_links.py tests/test_docs_links.py`, and all tests passed (`13 passed`). 
- The SecureRails work vault pipeline unit tests validate deterministic output hashing, RFC3339 `created_at` handling, enum validation, and sample-run consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f784cd0fac8333a767a471e4cf232c)