### PR TITLE
Implement SecureRails Work Vaults, MARK allocation, and Sovereigns

### DIFF
--- a/.github/workflows/securerails-work-vault-demo.yml
+++ b/.github/workflows/securerails-work-vault-demo.yml
@@ -1,0 +1,22 @@
+name: SecureRails Work Vault Demo
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m agialpha_securerails create-vault --repo-root . --out securerails-runs/demo
+      - run: python -m agialpha_securerails validate-vault --vault securerails-runs/demo/work-vault.json
+      - run: python scripts/secure_rails_safety_ledger_check.py securerails-runs/demo/safety-ledger.json
+      - run: python scripts/secure_rails_claim_boundary_check.py .
+      - run: python -m agialpha_securerails render --run securerails-runs/demo --out docs/secure-rails/work-vaults-demo
+      - uses: actions/upload-artifact@v4
+        with:
+          name: securerails-work-vault-demo
+          path: securerails-runs/demo

--- a/README.md
+++ b/README.md
@@ -177,3 +177,17 @@ If you prefer not to run commands locally:
 ## License
 
 Distributed under the terms in `LICENSE`.
+
+
+### SecureRails Work Vaults, MARK, and Sovereigns
+
+SecureRails routes agentic work through three governance primitives:
+
+```text
+Work Vaults → ALPHA AGI MARK → ALPHA AGI Sovereigns
+```
+
+Read more:
+
+* [SecureRails Work Vaults, MARK, and Sovereigns](docs/secure-rails/work-vaults-mark-sovereigns.md)
+* [SecureRails Work Vaults Operator Guide](docs/secure-rails/work-vaults-operator-guide.md)

--- a/agialpha_securerails/__init__.py
+++ b/agialpha_securerails/__init__.py
@@ -1,0 +1,1 @@
+from .cli import main

--- a/agialpha_securerails/__main__.py
+++ b/agialpha_securerails/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+if __name__=="__main__":
+    main()

--- a/agialpha_securerails/agi_jobs.py
+++ b/agialpha_securerails/agi_jobs.py
@@ -1,0 +1,3 @@
+import json,os
+def run_job(out_dir,vault):
+ o={"job_id":"job-demo-001","vault_id":vault["vault_id"],"status":"completed","task":"workflow permission review"};json.dump(o,open(os.path.join(out_dir,"agi-job.json"),"w"),indent=2);return o

--- a/agialpha_securerails/capability_archive.py
+++ b/agialpha_securerails/capability_archive.py
@@ -1,0 +1,3 @@
+import json,os
+def make_archive(out_dir,vault):
+ o={"schema_version":"1.0.0","entry_id":"capability-demo-001","vault_id":vault["vault_id"],"capability":"workflow permission defensive review","vnext_reuse_status":"queued"};json.dump(o,open(os.path.join(out_dir,"capability-archive-entry.json"),"w"),indent=2);return o

--- a/agialpha_securerails/claim_boundary.py
+++ b/agialpha_securerails/claim_boundary.py
@@ -1,0 +1,1 @@
+CLAIM_BOUNDARY = "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."

--- a/agialpha_securerails/cli.py
+++ b/agialpha_securerails/cli.py
@@ -25,7 +25,7 @@ def main():
   json.dump(v['hard_safety_counters'],open(os.path.join(out,'safety-ledger.json'),'w'),indent=2)
   make_settlement(out,v);make_archive(out,v)
   open(os.path.join(out,'README.md'),'w').write('SecureRails deterministic demo artifacts. Utility accounting only.\n')
-  manifest={"experiment_slug":"securerails-work-vault-demo","experiment_family":"securerails","claim_level":"local-demo","claim_boundary":v['claim_boundary'],"public_page":"docs/secure-rails/work-vaults-demo/README.md","raw_json_links":[f for f in os.listdir(out) if f.endswith('.json')],"safety_counters":v['hard_safety_counters']}
+  manifest={"experiment_slug":"securerails-work-vault-demo","experiment_family":"securerails","claim_level":"local-demo","claim_boundary":v['claim_boundary'],"public_page":"docs/secure-rails/work-vaults-demo/README.md","raw_json_links":sorted(f for f in os.listdir(out) if f.endswith('.json')),"safety_counters":v['hard_safety_counters']}
   json.dump(manifest,open(os.path.join(out,'evidence-run-manifest.json'),'w'),indent=2)
  if args.cmd=='score-mark': score_mark(os.path.dirname(args.vault),_load(args.vault))
  if args.cmd=='assign-sovereign': assign_sovereign(os.path.dirname(args.vault))

--- a/agialpha_securerails/cli.py
+++ b/agialpha_securerails/cli.py
@@ -1,0 +1,35 @@
+import argparse, json, os
+from .work_vaults import create_work_vault
+from .mark import score_mark
+from .sovereigns import assign_sovereign
+from .agi_jobs import run_job
+from .proofbundles import make_proofbundle
+from .evidence_dockets import make_evidence_docket
+from .settlement import make_settlement
+from .capability_archive import make_archive
+from .validators import validate_vault
+from .render import render
+
+def _load(p): return json.load(open(p))
+def main():
+ p=argparse.ArgumentParser();sp=p.add_subparsers(dest='cmd',required=True)
+ a=sp.add_parser('create-vault');a.add_argument('--repo-root');a.add_argument('--out',required=True)
+ b=sp.add_parser('score-mark');b.add_argument('--vault',required=True)
+ c=sp.add_parser('assign-sovereign');c.add_argument('--vault',required=True)
+ d=sp.add_parser('run-demo-job');d.add_argument('--vault',required=True)
+ e=sp.add_parser('validate-vault');e.add_argument('--vault',required=True)
+ f=sp.add_parser('render');f.add_argument('--run',required=True);f.add_argument('--out',required=True)
+ args=p.parse_args()
+ if args.cmd=='create-vault':
+  out=args.out;v=create_work_vault(out);m=score_mark(out,v);assign_sovereign(out);run_job(out,v);make_proofbundle(out,v);make_evidence_docket(out,v);
+  json.dump(v['hard_safety_counters'],open(os.path.join(out,'safety-ledger.json'),'w'),indent=2)
+  make_settlement(out,v);make_archive(out,v)
+  open(os.path.join(out,'README.md'),'w').write('SecureRails deterministic demo artifacts. Utility accounting only.\n')
+  manifest={"experiment_slug":"securerails-work-vault-demo","experiment_family":"securerails","claim_level":"local-demo","claim_boundary":v['claim_boundary'],"public_page":"docs/secure-rails/work-vaults-demo/README.md","raw_json_links":[f for f in os.listdir(out) if f.endswith('.json')],"safety_counters":v['hard_safety_counters']}
+  json.dump(manifest,open(os.path.join(out,'evidence-run-manifest.json'),'w'),indent=2)
+ if args.cmd=='score-mark': score_mark(os.path.dirname(args.vault),_load(args.vault))
+ if args.cmd=='assign-sovereign': assign_sovereign(os.path.dirname(args.vault))
+ if args.cmd=='run-demo-job': v=_load(args.vault);run_job(os.path.dirname(args.vault),v);make_proofbundle(os.path.dirname(args.vault),v);make_evidence_docket(os.path.dirname(args.vault),v);make_settlement(os.path.dirname(args.vault),v);make_archive(os.path.dirname(args.vault),v)
+ if args.cmd=='validate-vault':
+  ok=validate_vault(_load(args.vault));print('valid' if ok else 'invalid');raise SystemExit(0 if ok else 1)
+ if args.cmd=='render': render(args.run,args.out)

--- a/agialpha_securerails/evidence_dockets.py
+++ b/agialpha_securerails/evidence_dockets.py
@@ -1,0 +1,4 @@
+import json,os
+from .claim_boundary import CLAIM_BOUNDARY
+def make_evidence_docket(out_dir,vault):
+ o={"evidence_docket_id":"evidence-docket-demo-001","vault_id":vault["vault_id"],"human_review_status":"required","claim_boundary":CLAIM_BOUNDARY};json.dump(o,open(os.path.join(out_dir,"evidence-docket.json"),"w"),indent=2);return o

--- a/agialpha_securerails/mark.py
+++ b/agialpha_securerails/mark.py
@@ -1,0 +1,5 @@
+import json,os
+from .claim_boundary import CLAIM_BOUNDARY
+def score_mark(out_dir,vault):
+    obj={"schema_version":"1.0.0","allocation_id":"mark-demo-001","vault_id":vault["vault_id"],"opportunity_id":"opportunity-workflow-permission-001","assigned_sovereign":vault["assigned_sovereign"],"risk_tier":"low","review_priority":"high","allocated_budget_proxy":100,"utility_asset":"$AGIALPHA","proof_required":True,"replay_required":True,"falsification_required":True,"human_review_required":True,"auto_merge_allowed":False,"promotion_without_evidence_allowed":False,"validators_required":2,"rejection_reason_if_any":"","claim_boundary":CLAIM_BOUNDARY}
+    json.dump(obj,open(os.path.join(out_dir,'mark-allocation.json'),'w'),indent=2);return obj

--- a/agialpha_securerails/proofbundles.py
+++ b/agialpha_securerails/proofbundles.py
@@ -1,0 +1,3 @@
+import json,os
+def make_proofbundle(out_dir,vault):
+ o={"proofbundle_id":"proofbundle-demo-001","vault_id":vault["vault_id"],"replay_status":"replayable"};json.dump(o,open(os.path.join(out_dir,"proofbundle.json"),"w"),indent=2);return o

--- a/agialpha_securerails/render.py
+++ b/agialpha_securerails/render.py
@@ -1,0 +1,23 @@
+import os,json
+def render(run_dir,out_dir):
+ os.makedirs(out_dir,exist_ok=True)
+ v=json.load(open(os.path.join(run_dir,'work-vault.json')));m=json.load(open(os.path.join(run_dir,'mark-allocation.json')));s=json.load(open(os.path.join(run_dir,'settlement-receipt.json')))
+ html=f"""# SecureRails Work Vaults
+
+- Vault ID: {v['vault_id']}
+- Status: {v['status']}
+- Assigned Sovereign: {v['assigned_sovereign']}
+- MARK allocation: {m['allocation_id']}
+- Risk tier: {m['risk_tier']}
+- Replay status: replayable
+- Safety status: clean
+- Human review status: required
+- Safe PR status: not merged
+- $AGIALPHA utility budget: {m['allocated_budget_proxy']}
+- Settlement status: {s['status']}
+- Capability archived: yes
+- vNext reuse status: queued
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+"""
+ open(os.path.join(out_dir,'README.md'),'w').write(html)

--- a/agialpha_securerails/render.py
+++ b/agialpha_securerails/render.py
@@ -1,7 +1,21 @@
 import os,json
+from .safety import HARD_COUNTERS
+
+def _safety_status(run_dir):
+    ledger_path=os.path.join(run_dir,'safety-ledger.json')
+    counters=json.load(open(ledger_path)) if os.path.exists(ledger_path) else {}
+    missing=[k for k in HARD_COUNTERS if k not in counters]
+    nonzero={k:v for k,v in counters.items() if k in HARD_COUNTERS and v!=0}
+    if missing:
+        return f"incomplete ({len(missing)} missing counters)"
+    if nonzero:
+        return f"violations ({len(nonzero)} non-zero counters)"
+    return "clean"
+
 def render(run_dir,out_dir):
  os.makedirs(out_dir,exist_ok=True)
  v=json.load(open(os.path.join(run_dir,'work-vault.json')));m=json.load(open(os.path.join(run_dir,'mark-allocation.json')));s=json.load(open(os.path.join(run_dir,'settlement-receipt.json')))
+ safety_status=_safety_status(run_dir)
  html=f"""# SecureRails Work Vaults
 
 - Vault ID: {v['vault_id']}
@@ -10,7 +24,7 @@ def render(run_dir,out_dir):
 - MARK allocation: {m['allocation_id']}
 - Risk tier: {m['risk_tier']}
 - Replay status: replayable
-- Safety status: clean
+- Safety status: {safety_status}
 - Human review status: required
 - Safe PR status: not merged
 - $AGIALPHA utility budget: {m['allocated_budget_proxy']}

--- a/agialpha_securerails/safety.py
+++ b/agialpha_securerails/safety.py
@@ -1,0 +1,1 @@
+HARD_COUNTERS=["raw_secret_leak_count","external_target_scan_count","exploit_execution_count","malware_generation_count","social_engineering_content_count","unsafe_automerge_count","critical_safety_incidents"]

--- a/agialpha_securerails/settlement.py
+++ b/agialpha_securerails/settlement.py
@@ -1,0 +1,5 @@
+import json,os
+from .claim_boundary import CLAIM_BOUNDARY
+def make_settlement(out_dir,vault):
+ o={"schema_version":"1.0.0","settlement_id":"settlement-demo-001","vault_id":vault["vault_id"],"utility_asset":"$AGIALPHA","settlement_type":"utility-accounting-only","status":"recorded","alpha_work_units":100,"validator_fee":20,"replay_fee":10,"safety_review_fee":10,"human_review_fee":20,"unused_refund":40,"slashing_event":False,"evidence_docket_id":"evidence-docket-demo-001","proofbundle_id":"proofbundle-demo-001","human_review_status":"required","claim_boundary":CLAIM_BOUNDARY,"notice":"This settlement receipt records utility accounting for validated protocol work. It is not equity, debt, yield, dividend, ownership, profit right, guaranteed appreciation, or investment return."}
+ json.dump(o,open(os.path.join(out_dir,'settlement-receipt.json'),'w'),indent=2);return o

--- a/agialpha_securerails/sovereigns.py
+++ b/agialpha_securerails/sovereigns.py
@@ -1,0 +1,5 @@
+import json,os
+from .claim_boundary import CLAIM_BOUNDARY
+def assign_sovereign(out_dir):
+ o={"schema_version":"1.0.0","sovereign_id":"sovereign-workflow-permission-001","sovereign_name":"Workflow Permission Sovereign","domain":"SecureRails","task_family":"workflow_permission_review","allowed_work":["repo-owned workflow permission review"],"forbidden_work":["offensive cyber","external scanning","exploit execution"],"validators":["policy-validator","replay-validator"],"proofbundle_policy":{"required":True},"evidence_docket_policy":{"required":True},"promotion_policy":{"autonomous_promotion_allowed":False,"human_review_required":True,"auto_merge_allowed":False},"archive_policy":{"enabled":True},"claim_boundary":CLAIM_BOUNDARY}
+ json.dump(o,open(os.path.join(out_dir,'sovereign.json'),'w'),indent=2);return o

--- a/agialpha_securerails/validators.py
+++ b/agialpha_securerails/validators.py
@@ -1,3 +1,12 @@
-import json
+from .safety import HARD_COUNTERS
+
 def validate_vault(v):
- return v["hard_safety_counters"]["external_target_scan_count"]==0 and v.get("claim_boundary")
+    counters = v.get("hard_safety_counters", {})
+    if not v.get("claim_boundary"):
+        return False
+    for key in HARD_COUNTERS:
+        if key not in counters:
+            return False
+        if counters[key] != 0:
+            return False
+    return True

--- a/agialpha_securerails/validators.py
+++ b/agialpha_securerails/validators.py
@@ -1,0 +1,3 @@
+import json
+def validate_vault(v):
+ return v["hard_safety_counters"]["external_target_scan_count"]==0 and v.get("claim_boundary")

--- a/agialpha_securerails/work_vaults.py
+++ b/agialpha_securerails/work_vaults.py
@@ -1,0 +1,10 @@
+import json, os
+from .claim_boundary import CLAIM_BOUNDARY
+from .safety import HARD_COUNTERS
+
+def create_work_vault(out_dir):
+    os.makedirs(out_dir,exist_ok=True)
+    counters={k:0 for k in HARD_COUNTERS}
+    vault={"schema_version":"1.0.0","vault_id":"vault-demo-001","vault_type":"workflow_permission_review","status":"proposed","created_at":"2026-05-03T00:00:00Z","operator":"agialpha_securerails","scope":{"repo_owned":True},"utility":{"asset":"$AGIALPHA","budget_proxy":100},"mark_allocation":"mark-demo-001","assigned_sovereign":"sovereign-workflow-permission-001","validators":["policy-validator","replay-validator"],"hard_safety_counters":counters,"evidence":{"proofbundle_id":"proofbundle-demo-001","evidence_docket_id":"evidence-docket-demo-001"},"settlement":{"settlement_id":"settlement-demo-001","status":"pending"},"archive":{"capability_entry_id":"capability-demo-001"},"claim_boundary":CLAIM_BOUNDARY}
+    json.dump(vault,open(os.path.join(out_dir,'work-vault.json'),'w'),indent=2)
+    return vault

--- a/config/securerails_mark_policy.json
+++ b/config/securerails_mark_policy.json
@@ -1,0 +1,6 @@
+{
+  "human_review_required": true,
+  "auto_merge_allowed": false,
+  "utility_only": true,
+  "no_offensive_cyber": true
+}

--- a/config/securerails_sovereign_policy.json
+++ b/config/securerails_sovereign_policy.json
@@ -1,0 +1,6 @@
+{
+  "human_review_required": true,
+  "auto_merge_allowed": false,
+  "utility_only": true,
+  "no_offensive_cyber": true
+}

--- a/config/securerails_work_vault_policy.json
+++ b/config/securerails_work_vault_policy.json
@@ -1,0 +1,6 @@
+{
+  "human_review_required": true,
+  "auto_merge_allowed": false,
+  "utility_only": true,
+  "no_offensive_cyber": true
+}

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -132,3 +132,5 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 | `agiga-foundry-001-policy-pr.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `agiga-foundry-001-safe-policy-pr.yml` | See [HOW_TO_RUN_WORKFLOW.md](HOW_TO_RUN_WORKFLOW.md) | no |
 | `secure-rails-compliance-guard.yml` | SecureRails CI-level compliance guard: enforces claim-boundary, no-auto-merge, safety-ledger, and EU AI Act use-case triage. | no |
+
+| `securerails-work-vault-demo.yml` | SecureRails / Work Vaults / governance: deterministic demo of Work Vault → MARK → Sovereign → ProofBundle → Evidence Docket → settlement receipt → capability archive; trigger pull_request/workflow_dispatch; claim boundary utility accounting only; no security assurance certificate; no investment product. | no |

--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -363,3 +363,5 @@ This is an enforcement layer, not a certification claim.
 ## Final boundary
 
 SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+
+* [Work Vaults operator guide](work-vaults-operator-guide.md)

--- a/docs/secure-rails/work-vaults-demo/README.md
+++ b/docs/secure-rails/work-vaults-demo/README.md
@@ -1,0 +1,17 @@
+# SecureRails Work Vaults
+
+- Vault ID: vault-demo-001
+- Status: proposed
+- Assigned Sovereign: sovereign-workflow-permission-001
+- MARK allocation: mark-demo-001
+- Risk tier: low
+- Replay status: replayable
+- Safety status: clean
+- Human review status: required
+- Safe PR status: not merged
+- $AGIALPHA utility budget: 100
+- Settlement status: recorded
+- Capability archived: yes
+- vNext reuse status: queued
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.

--- a/docs/secure-rails/work-vaults-mark-sovereigns.md
+++ b/docs/secure-rails/work-vaults-mark-sovereigns.md
@@ -1,81 +1,11 @@
-# SecureRails Work Vaults, ALPHA AGI MARK, and ALPHA AGI Sovereigns
+# SecureRails Work Vaults, MARK, and Sovereigns
 
-SecureRails Work Vaults are the protocol boundary that converts AI-agent defensive work into auditable, human-governed remediation decisions.
+A Work Vault is not a bank account, investment vehicle, fund, yield product, profit pool, ownership claim, or financial product.
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
 
-## Scope and boundary
+AI-agent work event → SecureRails Work Vault → ALPHA AGI MARK allocation → ALPHA AGI Sovereign assignment → AGI Job execution → ProofBundle → Evidence Docket → validator decision → safe remediation / rejection / escalation → $AGIALPHA utility settlement → CyberSecurityCapabilityArchive → vNext defensive work
 
-SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity assurance or attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+Lifecycle: proposed → MARK_scored → vault_opened → sovereign_assigned → job_started → proof_submitted → validator_review → evidence_docket_created → human_review → accepted / rejected / escalated → settled → archived → vNext_reuse_tested
 
-All outputs are advisory and require independent human validation before action.
-
-$AGIALPHA in this protocol is utility infrastructure for protocol operations only. It is not investment, equity, yield, dividend, appreciation, ownership, or a financial product claim.
-
-## Lifecycle
-
-```text
-SecureRails Work Vault
-→ ALPHA AGI MARK allocation
-→ ALPHA AGI Sovereign assignment
-→ AGI Job execution
-→ ProofBundle production
-→ Evidence Docket assembly
-→ Human review decision
-→ Safe remediation / rejection / escalation
-→ $AGIALPHA utility settlement receipt
-→ Reusable defensive capability archive
-→ vNext defensive work
-```
-
-## Core entities
-
-- **Work Vault**: isolated, deterministic job context with pinned inputs, policy controls, and immutable run IDs.
-- **ALPHA AGI MARK allocation**: governance allocation record that authorizes a bounded defensive job under explicit replay/validator requirements.
-- **ALPHA AGI Sovereign assignment**: assignment of accountable defensive operating policy and reviewers to a vault run.
-- **AGI Job**: deterministic task run that emits artifacts and logs.
-- **ProofBundle**: reproducible evidence package (inputs, outputs, checksums, commands).
-- **Evidence Docket**: claim-bound, reviewer-readable evidence summary and decision record.
-- **Settlement receipt**: protocol utility accounting receipt for operations tracking only (no real transfer).
-
-## Deterministic execution requirements
-
-1. Stable job ID derived from normalized JSON inputs.
-2. Stable ordering for all list/object serialization.
-3. No network or external target scanning required for pipeline validation.
-4. Replay output must hash-identical for identical input.
-5. Human review gates must remain explicit before promotion.
-
-## Safety requirements
-
-- Defensive-only remediation recommendations.
-- No exploit execution, malware creation, secret disclosure, or social engineering.
-- No autonomous merge.
-- No autonomous claim promotion.
-- Reject if Evidence Docket is missing or incomplete.
-
-## Evidence Mission Control integration
-
-Mission Control operators should register each Work Vault run using generated run IDs and docket IDs, then link the docket and ProofBundle in evidence index pages.
-
-Suggested integration fields:
-
-- `work_vault.vault_id`
-- `mark_allocation.mark_id`
-- `sovereign_assignment.sovereign_id`
-- `proof_bundle.proof_bundle_id`
-- `evidence_docket.docket_id`
-- `human_review.decision`
-- `utility_settlement.receipt_id`
-
-## Reference artifacts
-
-- `schemas/secure_rails_work_vault.schema.json`
-- `schemas/secure_rails_mark_allocation.schema.json`
-- `schemas/secure_rails_sovereign_assignment.schema.json`
-- `schemas/secure_rails_job_record.schema.json`
-- `schemas/secure_rails_proof_bundle.schema.json`
-- `schemas/secure_rails_evidence_docket.schema.json`
-- `schemas/secure_rails_settlement_receipt.schema.json`
-- `sample_outputs/secure_rails_work_vault/sample_work_vault_run.json`
-- `scripts/secure_rails_work_vault_pipeline.py`
+Rules: One work event, one vault. No vault, no settlement. No ProofBundle, no Evidence Docket. No Evidence Docket, no strong claim. No human review, no promotion. No auto-merge. No token investment language. Rejections are valuable. Archives compound. Sovereigns remain bounded.

--- a/docs/secure-rails/work-vaults-operator-guide.md
+++ b/docs/secure-rails/work-vaults-operator-guide.md
@@ -1,0 +1,6 @@
+Run:
+python -m agialpha_securerails create-vault --repo-root . --out securerails-runs/demo
+python -m agialpha_securerails validate-vault --vault securerails-runs/demo/work-vault.json
+
+Settlement is utility accounting only and not investment return.
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.

--- a/schemas/securerails_agi_job.schema.json
+++ b/schemas/securerails_agi_job.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "job_id",
+    "vault_id"
+  ],
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "vault_id": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/securerails_capability_archive_entry.schema.json
+++ b/schemas/securerails_capability_archive_entry.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "entry_id",
+    "vault_id"
+  ],
+  "properties": {
+    "entry_id": {
+      "type": "string"
+    },
+    "vault_id": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/securerails_mark_allocation.schema.json
+++ b/schemas/securerails_mark_allocation.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "human_review_required",
+    "auto_merge_allowed",
+    "promotion_without_evidence_allowed"
+  ],
+  "properties": {
+    "human_review_required": {
+      "const": true
+    },
+    "auto_merge_allowed": {
+      "const": false
+    },
+    "promotion_without_evidence_allowed": {
+      "const": false
+    }
+  }
+}

--- a/schemas/securerails_settlement_receipt.schema.json
+++ b/schemas/securerails_settlement_receipt.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "utility_asset",
+    "settlement_type"
+  ],
+  "properties": {
+    "utility_asset": {
+      "type": "string"
+    },
+    "settlement_type": {
+      "type": "string"
+    },
+    "notice": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/securerails_sovereign.schema.json
+++ b/schemas/securerails_sovereign.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "promotion_policy"
+  ],
+  "properties": {
+    "promotion_policy": {
+      "type": "object",
+      "required": [
+        "autonomous_promotion_allowed",
+        "human_review_required",
+        "auto_merge_allowed"
+      ],
+      "properties": {
+        "autonomous_promotion_allowed": {
+          "const": false
+        },
+        "human_review_required": {
+          "const": true
+        },
+        "auto_merge_allowed": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/schemas/securerails_work_vault.schema.json
+++ b/schemas/securerails_work_vault.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "vault_id",
+    "status",
+    "hard_safety_counters",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "vault_id": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "hard_safety_counters": {
+      "type": "object",
+      "required": [
+        "raw_secret_leak_count",
+        "external_target_scan_count",
+        "exploit_execution_count",
+        "malware_generation_count",
+        "social_engineering_content_count",
+        "unsafe_automerge_count",
+        "critical_safety_incidents"
+      ],
+      "properties": {
+        "raw_secret_leak_count": {
+          "type": "number"
+        },
+        "external_target_scan_count": {
+          "type": "number"
+        },
+        "exploit_execution_count": {
+          "type": "number"
+        },
+        "malware_generation_count": {
+          "type": "number"
+        },
+        "social_engineering_content_count": {
+          "type": "number"
+        },
+        "unsafe_automerge_count": {
+          "type": "number"
+        },
+        "critical_safety_incidents": {
+          "type": "number"
+        }
+      }
+    },
+    "claim_boundary": {
+      "type": "string"
+    }
+  }
+}

--- a/securerails-runs/demo/README.md
+++ b/securerails-runs/demo/README.md
@@ -1,0 +1,1 @@
+SecureRails deterministic demo artifacts. Utility accounting only.

--- a/securerails-runs/demo/agi-job.json
+++ b/securerails-runs/demo/agi-job.json
@@ -1,0 +1,6 @@
+{
+  "job_id": "job-demo-001",
+  "vault_id": "vault-demo-001",
+  "status": "completed",
+  "task": "workflow permission review"
+}

--- a/securerails-runs/demo/capability-archive-entry.json
+++ b/securerails-runs/demo/capability-archive-entry.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "1.0.0",
+  "entry_id": "capability-demo-001",
+  "vault_id": "vault-demo-001",
+  "capability": "workflow permission defensive review",
+  "vnext_reuse_status": "queued"
+}

--- a/securerails-runs/demo/evidence-docket.json
+++ b/securerails-runs/demo/evidence-docket.json
@@ -1,0 +1,6 @@
+{
+  "evidence_docket_id": "evidence-docket-demo-001",
+  "vault_id": "vault-demo-001",
+  "human_review_status": "required",
+  "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
+}

--- a/securerails-runs/demo/evidence-run-manifest.json
+++ b/securerails-runs/demo/evidence-run-manifest.json
@@ -1,0 +1,28 @@
+{
+  "experiment_slug": "securerails-work-vault-demo",
+  "experiment_family": "securerails",
+  "claim_level": "local-demo",
+  "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.",
+  "public_page": "docs/secure-rails/work-vaults-demo/README.md",
+  "raw_json_links": [
+    "work-vault.json",
+    "evidence-run-manifest.json",
+    "proofbundle.json",
+    "settlement-receipt.json",
+    "mark-allocation.json",
+    "capability-archive-entry.json",
+    "evidence-docket.json",
+    "sovereign.json",
+    "safety-ledger.json",
+    "agi-job.json"
+  ],
+  "safety_counters": {
+    "raw_secret_leak_count": 0,
+    "external_target_scan_count": 0,
+    "exploit_execution_count": 0,
+    "malware_generation_count": 0,
+    "social_engineering_content_count": 0,
+    "unsafe_automerge_count": 0,
+    "critical_safety_incidents": 0
+  }
+}

--- a/securerails-runs/demo/evidence-run-manifest.json
+++ b/securerails-runs/demo/evidence-run-manifest.json
@@ -5,16 +5,16 @@
   "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.",
   "public_page": "docs/secure-rails/work-vaults-demo/README.md",
   "raw_json_links": [
-    "work-vault.json",
-    "evidence-run-manifest.json",
-    "proofbundle.json",
-    "settlement-receipt.json",
-    "mark-allocation.json",
+    "agi-job.json",
     "capability-archive-entry.json",
     "evidence-docket.json",
-    "sovereign.json",
+    "evidence-run-manifest.json",
+    "mark-allocation.json",
+    "proofbundle.json",
     "safety-ledger.json",
-    "agi-job.json"
+    "settlement-receipt.json",
+    "sovereign.json",
+    "work-vault.json"
   ],
   "safety_counters": {
     "raw_secret_leak_count": 0,

--- a/securerails-runs/demo/mark-allocation.json
+++ b/securerails-runs/demo/mark-allocation.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0.0",
+  "allocation_id": "mark-demo-001",
+  "vault_id": "vault-demo-001",
+  "opportunity_id": "opportunity-workflow-permission-001",
+  "assigned_sovereign": "sovereign-workflow-permission-001",
+  "risk_tier": "low",
+  "review_priority": "high",
+  "allocated_budget_proxy": 100,
+  "utility_asset": "$AGIALPHA",
+  "proof_required": true,
+  "replay_required": true,
+  "falsification_required": true,
+  "human_review_required": true,
+  "auto_merge_allowed": false,
+  "promotion_without_evidence_allowed": false,
+  "validators_required": 2,
+  "rejection_reason_if_any": "",
+  "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
+}

--- a/securerails-runs/demo/proofbundle.json
+++ b/securerails-runs/demo/proofbundle.json
@@ -1,0 +1,5 @@
+{
+  "proofbundle_id": "proofbundle-demo-001",
+  "vault_id": "vault-demo-001",
+  "replay_status": "replayable"
+}

--- a/securerails-runs/demo/safety-ledger.json
+++ b/securerails-runs/demo/safety-ledger.json
@@ -1,0 +1,9 @@
+{
+  "raw_secret_leak_count": 0,
+  "external_target_scan_count": 0,
+  "exploit_execution_count": 0,
+  "malware_generation_count": 0,
+  "social_engineering_content_count": 0,
+  "unsafe_automerge_count": 0,
+  "critical_safety_incidents": 0
+}

--- a/securerails-runs/demo/settlement-receipt.json
+++ b/securerails-runs/demo/settlement-receipt.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0.0",
+  "settlement_id": "settlement-demo-001",
+  "vault_id": "vault-demo-001",
+  "utility_asset": "$AGIALPHA",
+  "settlement_type": "utility-accounting-only",
+  "status": "recorded",
+  "alpha_work_units": 100,
+  "validator_fee": 20,
+  "replay_fee": 10,
+  "safety_review_fee": 10,
+  "human_review_fee": 20,
+  "unused_refund": 40,
+  "slashing_event": false,
+  "evidence_docket_id": "evidence-docket-demo-001",
+  "proofbundle_id": "proofbundle-demo-001",
+  "human_review_status": "required",
+  "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.",
+  "notice": "This settlement receipt records utility accounting for validated protocol work. It is not equity, debt, yield, dividend, ownership, profit right, guaranteed appreciation, or investment return."
+}

--- a/securerails-runs/demo/sovereign.json
+++ b/securerails-runs/demo/sovereign.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1.0.0",
+  "sovereign_id": "sovereign-workflow-permission-001",
+  "sovereign_name": "Workflow Permission Sovereign",
+  "domain": "SecureRails",
+  "task_family": "workflow_permission_review",
+  "allowed_work": [
+    "repo-owned workflow permission review"
+  ],
+  "forbidden_work": [
+    "offensive cyber",
+    "external scanning",
+    "exploit execution"
+  ],
+  "validators": [
+    "policy-validator",
+    "replay-validator"
+  ],
+  "proofbundle_policy": {
+    "required": true
+  },
+  "evidence_docket_policy": {
+    "required": true
+  },
+  "promotion_policy": {
+    "autonomous_promotion_allowed": false,
+    "human_review_required": true,
+    "auto_merge_allowed": false
+  },
+  "archive_policy": {
+    "enabled": true
+  },
+  "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
+}

--- a/securerails-runs/demo/work-vault.json
+++ b/securerails-runs/demo/work-vault.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0.0",
+  "vault_id": "vault-demo-001",
+  "vault_type": "workflow_permission_review",
+  "status": "proposed",
+  "created_at": "2026-05-03T00:00:00Z",
+  "operator": "agialpha_securerails",
+  "scope": {
+    "repo_owned": true
+  },
+  "utility": {
+    "asset": "$AGIALPHA",
+    "budget_proxy": 100
+  },
+  "mark_allocation": "mark-demo-001",
+  "assigned_sovereign": "sovereign-workflow-permission-001",
+  "validators": [
+    "policy-validator",
+    "replay-validator"
+  ],
+  "hard_safety_counters": {
+    "raw_secret_leak_count": 0,
+    "external_target_scan_count": 0,
+    "exploit_execution_count": 0,
+    "malware_generation_count": 0,
+    "social_engineering_content_count": 0,
+    "unsafe_automerge_count": 0,
+    "critical_safety_incidents": 0
+  },
+  "evidence": {
+    "proofbundle_id": "proofbundle-demo-001",
+    "evidence_docket_id": "evidence-docket-demo-001"
+  },
+  "settlement": {
+    "settlement_id": "settlement-demo-001",
+    "status": "pending"
+  },
+  "archive": {
+    "capability_entry_id": "capability-demo-001"
+  },
+  "claim_boundary": "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
+}

--- a/tests/test_securerails_mark_allocation.py
+++ b/tests/test_securerails_mark_allocation.py
@@ -1,0 +1,5 @@
+import json,unittest
+class T(unittest.TestCase):
+    def test_required_flags(self):
+        m=json.load(open('securerails-runs/demo/mark-allocation.json'))
+        self.assertTrue(m['human_review_required']);self.assertFalse(m['auto_merge_allowed']);self.assertFalse(m['promotion_without_evidence_allowed'])

--- a/tests/test_securerails_no_overclaim.py
+++ b/tests/test_securerails_no_overclaim.py
@@ -1,0 +1,5 @@
+import pathlib,unittest
+class T(unittest.TestCase):
+    def test_claim_boundary(self):
+        txt=pathlib.Path('docs/secure-rails/work-vaults-mark-sovereigns.md').read_text()
+        self.assertIn('No Evidence Docket, no empirical SOTA claim',txt)

--- a/tests/test_securerails_render.py
+++ b/tests/test_securerails_render.py
@@ -1,0 +1,5 @@
+import pathlib,unittest
+class T(unittest.TestCase):
+    def test_render_contains_boundary(self):
+        txt=pathlib.Path('docs/secure-rails/work-vaults-demo/README.md').read_text()
+        self.assertIn('No Evidence Docket, no empirical SOTA claim',txt)

--- a/tests/test_securerails_settlement_receipt.py
+++ b/tests/test_securerails_settlement_receipt.py
@@ -1,0 +1,5 @@
+import json,unittest
+class T(unittest.TestCase):
+    def test_utility_only(self):
+        s=json.load(open('securerails-runs/demo/settlement-receipt.json'))
+        self.assertIn('utility accounting',s['notice'])

--- a/tests/test_securerails_sovereign_schema.py
+++ b/tests/test_securerails_sovereign_schema.py
@@ -1,0 +1,5 @@
+import json,unittest
+class T(unittest.TestCase):
+    def test_promotion_policy(self):
+        s=json.load(open('securerails-runs/demo/sovereign.json'))
+        p=s['promotion_policy'];self.assertFalse(p['autonomous_promotion_allowed']);self.assertTrue(p['human_review_required'])

--- a/tests/test_securerails_token_utility_boundary.py
+++ b/tests/test_securerails_token_utility_boundary.py
@@ -1,0 +1,5 @@
+import pathlib,unittest
+class T(unittest.TestCase):
+    def test_no_investment_lang(self):
+        txt=pathlib.Path('docs/secure-rails/work-vaults-mark-sovereigns.md').read_text().lower()
+        self.assertNotIn('guaranteed investment return',txt)

--- a/tests/test_securerails_vault_lifecycle.py
+++ b/tests/test_securerails_vault_lifecycle.py
@@ -1,0 +1,5 @@
+import json,unittest
+class T(unittest.TestCase):
+    def test_deterministic_ids(self):
+        v=json.load(open('securerails-runs/demo/work-vault.json'))
+        self.assertEqual(v['vault_id'],'vault-demo-001')

--- a/tests/test_securerails_work_vault_schema.py
+++ b/tests/test_securerails_work_vault_schema.py
@@ -1,0 +1,6 @@
+import json,unittest
+class T(unittest.TestCase):
+    def test_has_counters(self):
+        v=json.load(open('securerails-runs/demo/work-vault.json'))
+        for k in ["raw_secret_leak_count","external_target_scan_count","exploit_execution_count","malware_generation_count","social_engineering_content_count","unsafe_automerge_count","critical_safety_incidents"]:
+            self.assertIn(k,v['hard_safety_counters'])


### PR DESCRIPTION
### Motivation
- Add a deterministic, auditable SecureRails Work Vault layer to route AI-agent work through MARK allocation and Sovereign assignment for proof-bound defensive remediation. 
- Provide operator-friendly documentation, deterministic demo artifacts, JSON schemas, and policy configs that enforce claim boundaries and forbid offensive or investment semantics. 
- Expose a small Python CLI to create, score, assign, run, validate, render, and manifest demo Work Vault runs for Evidence Mission Control integration. 

### Description
- New Python package `agialpha_securerails` with a CLI and modules for vault creation, MARK scoring, Sovereign assignment, AGI jobs, ProofBundles, Evidence Dockets, settlement receipts, capability archive entries, validators, render, and safety counters. 
- Added deterministic demo artifacts under `securerails-runs/demo/`, a renderer output at `docs/secure-rails/work-vaults-demo/`, and an evidence-run manifest for Evidence Mission Control integration. 
- Added JSON Schemas in `schemas/` and policy configs in `config/` that require human review, disallow auto-merge, enforce hard safety counters, and mark `$AGIALPHA` as utility-only. 
- Added docs `docs/secure-rails/work-vaults-mark-sovereigns.md` and `docs/secure-rails/work-vaults-operator-guide.md`, updated README links and workflow catalog, and added a non-publishing GitHub Actions workflow `.github/workflows/securerails-work-vault-demo.yml`. 
- Added unit tests exercising vault counters, MARK enforcement, sovereign promotion gates, settlement utility boundary, deterministic IDs, claim-boundary text, and render output. 

### Testing
- `python -m agialpha_securerails create-vault --repo-root . --out securerails-runs/demo` succeeded and produced the full set of demo JSON artifacts. 
- `python -m agialpha_securerails validate-vault --vault securerails-runs/demo/work-vault.json` returned `valid`, and `python scripts/secure_rails_safety_ledger_check.py securerails-runs/demo/safety-ledger.json` passed with all hard counters present and zero. 
- Claim and docs audits `python scripts/secure_rails_claim_boundary_check.py .`, `python -m agialpha_docs audit-workflows --repo-root .`, and `python -m agialpha_docs audit-claims --repo-root .` passed after a minor wording update to avoid a disallowed phrase. 
- SecureRails-specific unit tests added in `tests/` were executed and passed when run against the generated demo artifacts, and repository claim/audit checks pass; an unrelated repository-wide docs claim phrasing issue was detected and corrected during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b302e44c8333a15adb83a0869951)