### PR TITLE
Implement SecureRails Work Vaults, MARK allocation, and Sovereigns

### DIFF
--- a/tests/test_securerails_mark_allocation.py
+++ b/tests/test_securerails_mark_allocation.py
@@ -1,5 +1,6 @@
 import json,unittest
 class T(unittest.TestCase):
     def test_required_flags(self):
-        m=json.load(open('securerails-runs/demo/mark-allocation.json'))
+        with open('securerails-runs/demo/mark-allocation.json', encoding='utf-8') as fh:
+            m=json.load(fh)
         self.assertTrue(m['human_review_required']);self.assertFalse(m['auto_merge_allowed']);self.assertFalse(m['promotion_without_evidence_allowed'])

--- a/tests/test_securerails_settlement_receipt.py
+++ b/tests/test_securerails_settlement_receipt.py
@@ -1,5 +1,6 @@
 import json,unittest
 class T(unittest.TestCase):
     def test_utility_only(self):
-        s=json.load(open('securerails-runs/demo/settlement-receipt.json'))
+        with open('securerails-runs/demo/settlement-receipt.json', encoding='utf-8') as fh:
+            s=json.load(fh)
         self.assertIn('utility accounting',s['notice'])

--- a/tests/test_securerails_sovereign_schema.py
+++ b/tests/test_securerails_sovereign_schema.py
@@ -1,5 +1,6 @@
 import json,unittest
 class T(unittest.TestCase):
     def test_promotion_policy(self):
-        s=json.load(open('securerails-runs/demo/sovereign.json'))
+        with open('securerails-runs/demo/sovereign.json', encoding='utf-8') as fh:
+            s=json.load(fh)
         p=s['promotion_policy'];self.assertFalse(p['autonomous_promotion_allowed']);self.assertTrue(p['human_review_required'])

--- a/tests/test_securerails_vault_lifecycle.py
+++ b/tests/test_securerails_vault_lifecycle.py
@@ -1,5 +1,6 @@
 import json,unittest
 class T(unittest.TestCase):
     def test_deterministic_ids(self):
-        v=json.load(open('securerails-runs/demo/work-vault.json'))
+        with open('securerails-runs/demo/work-vault.json', encoding='utf-8') as fh:
+            v=json.load(fh)
         self.assertEqual(v['vault_id'],'vault-demo-001')

--- a/tests/test_securerails_work_vault_schema.py
+++ b/tests/test_securerails_work_vault_schema.py
@@ -1,6 +1,7 @@
 import json,unittest
 class T(unittest.TestCase):
     def test_has_counters(self):
-        v=json.load(open('securerails-runs/demo/work-vault.json'))
+        with open('securerails-runs/demo/work-vault.json', encoding='utf-8') as fh:
+            v=json.load(fh)
         for k in ["raw_secret_leak_count","external_target_scan_count","exploit_execution_count","malware_generation_count","social_engineering_content_count","unsafe_automerge_count","critical_safety_incidents"]:
             self.assertIn(k,v['hard_safety_counters'])


### PR DESCRIPTION
### Motivation
- Remove `ResourceWarning` noise from unclosed file handles and harden SecureRails demo test fixtures while preserving existing validation behavior.

### Description
- Replace bare `open(...)` reads with context-managed `with open(..., encoding='utf-8')` in five tests (`tests/test_securerails_mark_allocation.py`, `tests/test_securerails_settlement_receipt.py`, `tests/test_securerails_sovereign_schema.py`, `tests/test_securerails_vault_lifecycle.py`, `tests/test_securerails_work_vault_schema.py`) with no other functional changes.

### Testing
- Ran `python -m unittest discover -s tests -p 'test_securerails_*py'`, `python -m agialpha_securerails create-vault --repo-root . --out securerails-runs/demo`, `python -m agialpha_securerails validate-vault --vault securerails-runs/demo/work-vault.json`, `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py securerails-runs/demo/safety-ledger.json`, `python -m agialpha_docs audit-workflows --repo-root .`, and `python -m agialpha_docs audit-claims --repo-root .`; all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd0aab5083338113f7b386a9d4a0)