### PR TITLE
docs: make AGI ALPHA repository user-friendly and audit-ready

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -44,6 +44,9 @@ python scripts/secure_rails_no_automerge_check.py .
 python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
 python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
 python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json
+python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/mark-allocation-example.json
+python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/sovereign-example.json
+python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/vault-settlement-example.json
 ```
 
 ## Debugging docs-audit and SecureRails guard

--- a/docs/RESEARCH_REVIEWER_GUIDE.md
+++ b/docs/RESEARCH_REVIEWER_GUIDE.md
@@ -1,24 +1,61 @@
 # Research Reviewer Guide
 
-## Scope
-How to evaluate AGI ALPHA evidence quality without overclaiming.
+## What is this?
+This guide explains how to review AGI ALPHA evidence rigorously and conservatively.
 
-## What is being tested
-Bounded experiment families (HELIOS, Cyber Sovereign, AGI-GA Foundry, RSI Governor, SecureRails governance flows) with replay/falsification/delayed-outcome scaffolds.
+## Who is it for?
+- Internal and external research reviewers.
+- Methodology auditors checking replayability and falsification discipline.
 
-## What is not being claimed
-No frontier-capability attainment claim without the required evidence chain, and no autonomy/certification claim.
+## What AGI ALPHA is testing
+- Bounded, workflow-mediated experiment loops across HELIOS, Cyber Sovereign, AGI-GA Foundry, RSI Governor, and SecureRails.
+- Evidence production quality: manifests, dockets, proofs, baselines, replay artifacts, and delayed-outcome follow-ups.
 
-## Evidence method
-- Evidence Dockets: structured claim/evidence packages.
-- ProofBundles: linked evidence artifacts and traceability.
-- Baselines: comparator runs required for directional conclusions.
-- Replay: independent reruns where supported.
-- Falsification audits: explicit challenge attempts.
-- Delayed outcomes: post-hoc checks to avoid premature claims.
+## What AGI ALPHA is **not** claiming
+- Unsupported AGI attainment claims.
+- Unsupported ASI attainment claims.
+- Unsupported top-performance claims without official public benchmark execution + Evidence Docket + independent replay.
+- Safe autonomy.
+- External security-assurance certification claims.
 
-## Local/proxy vs external validation
-CI/local evidence is useful but not equivalent to public benchmark victory or external independent certification.
+## Evidence method and review order
+1. Read the run summary in Evidence Mission Control.
+2. Open the Evidence Docket and confirm scope/claim boundary.
+3. Review ProofBundle links and hash/manifests.
+4. Confirm treatment vs baseline comparisons.
+5. Check replay instructions and rerun feasibility.
+6. Check falsification audit outputs.
+7. Check delayed-outcome records.
+
+## How Evidence Dockets and ProofBundles work
+- Evidence Docket: the bounded claim package (what was tested, what was observed, what is out of scope).
+- ProofBundle: the linked artifact bundle supporting the docket (manifests, logs, comparisons, checks).
+
+## Baselines, replay, falsification, delayed outcomes
+- Baselines prevent one-run overclaims.
+- Replay checks reproducibility under documented conditions.
+- Falsification audits test counter-hypotheses and failure modes.
+- Delayed outcomes reduce premature conclusions from fresh runs.
+
+## Local/proxy evidence vs external validation
+- Local/proxy CI evidence can support internal iteration.
+- It is not equal to external benchmark victory or independent certification.
+- Public benchmark claims are pending/absent unless explicitly docketed and externally replayed.
+
+## How to interpret major families
+- **HELIOS**: bounded frontier-style tasks; review baselines/replay before capability interpretation.
+- **Cyber Sovereign**: defensive governance experiments; reject any offensive or certification interpretation.
+- **AGI-GA Foundry**: workflowed generation/evaluation loops; verify claim boundaries and comparator quality.
+- **RSI Governor**: governed candidate/promotion lifecycle; confirm human-reviewed promotion gates.
+- **SecureRails**: proof-bound defensive remediation governance; not autonomous security-assurance certification.
+
+## Independent review and replay checklist
+- Re-run documented replay commands where available.
+- Verify artifacts against manifests/hashes.
+- Confirm claim text does not exceed evidence scope.
+- Record disagreements and unresolved uncertainties.
 
 ## Reviewer honesty box
-Current empirical status: this repository contains bounded local/proxy CI evidence, replay scaffolds, Evidence Dockets, safety ledgers, and governance infrastructure. It does not establish achieved AGI, achieved ASI, empirical SOTA, safe autonomy, cybersecurity certification, real-world security certification, or external benchmark victory unless explicitly supported by an Evidence Docket, public benchmark execution, independent replay, and reviewer attestation.
+Current empirical status: this repository contains bounded local/proxy CI evidence, replay scaffolds, Evidence Dockets, safety ledgers, and governance infrastructure. It does not establish achieved AGI, achieved ASI, empirical SOTA, safe autonomy, external security-assurance certification, real-world security-assurance certification, or external benchmark victory unless explicitly supported by an Evidence Docket, public benchmark execution, independent replay, and reviewer attestation.
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.

--- a/docs/SECURITY_COMPLIANCE_REVIEWER_GUIDE.md
+++ b/docs/SECURITY_COMPLIANCE_REVIEWER_GUIDE.md
@@ -1,25 +1,37 @@
 # Security & Compliance Reviewer Guide
 
-## SecureRails boundary
-SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cyber assurance, not offensive cyber, not high-risk decision automation by intended purpose, not default GPAI model provision, and not an investment product.
+## What is this?
+A practical review guide for SecureRails-aligned governance and compliance evidence.
 
-## Required exclusions
-- No HR/worker evaluation
-- No profiling of natural persons
-- No automated decisions about natural persons
-- No critical-infrastructure safety-component reliance
-- No external target scanning/exploit execution/malware/social engineering
-- No auto-merge for safety-critical PR promotion
-- No cyber-assurance certification claims
-- No token-investment framing
+## SecureRails product boundary
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous external security-assurance certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 
-## Review artifacts
-- Deployment intake
-- Safety ledger hard counters
-- AI Act triage record
-- Customer attestation
-- Material modification log + re-screening
-- Incident log + regulator audit readiness
+## AI Act posture
+- Designed to remain outside high-risk use by intended purpose when deployed within documented boundaries.
+- Requires use-case triage and human accountability before deployment.
+
+## Foreseeable misuse and excluded uses
+- No HR / worker evaluation.
+- No profiling of natural persons.
+- No automated decisions about natural persons.
+- No critical-infrastructure safety-component reliance.
+- No offensive cyber.
+- No external target scanning.
+- No exploit execution.
+- No malware generation.
+- No social engineering.
+- No auto-merge for governed promotion.
+- No external security-assurance certification claim.
+- No token investment framing.
+
+## Required evidence pack
+- Deployment intake.
+- Safety ledger hard counters.
+- Customer use attestation.
+- Annex III triage record.
+- Material modification log + re-screening evidence.
+- Incident log.
+- Evidence Docket and ProofBundle linkage.
 
 ## Compliance checklist
 - [ ] Deployment intake completed
@@ -32,3 +44,8 @@ SecureRails is AI-agent security governance and proof-bound defensive remediatio
 - [ ] SecureRails Compliance Guard passed
 - [ ] Evidence Docket attached
 - [ ] Safe PR reviewed manually
+
+## Regulator audit readiness
+- Keep dated records for intake, triage, review decisions, incidents, and remediations.
+- Preserve replay instructions and artifact integrity evidence.
+- Track material modifications and re-screen before promoting changes.


### PR DESCRIPTION
### Motivation
- Improve role-based, audit-ready documentation so non-technical operators, developers/Codex, research reviewers, security/compliance reviewers, and deployment reviewers can understand, run, verify, and safely extend repository workflows and evidence artifacts. 
- Close documentation gaps around SecureRails, Work Vault / MARK / Sovereigns validation, Evidence Dockets, ProofBundles, replay/falsification flows, and claim-boundary-safe wording without weakening any existing boundaries or tests. 

### Description
- Expanded and clarified the Research Reviewer guide (`docs/RESEARCH_REVIEWER_GUIDE.md`) with a stepwise evidence review order, replay/falsification/delayed-outcome guidance, subsystem interpretation notes (HELIOS, Cyber Sovereign, AGI-GA Foundry, RSI Governor, SecureRails), and conservative claim language. 
- Expanded the Security & Compliance Reviewer guide (`docs/SECURITY_COMPLIANCE_REVIEWER_GUIDE.md`) to explicitly state SecureRails product boundary, AI Act posture, excluded uses, required evidence pack, compliance checklist, and regulator-audit readiness steps. 
- Strengthened the Developer guide (`docs/DEVELOPER_GUIDE.md`) to include the full local validation command set for SecureRails Work Vault templates by adding checks for `mark-allocation`, `sovereign`, and `vault-settlement` templates. 
- Performed safe wording normalization to replace risky phrasing (e.g., replace ambiguous "security certification" language with "security-assurance certification" / "external security-assurance certification") and preserved the doctrine: "No Evidence Docket, no empirical SOTA claim." 

### Testing
- Ran the unit test suite with `python -m unittest discover -s tests` and all tests passed (`Ran 175 tests ... OK`).
- Ran documentation and workflow audits and they passed: `python -m agialpha_docs audit-workflows --repo-root .` (no undocumented workflows), `python -m agialpha_docs audit-links --repo-root .` (OK), and `python -m agialpha_docs audit-readmes --repo-root .` (OK).
- Ran claims audit and iterated wording fixes until `python -m agialpha_docs audit-claims --repo-root .` returned clean results.
- Ran SecureRails guard scripts and template validators which all passed: `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, and `python scripts/secure_rails_work_vault_check.py` against `work-vault`, `mark-allocation`, `sovereign`, and `vault-settlement` templates (all OK).
- All automated checks listed above succeeded and the SecureRails Compliance Guard remained green after edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f2857b34833396e101e28d48ebb9)