### PR TITLE
docs: make AGI ALPHA First Real Loop documentation user-friendly and complete

### DIFF
--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -1,41 +1,66 @@
 # Claim Boundaries
 
-## Allowed claims
-- local evidence produced
-- proxy evidence collected
-- replayed in CI
-- Evidence Docket produced
-- safe PR proposed
-- human review pending
-- external review pending
-- designed as governance infrastructure
+This document defines allowed and forbidden language for repository outputs, docs, and workflow summaries.
+
+## Core doctrine
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
+
+## Allowed claim classes
+- Local evidence produced.
+- Proxy evidence produced in CI.
+- Replay completed in CI or locally.
+- Evidence Docket produced for a run.
+- Safe PR proposed (human merge decision pending).
+- Human review pending.
+- External review pending.
+- System designed as governance infrastructure.
 
 ## Forbidden positive claims
-- unsupported capability milestones
-- top-tier empirical victories without required evidence tiers
-- guaranteed security, autonomous cyber-governance certification, or safe autonomy
-- EU AI Act exemption or worldwide legal approval claims
-- investment return, yield, dividends, ownership, or profit-right claims
+- achieved AGI
+- achieved ASI
+- empirical SOTA without required evidence tier
+- guaranteed security
+- cybercertification claim
+- safe autonomy
+- top benchmark win claim without required independent evidence
+- EU AI Act exempt
+- legally approved worldwide
+- investment return, yield, dividends, ownership rights, profit rights
 
-## Claim levels
-- L3 local scaffold
-- L4-ready replay kit
-- L4-external attested
-- L5-local local baseline evidence
-- L5-external public baseline evidence
-- L6-CI-proxy CI scaling proxy
-- L6-real real scaling
-- L7-local real-task local
-- L7-external external real-task
-- L8-sentinel delayed outcomes
-- L9-human-reviewed governed remediation
-- L10-official-benchmark official benchmark with independent audit
+## SecureRails boundary
+SecureRails is AI-agent security governance and proof-bound defensive remediation.
 
-## Doctrine
-No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+It is not:
+- autonomous cybercertification claim
+- offensive cyber capability
+- a high-risk decision system by intended purpose
+- a GPAI model provider by default
+- an investment product
 
-## Examples
-- ✅ “This run produced local evidence with replay pending external review.”
-- ✅ “SecureRails is not autonomous cyber-governance certification.”
-- ❌ “This proves unsupported capability milestones.”
-- ❌ “$AGIALPHA offers passive investment return.”
+## `$AGIALPHA` boundary
+`$AGIALPHA` is utility infrastructure for protocol operations only:
+- access credits
+- Work Vault utility budgets
+- validator fees
+- replay fees
+- ProofBundle fees
+- Evidence Docket fees
+- slashing for defined rule violations
+- α-Work Unit accounting
+- archive-access accounting
+- utility settlement records
+
+Use terms like **capacity allocation**, **utility budget**, **validated work**, and **utility accounting**.
+Avoid investment framing.
+
+## Positive and negative examples
+Allowed:
+- “This workflow produced local evidence and replay artifacts.”
+- “Human review is pending before any promotion decision.”
+- “SecureRails is not autonomous cybercertification claim.”
+
+Forbidden:
+- “This proves AGI.”
+- “This run guarantees security outcomes.”
+- “This token provides passive investment return.”
+- “This system is EU AI Act exempt.”

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -1,33 +1,73 @@
 # Operator Guide (GitHub UI)
 
-## Run a workflow
-1. Open repository **Actions** tab.
-2. Select a workflow from `docs/WORKFLOW_CATALOG.md`.
-3. Click **Run workflow**.
-4. Fill `workflow_dispatch` inputs (branch, mode, flags).
-5. Start run and monitor job logs.
+Use this guide when running repository workflows from the GitHub web interface.
 
-<!-- screenshot placeholder: Actions tab workflow selection -->
+## 1) Open Actions
+1. Open the repository on GitHub.
+2. Click the **Actions** tab.
+3. Select a workflow from `docs/WORKFLOW_LAUNCHPAD.md` or `docs/WORKFLOW_CATALOG.md`.
 
-## Inputs, logs, artifacts
-- Inputs define run mode and scope; keep defaults unless runbook says otherwise.
-- Logs show pass/fail and validator notes.
-- Download artifacts from the run summary page.
+<!-- screenshot placeholder: actions-tab-overview -->
 
-## Evidence review flow
-1. Find Evidence Docket and ProofBundle outputs.
-2. Read replay log and safety ledger.
-3. Check claim boundary in docs/claims output.
-4. Treat as pending until human review is complete.
+## 2) Select workflow and click Run workflow
+1. Choose the workflow page.
+2. Click **Run workflow** (top-right).
+3. Choose branch/ref.
+4. Fill `workflow_dispatch` inputs.
+5. Click **Run workflow** to submit.
 
-## Pass/fail interpretation
-- Pass = bounded checks passed for this run.
-- Fail = boundary or execution issue; use `docs/TROUBLESHOOTING.md`.
+<!-- screenshot placeholder: run-workflow-dialog -->
 
-## Reruns and safe PR proposals
-- Use **Re-run jobs** for transient issues.
-- Review safe PR proposals manually; avoid accidental merges.
+## 3) Understand workflow inputs
+Common input meanings:
+- `ref`/`branch`: code revision to run.
+- `mode`/`profile`: bounded run profile.
+- `seed`/`pack`: deterministic test data selector.
+- `publish`: whether output is sent to central publishing flow.
 
-## Evidence Mission Control / Autopublisher
-- Trigger publisher workflows only through documented central publisher flow.
-- If Pages does not update, check `evidence-hub-publish` run logs and permissions.
+Use documented defaults unless a runbook says otherwise.
+
+## 4) Inspect logs and status
+- Open each job/step for detailed logs.
+- Validate safety checks, replay checks, and claim-boundary checks.
+- Green = checks passed for run scope.
+- Red = failed check; follow `docs/TROUBLESHOOTING.md`.
+
+## 5) Download artifacts
+1. Open run summary.
+2. In **Artifacts**, download the output bundle.
+3. Confirm expected files exist (manifest, replay files, ledgers, Evidence Docket).
+
+## 6) Find Evidence Dockets and safety ledgers
+- Evidence Docket location is workflow-specific; use artifact manifest and run logs.
+- Safety ledger and cost ledger should be present for bounded security/evidence workflows.
+- If missing, treat run as incomplete.
+
+## 7) Interpret pass/fail conservatively
+- **Pass**: bounded workflow checks passed.
+- **Fail**: run failed or guardrail blocked execution.
+- Neither status alone authorizes capability overclaims.
+
+## 8) Rerun jobs safely
+- Use **Re-run failed jobs** for transient failures.
+- Do not rerun to bypass policy gates.
+- Keep notes in run comments or issue tracker for auditability.
+
+## 9) Review safe PR proposals
+- Safe PR proposals still require human review.
+- Verify diff scope, safety counters, claim boundary language, and artifact integrity.
+- Avoid accidental merges; never auto-merge unsafe remediation.
+
+## 10) Trigger Evidence Mission Control / Autopublisher
+- Use central publisher workflows only (`evidence-hub-publish` path).
+- Do not create side-channel Pages deploy workflows.
+- Validate publish logs and resulting page references.
+
+## 11) If Pages does not update
+1. Check latest `evidence-hub-publish` run status.
+2. Confirm permissions and token scope.
+3. Confirm artifacts contain expected publish payload.
+4. Re-run publish workflow once root cause is fixed.
+
+## Boundary reminder
+SecureRails is governance + defensive remediation, not autonomous certification or offensive cyber. `$AGIALPHA` is utility accounting infrastructure only.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,30 @@
 # Documentation Hub
 
-- `START_HERE.md`
-- `OPERATOR_GUIDE.md`
-- `DEVELOPER_GUIDE.md`
-- `EVIDENCE_GUIDE.md`
-- `EXPERIMENT_GUIDE.md`
-- `WORKFLOW_CATALOG.md`
-- `CLAIM_BOUNDARIES.md`
-- `TROUBLESHOOTING.md`
+Use this page as the navigation index for operators, developers, reviewers, and governance teams.
+
+## Start here
+- `START_HERE.md` — first-run orientation for non-technical operators.
+- `OPERATOR_GUIDE.md` — run workflows from GitHub UI safely.
+
+## Build and maintain
+- `DEVELOPER_GUIDE.md` — repo structure, setup, tests, docs audits.
+- `ADDING_NEW_EXPERIMENTS.md` — safe experiment onboarding.
+- `ADDING_NEW_WORKFLOWS.md` — workflow authoring and catalog policy.
+
+## Evidence and claims
+- `EVIDENCE_GUIDE.md` — Evidence Dockets, ProofBundles, replay, ledgers.
+- `EVIDENCE_DOCKET_STANDARD.md` — docket field standard.
+- `CLAIM_BOUNDARIES.md` — allowed vs forbidden claim language.
+- `TROUBLESHOOTING.md` — common failure modes and fixes.
+
+## Program areas
+- `EXPERIMENT_GUIDE.md` — experiment families and run paths.
+- `EVIDENCE_MISSION_CONTROL.md` — publication and evidence discovery.
+- `WORKFLOW_CATALOG.md` — every workflow with boundary notes.
+- `WORKFLOW_LAUNCHPAD.md` — operator launch list.
+
+## SecureRails
+- `SECURERAILS_OVERVIEW.md`
+- `SECURERAILS_WORK_VAULTS.md`
 - `secure-rails/README.md`
+- `secure-rails/work-vaults-mark-sovereigns.md`

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,40 +1,73 @@
 # START HERE
 
-## What is this repository?
-AGI ALPHA First Real Loop is an evidence-first operating repo for bounded AI-agent experiments, governance checks, and replayable artifacts.
+This page is for first-time operators who want to run the repository safely from GitHub in under 5 minutes.
 
-## Key concepts in plain English
-- **Evidence Mission Control**: central hub that collects and publishes experiment outputs.
-- **SecureRails**: AI-agent security governance + proof-bound defensive remediation process.
-- **Evidence Docket**: structured evidence package used for conservative claims.
-- **ProofBundle**: bundle of artifacts, logs, and integrity metadata.
-- **Work Vault**: governed container for scoped defensive work requests and outcomes.
-- **ALPHA AGI MARK**: utility budget allocation signal for bounded work.
-- **ALPHA AGI Sovereign**: assigned governed execution identity for a work stream.
+## What is AGI ALPHA First Real Loop?
+AGI ALPHA First Real Loop is a research and governance repository for **workflow-driven evidence production**. It packages experiments, safety checks, replay paths, and documentation into a single operational system.
+
+## What is Evidence Mission Control?
+Evidence Mission Control is the repository’s publishing and discovery surface for experiment outputs, Evidence Dockets, and workflow artifacts. Start at `docs/EVIDENCE_MISSION_CONTROL.md`.
+
+## What is SecureRails?
+SecureRails is **AI-agent security governance and proof-bound defensive remediation**. It is designed to gate risky actions through Evidence Dockets, safety ledgers, validators, and human review.
+
+SecureRails is **not**:
+- autonomous cybercertification claim
+- offensive cyber capability
+- guaranteed security
+- autonomous claim promotion
+
+## What is an Evidence Docket?
+An Evidence Docket is the structured evidence record for a run: what executed, what artifacts were produced, what limits apply, and what claim level is permitted.
+
+## What is a ProofBundle?
+A ProofBundle is the artifact package (logs, hashes, manifests, replay instructions, and checks) that supports an Evidence Docket.
+
+## What is a Work Vault?
+A Work Vault is the governed container for a scoped defensive work request and its bounded execution trail.
+
+## What is MARK?
+ALPHA AGI MARK is a utility-budget allocation signal for bounded protocol work. It is governance/accounting metadata, not investment framing.
+
+## What is a Sovereign?
+An ALPHA AGI Sovereign is the assigned governed execution identity responsible for an AGI Job scope and related accountability records.
 
 ## What can I safely run?
-Run documented workflows from GitHub Actions and only treat results as local/proxy evidence until review is complete.
+- Workflows listed in `docs/WORKFLOW_LAUNCHPAD.md` and `docs/WORKFLOW_CATALOG.md`.
+- Evidence and replay workflows that produce bounded artifacts.
+- SecureRails demo and compliance workflows.
 
 ## What should I avoid?
-- Do not treat a green workflow as AGI/ASI/SOTA proof.
-- Do not auto-merge unsafe remediation.
-- Do not promote claims without an Evidence Docket.
+- Treating green checks as AGI/ASI/SOTA proof.
+- Merging remediation PRs automatically.
+- Publishing claims without an Evidence Docket.
+- Using investment language for `$AGIALPHA`.
 
-## Green check vs red check
-- **Green**: workflow checks passed for that run scope.
-- **Red**: workflow or guardrail failed; investigate before any follow-on action.
+## What does a green check mean?
+A green check means that workflow checks passed for that run configuration. It does **not** authorize unrestricted claims.
 
-## Where to find artifacts and results
-- Artifacts: GitHub Actions run page.
-- Public pages / mission control: `docs/EVIDENCE_MISSION_CONTROL.md`.
+## What does a red check mean?
+A red check means at least one guardrail, test, or execution path failed and needs investigation before follow-up action.
+
+## Where do I find artifacts?
+Open the specific GitHub Actions run and use the **Artifacts** section.
+
+## Where do I see public results?
+Use:
+- `docs/EVIDENCE_MISSION_CONTROL.md`
+- `docs/WORKFLOW_LAUNCHPAD.md`
+- `docs/EXPERIMENT_GUIDE.md`
 
 ## Recommended first path
-1. Open Evidence Mission Control docs.
-2. Open **Actions**.
-3. Run a safe workflow.
-4. Inspect logs.
-5. Download artifact.
-6. Read Evidence Docket.
-7. Check safety ledger.
-8. Confirm claim boundary.
+1. Open Evidence Mission Control (`docs/EVIDENCE_MISSION_CONTROL.md`).
+2. Open the GitHub **Actions** tab.
+3. Run a safe workflow from `docs/WORKFLOW_LAUNCHPAD.md`.
+4. Inspect logs for checks and boundaries.
+5. Download the artifact package.
+6. Read the Evidence Docket.
+7. Check safety ledger counters.
+8. Confirm claim boundary statements.
 9. Never merge unsafe remediation automatically.
+
+## One-line doctrine
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**


### PR DESCRIPTION
### Motivation
- Make the repository immediately usable by non-technical operators while preserving conservative, auditable claim boundaries and governance posture.
- Provide an organized documentation-as-infrastructure hub so a new user can answer core questions in under five minutes and safely run workflows from the GitHub UI.
- Centralize SecureRails and $AGIALPHA boundaries to avoid ambiguous or investment-like language and prevent overclaiming.

### Description
- Added or substantially revised operator-facing onboarding and runbook files including `docs/START_HERE.md` and `docs/OPERATOR_GUIDE.md` to provide a clear 5-minute path, step-by-step UI run instructions, artifact locations, and safe rerun/PR guidance.
- Hardened and centralized policy language in `docs/CLAIM_BOUNDARIES.md` with explicit allowed/forbidden claims, a SecureRails boundary section, and `$AGIALPHA` utility-only framing and examples.
- Reworked the documentation index in `docs/README.md` to act as a navigation hub and linked the major guides (`EVIDENCE_GUIDE.md`, `WORKFLOW_CATALOG.md`, `SECURERAILS_*`, `ADDING_*`), preserving existing content and templates rather than deleting substantive material.
- Ensured workflow catalog and operator launch materials remain referenced and unchanged in function, and updated wording to satisfy repository audits without changing runtime workflow logic or security boundaries.

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests`, which passed.
- Ran repository documentation audits with `python -m agialpha_docs audit-workflows --repo-root .`, `python -m agialpha_docs audit-claims --repo-root .`, `python -m agialpha_docs audit-links --repo-root .`, and `python -m agialpha_docs audit-readmes --repo-root .`, all of which reported OK.
- Addressed a claim-audit failure by aligning phrasing to the claims doctrine and re-ran the audits and unit tests to confirm the repo-level claim checks now pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa61f4093c8333a93234121633b775)