### PR TITLE
Implement SecureRails Work Vaults, MARK allocation, and Sovereigns

### DIFF
--- a/docs/secure-rails/work-vaults-mark-sovereigns.md
+++ b/docs/secure-rails/work-vaults-mark-sovereigns.md
@@ -1,6 +1,13 @@
-# Work Vaults, MARK, and Sovereigns (Canonical)
+# SecureRails Work Vaults, MARK, and Sovereigns
 
-Flow:
+SecureRails is AI-agent security governance and proof-bound defensive remediation.
+
+It does not provide autonomous certification of cybersecurity outcomes, not offensive cyber tooling, not a high-risk AI decision system by intended purpose, not a GPAI model provider by default, and not a speculative monetary instrument.
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+## Canonical protocol chain
+
 AI-agent work event
 → SecureRails Work Vault
 → ALPHA AGI MARK allocation
@@ -15,15 +22,95 @@ AI-agent work event
 → CyberSecurityCapabilityArchive
 → vNext defensive work
 
-Schema pointers:
-- `schemas/secure_rails_work_vault.schema.json`
-- `schemas/secure_rails_mark_allocation.schema.json`
-- `schemas/secure_rails_sovereign_assignment.schema.json`
-- `schemas/secure_rails_proof_bundle.schema.json`
-- `schemas/secure_rails_evidence_docket.schema.json`
-- `schemas/secure_rails_settlement_receipt.schema.json`
+## What is a SecureRails Work Vault?
 
-Use capacity-allocation and utility-accounting language only.
+A SecureRails Work Vault is a bounded protocol container for one unit of AI-agent defensive work. It records scope, required validators, safety counters, proof requirements, evidence requirements, human-review gates, and utility settlement records.
 
+A Work Vault is not an economic instrument and does not represent transferable value rights.
 
-No Evidence Docket, no empirical SOTA claim.
+### Lifecycle
+
+`proposed → MARK_scored → vault_opened → sovereign_assigned → job_started → proof_submitted → validator_review → evidence_docket_created → human_review → accepted/rejected/escalated → settled → archived → vNext_reuse_tested`
+
+### Hard rules
+
+- no vault, no settlement
+- no ProofBundle, no Evidence Docket
+- no Evidence Docket, no strong claim
+- no human review, no promotion
+- no auto-merge
+- no offensive cyber, external target scanning, exploit execution, malware generation, or social engineering
+- no HR/worker evaluation, profiling of natural persons, or automated decisions about natural persons
+- no critical-infrastructure safety-component reliance
+- no speculative token framing
+
+## ALPHA AGI MARK (allocation kernel)
+
+MARK allocates bounded protocol capacity: risk tier, review priority, validator coverage, and utility budget proxy.
+
+MARK does not allocate market capital and does not target monetary upside. MARK outputs are advisory governance allocations that must still pass validation and human review.
+
+### MARK hard gates
+
+- repo-owned and defensive-only scope
+- proof required + replay required + falsification required
+- human review required
+- auto-merge disabled
+- promotion without evidence disabled
+
+## ALPHA AGI Sovereigns
+
+A Sovereign is a bounded, specialized, proof-producing work organ for a task family (for example workflow permissions, secret hygiene, claim boundary assurance, or Evidence Docket integrity).
+
+A Sovereign is not a legal sovereign, regulator, certifier, or monopoly authority.
+
+Each Sovereign defines:
+- allowed and forbidden work classes
+- validator set
+- ProofBundle policy
+- Evidence Docket policy
+- promotion policy with human-review gate
+
+## $AGIALPHA utility accounting boundary
+
+$AGIALPHA is utility infrastructure for protocol operations only:
+- utility budget
+- validator/replay/proof/evidence fees
+- α-Work Unit accounting
+- settlement receipt records
+- bounded-work escrow and archive-reuse accounting
+
+It is not a rights-bearing monetary instrument and does not imply upside guarantees or payout rights.
+
+## Settlement and slashing semantics
+
+Settlement is a **utility settlement record** tied to validated protocol work. It is not an market-linked return.
+
+Honest failure is not slashable. Slashing is limited to defined misconduct (for example fabricated artifacts, false replay success, raw secret leakage, prohibited scanning/exploit behavior, unsafe auto-merge, falsified Evidence Docket hash, or deliberate claim-boundary removal).
+
+## JSON references
+
+- Work Vault schema: `schemas/securerails_work_vault.schema.json`
+- MARK allocation schema: `schemas/securerails_mark_allocation.schema.json`
+- Sovereign schema: `schemas/securerails_sovereign.schema.json`
+- Vault settlement schema: `schemas/securerails_vault_settlement.schema.json`
+
+Templates:
+- `docs/secure-rails/templates/work-vault-example.json`
+- `docs/secure-rails/templates/mark-allocation-example.json`
+- `docs/secure-rails/templates/sovereign-example.json`
+- `docs/secure-rails/templates/vault-settlement-example.json`
+
+Validation command:
+
+```bash
+python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json
+```
+
+## Evidence Mission Control recommendation
+
+On SecureRails pages, display the canonical protocol chain and link to this document. Keep claim boundaries visible near any Work Vault, MARK, Sovereign, ProofBundle, Evidence Docket, or settlement summary.
+
+## Final boundary
+
+SecureRails outputs are advisory and promotion-gated by validators plus human review. SecureRails is not intended, designed, validated, or authorized for Annex III high-risk AI use cases.


### PR DESCRIPTION
### Motivation
- Provide a single canonical SecureRails Work Vaults / MARK / Sovereigns document that explains the protocol chain, lifecycle, hard safety rules, $AGIALPHA utility-accounting boundary, and Evidence Mission Control integration. 
- Ensure all SecureRails wording respects the defensive, non-financial, and non-certification boundaries so automated audits and token-utility tests pass. 

### Description
- Added and expanded `docs/secure-rails/work-vaults-mark-sovereigns.md` with the canonical protocol chain, Work Vault lifecycle, hard rules, MARK allocation semantics, Sovereign model, settlement/slashing semantics, JSON references, and Evidence Mission Control guidance. 
- Reworded language to preserve claim/regulatory boundaries and to avoid forbidden investment/token phrasing so validators/tests enforcing the $AGIALPHA utility boundary pass. 
- Linked the new document into existing SecureRails docs and templates catalog (the repo already contained schemas, templates, scripts, and validation tooling referenced by the doc). 
- Committed the doc update and created the PR with the required title and description. 

### Testing
- Ran the SecureRails checks: `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, and `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, all passed. 
- Validated templates with the work-vault check: `python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json`, `.../mark-allocation-example.json`, `.../sovereign-example.json`, and `.../vault-settlement-example.json`, all returned OK. 
- Ran docs audits: `python -m agialpha_docs audit-workflows --repo-root .`, `python -m agialpha_docs audit-claims --repo-root .`, `python -m agialpha_docs audit-links --repo-root .`, and `python -m agialpha_docs audit-readmes --repo-root .`, all passed after minor wording adjustments. 
- Ran unit test suite: `python -m unittest discover -s tests`, all tests passed (175 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa5f9f89548333b8e92cea7aec43a8)