### PR TITLE
Implement SecureRails Work Vaults, MARK allocation, and Sovereigns

### DIFF
--- a/docs/secure-rails/work-vaults-mark-sovereigns.md
+++ b/docs/secure-rails/work-vaults-mark-sovereigns.md
@@ -4,6 +4,8 @@ SecureRails is AI-agent security governance and proof-bound defensive remediatio
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
 
+SecureRails does not autonomously approve cybersecurity posture; outputs remain advisory and human-reviewed.
+
 ## Canonical chain
 
 AI-agent work event → SecureRails Work Vault → ALPHA AGI MARK allocation → ALPHA AGI Sovereign assignment → AGI Job execution → ProofBundle → Evidence Docket → validator decision → human review → safe remediation / rejection / escalation → $AGIALPHA utility settlement → CyberSecurityCapabilityArchive → vNext defensive work


### PR DESCRIPTION
### Motivation
- Reinforce the SecureRails claim boundary by clarifying that SecureRails does not autonomously approve cybersecurity posture and that outputs remain advisory and human-reviewed, preserving the non-autonomous, non-financial, defensive governance intent.

### Description
- Add a concise human-review clarification to `docs/secure-rails/work-vaults-mark-sovereigns.md` to make the governance boundary explicit; no protocol logic, schemas, workflows, or tests were changed.

### Testing
- Ran the SecureRails checks and repo audits which all passed: `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, `python scripts/secure_rails_work_vault_check.py` against work-vault, mark-allocation, sovereign, and vault-settlement templates, `python -m agialpha_docs audit-workflows|audit-claims|audit-links|audit-readmes`, and `python -m unittest discover -s tests`; all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a0fa3b1883339ccb6498b1fa1d8c)