### PR TITLE
Docs: Clarify claim boundaries and onboarding; expand Developer Guide and START_HERE

### DIFF
--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -1,66 +1,48 @@
 # Claim Boundaries
 
-This document defines allowed and forbidden language for repository outputs, docs, and workflow summaries.
+This document defines what can and cannot be claimed from this repository.
 
 ## Core doctrine
-**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
+**No Evidence Docket, no unsupported top-tier benchmark claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
 
-## Allowed claim classes
-- Local evidence produced.
-- Proxy evidence produced in CI.
-- Replay completed in CI or locally.
-- Evidence Docket produced for a run.
-- Safe PR proposed (human merge decision pending).
-- Human review pending.
-- External review pending.
-- System designed as governance infrastructure.
+## Allowed claim categories
+- Local evidence generated in this repository.
+- Proxy evidence with explicit limits.
+- Replayed in CI with run IDs and artifacts.
+- Evidence Docket produced for a specific run.
+- Safe PR proposed (human review pending).
+- External review pending / unresolved.
+- Governance infrastructure design claims.
 
-## Forbidden positive claims
-- achieved AGI
-- achieved ASI
-- empirical SOTA without required evidence tier
-- guaranteed security
-- cybercertification claim
-- safe autonomy
-- top benchmark win claim without required independent evidence
-- EU AI Act exempt
-- legally approved worldwide
-- investment return, yield, dividends, ownership rights, profit rights
+## Forbidden claim categories
+- Achieved AGI / achieved ASI.
+- Unqualified top-tier benchmark ranking claims.
+- Guaranteed security / safe autonomy.
+- Cyberformal security attestation claims.
+- Unqualified benchmark-win language without qualifying evidence and review context.
+- EU AI Act exemption claim.
+- Legally approved worldwide claim.
+- Investment return, yield, dividends, ownership/profit rights.
+
+## Positive/negative examples
+- ✅ Allowed: “Run `X` produced an Evidence Docket and replay log in CI.”
+- ✅ Allowed: “SecureRails is not offensive cyber and is not certification.”
+- ✅ Allowed: “External review is pending; promotion is blocked.”
+- ❌ Forbidden: “This proves AGI has been achieved.”
+- ❌ Forbidden: “Certified secure autonomous remediation.”
+- ❌ Forbidden: “$AGIALPHA holders receive yield.”
 
 ## SecureRails boundary
 SecureRails is AI-agent security governance and proof-bound defensive remediation.
+It is not autonomous cyberformal security attestation, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 
-It is not:
-- autonomous cybercertification claim
-- offensive cyber capability
-- a high-risk decision system by intended purpose
-- a GPAI model provider by default
-- an investment product
-
-## `$AGIALPHA` boundary
-`$AGIALPHA` is utility infrastructure for protocol operations only:
+## $AGIALPHA boundary
+`$AGIALPHA` is protocol utility infrastructure only:
 - access credits
 - Work Vault utility budgets
-- validator fees
-- replay fees
-- ProofBundle fees
-- Evidence Docket fees
-- slashing for defined rule violations
-- α-Work Unit accounting
-- archive-access accounting
+- validator/replay/ProofBundle/Evidence Docket fees
+- slashing for defined violations
+- α-Work Unit and archive-access accounting
 - utility settlement records
 
-Use terms like **capacity allocation**, **utility budget**, **validated work**, and **utility accounting**.
-Avoid investment framing.
-
-## Positive and negative examples
-Allowed:
-- “This workflow produced local evidence and replay artifacts.”
-- “Human review is pending before any promotion decision.”
-- “SecureRails is not autonomous cybercertification claim.”
-
-Forbidden:
-- “This proves AGI.”
-- “This run guarantees security outcomes.”
-- “This token provides passive investment return.”
-- “This system is EU AI Act exempt.”
+Use terms like **capacity allocation**, **utility budget**, **validator budget**, **protocol settlement**, and **utility accounting**.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,13 +1,25 @@
 # Developer Guide
 
-## Repo structure
-- `agialpha_*` packages: experiment/runtime code.
-- `.github/workflows/`: automation and evidence workflows.
-- `schemas/`: JSON schemas for manifests, dockets, vault records.
-- `docs/`: operator, reviewer, and governance documentation.
-- `tests/`: quality, boundary, and regression tests.
+## Repository structure (high level)
+- `.github/workflows/`: automation, evidence pipelines, publishing.
+- `docs/`: operator + developer + governance documentation.
+- `scripts/`: evidence, SecureRails, rendering, and guardrail helpers.
+- `tests/`: unit/integration/doc-audit enforcement.
 
-## Local setup + checks
+## Local setup
+This repository currently does **not** ship a `requirements.txt` or lockfile. Start with a clean virtualenv, then run tests/audits and install any missing packages reported by Python.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m unittest discover -s tests
+```
+
+If a command reports a missing module, install that package explicitly in your active environment and record the dependency source in your PR notes.
+
+## Core test and docs checks
+Run these before pushing:
 ```bash
 python -m unittest discover -s tests
 python -m agialpha_docs audit-workflows --repo-root .
@@ -16,14 +28,44 @@ python -m agialpha_docs audit-links --repo-root .
 python -m agialpha_docs audit-readmes --repo-root .
 ```
 
-## Adding scripts, schemas, workflows
-- Add scripts under appropriate package/module and test them.
-- Add/update schema under `schemas/` and include tests.
-- Add workflow in `.github/workflows/` with least-privilege permissions.
-- Update `docs/WORKFLOW_CATALOG.md` for every workflow file.
+## Docs-audit expectations
+- Every workflow in `.github/workflows/` must appear in `docs/WORKFLOW_CATALOG.md`.
+- Root README and docs links must resolve.
+- Required docs must exist and remain navigable for non-technical operators.
+- Claim-boundary language must block overclaims and allow explicit negative-boundary statements.
 
-## Evidence + docs guardrails
-- Add Evidence Docket template/paths and artifact manifest fields.
-- Keep README/docs links valid and relative.
-- Preserve claim boundaries; use conservative wording.
-- Avoid stale workflow references by re-running docs audits.
+## Adding scripts safely
+1. Place script in `scripts/` with clear name and docstring.
+2. Add/extend tests in `tests/`.
+3. Document usage in relevant guide and workflow docs.
+4. Ensure logs/artifacts are bounded and auditable.
+
+## Adding schemas / docket templates
+1. Add schema/template in the established schema/template path.
+2. Add validation tests.
+3. Reference schema in Evidence/secure-rails docs.
+4. Update replay/falsification expectations if schema semantics changed.
+
+## Adding workflows
+Follow `docs/ADDING_NEW_WORKFLOWS.md`.
+
+Minimum requirements:
+- Documented `workflow_dispatch` inputs.
+- Least-privilege permissions.
+- Artifact uploads for evidence-bearing runs.
+- Claim-boundary-safe language in outputs/logs.
+- Workflow catalog entry + related docs links.
+
+## Keeping claim boundaries intact
+- Never imply AGI/ASI achievement.
+- Never imply unsupported top-tier benchmark claim without docket-backed external evidence and approved phrasing.
+- Keep `$AGIALPHA` language in utility/accounting terms only.
+- Keep SecureRails framed as governance + proof-bound defensive remediation.
+
+## Avoid stale workflows and broken links
+- Remove or update docs references when workflow files are renamed.
+- Update workflow catalog in same PR as workflow changes.
+- Run link audits locally.
+
+## Content preservation note policy
+If you relocate or replace substantive docs, add a short note in changelog/PR body indicating where content moved.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,73 +1,60 @@
 # START HERE
 
-This page is for first-time operators who want to run the repository safely from GitHub in under 5 minutes.
+Welcome. This guide is for first-time operators who want to safely run AGI ALPHA First Real Loop from GitHub in under 5 minutes.
 
-## What is AGI ALPHA First Real Loop?
-AGI ALPHA First Real Loop is a research and governance repository for **workflow-driven evidence production**. It packages experiments, safety checks, replay paths, and documentation into a single operational system.
+## In one sentence
+AGI ALPHA First Real Loop is a workflow-driven research/governance repo that produces auditable evidence (ProofBundles + Evidence Dockets) with safety boundaries and human review gates.
 
-## What is Evidence Mission Control?
-Evidence Mission Control is the repository’s publishing and discovery surface for experiment outputs, Evidence Dockets, and workflow artifacts. Start at `docs/EVIDENCE_MISSION_CONTROL.md`.
+## What each core term means
+- **Evidence Mission Control**: the publication and navigation layer for generated evidence and workflow outcomes (`docs/EVIDENCE_MISSION_CONTROL.md`).
+- **SecureRails**: AI-agent security governance and proof-bound defensive remediation, with explicit limits (`docs/secure-rails/README.md`).
+- **Evidence Docket**: structured record of what ran, what was produced, what boundaries apply, and what claims are allowed.
+- **ProofBundle**: run artifact package (manifests, logs, hashes, replay/falsification outputs).
+- **Work Vault**: bounded work container for a defensive task + safety/accountability trail.
+- **ALPHA AGI MARK**: utility budget/capacity allocation metadata for bounded protocol work.
+- **ALPHA AGI Sovereign**: governed execution identity assigned to a bounded AGI Job.
 
-## What is SecureRails?
-SecureRails is **AI-agent security governance and proof-bound defensive remediation**. It is designed to gate risky actions through Evidence Dockets, safety ledgers, validators, and human review.
+## What this system is not
+- Not a claim that AGI or ASI has been achieved.
+- Not a default top-tier benchmark claim.
+- Not cyberformal security attestation.
+- Not offensive cyber capability.
+- Not autonomous claim promotion.
+- Not an investment product.
 
-SecureRails is **not**:
-- autonomous cybercertification claim
-- offensive cyber capability
-- guaranteed security
-- autonomous claim promotion
-
-## What is an Evidence Docket?
-An Evidence Docket is the structured evidence record for a run: what executed, what artifacts were produced, what limits apply, and what claim level is permitted.
-
-## What is a ProofBundle?
-A ProofBundle is the artifact package (logs, hashes, manifests, replay instructions, and checks) that supports an Evidence Docket.
-
-## What is a Work Vault?
-A Work Vault is the governed container for a scoped defensive work request and its bounded execution trail.
-
-## What is MARK?
-ALPHA AGI MARK is a utility-budget allocation signal for bounded protocol work. It is governance/accounting metadata, not investment framing.
-
-## What is a Sovereign?
-An ALPHA AGI Sovereign is the assigned governed execution identity responsible for an AGI Job scope and related accountability records.
-
-## What can I safely run?
-- Workflows listed in `docs/WORKFLOW_LAUNCHPAD.md` and `docs/WORKFLOW_CATALOG.md`.
-- Evidence and replay workflows that produce bounded artifacts.
-- SecureRails demo and compliance workflows.
-
-## What should I avoid?
-- Treating green checks as AGI/ASI/SOTA proof.
-- Merging remediation PRs automatically.
-- Publishing claims without an Evidence Docket.
-- Using investment language for `$AGIALPHA`.
-
-## What does a green check mean?
-A green check means that workflow checks passed for that run configuration. It does **not** authorize unrestricted claims.
-
-## What does a red check mean?
-A red check means at least one guardrail, test, or execution path failed and needs investigation before follow-up action.
-
-## Where do I find artifacts?
-Open the specific GitHub Actions run and use the **Artifacts** section.
-
-## Where do I see public results?
-Use:
-- `docs/EVIDENCE_MISSION_CONTROL.md`
+## What you can safely run first
+Use workflows listed in:
 - `docs/WORKFLOW_LAUNCHPAD.md`
-- `docs/EXPERIMENT_GUIDE.md`
+- `docs/WORKFLOW_CATALOG.md`
 
-## Recommended first path
-1. Open Evidence Mission Control (`docs/EVIDENCE_MISSION_CONTROL.md`).
-2. Open the GitHub **Actions** tab.
-3. Run a safe workflow from `docs/WORKFLOW_LAUNCHPAD.md`.
-4. Inspect logs for checks and boundaries.
-5. Download the artifact package.
+Prefer evidence/replay/falsification and SecureRails compliance workflows first.
+
+## What to avoid
+- Treating a green check as a capability promotion.
+- Merging remediation automatically without human review.
+- Publishing claims without an Evidence Docket.
+- Describing `$AGIALPHA` as investment/returns/yield.
+
+## Green check vs red check
+- **Green check**: workflow checks passed for that run scope.
+- **Red check**: one or more checks failed, or guardrails blocked execution.
+- In both cases, claims remain bounded by docket/ledger evidence and review status.
+
+## Where artifacts and results live
+- **Run artifacts**: GitHub Actions run page → **Artifacts**.
+- **Public evidence pages / discovery**: `docs/EVIDENCE_MISSION_CONTROL.md` and workflow-linked pages.
+- **Safety and claim posture**: `docs/CLAIM_BOUNDARIES.md` and SecureRails docs.
+
+## Recommended first path (do this in order)
+1. Open `docs/EVIDENCE_MISSION_CONTROL.md`.
+2. Open repository **Actions** tab.
+3. Launch one safe workflow from `docs/WORKFLOW_LAUNCHPAD.md`.
+4. Inspect logs for safety + claim checks.
+5. Download artifacts.
 6. Read the Evidence Docket.
-7. Check safety ledger counters.
-8. Confirm claim boundary statements.
-9. Never merge unsafe remediation automatically.
+7. Check safety ledger counters and replay/falsification status.
+8. Confirm claim boundary language before any sharing.
+9. Never auto-merge unsafe remediation.
 
-## One-line doctrine
-**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
+## Doctrine (non-negotiable)
+**No Evidence Docket, no unsupported top-tier benchmark claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**


### PR DESCRIPTION
### Motivation
- Tighten and clarify allowed/forbidden claim language to prevent unsupported top-tier benchmark or investment framing and to make governance boundaries explicit.
- Improve onboarding and developer guidance so operators run evidence-producing workflows safely and follow doc-audit expectations.
- Standardize terminology for `SecureRails`, `Evidence Docket`, `ProofBundle`, and `$AGIALPHA` utility semantics to avoid ambiguous or promotional language.

### Description
- Rewrote `docs/CLAIM_BOUNDARIES.md` to replace free-form lists with explicit "Allowed" and "Forbidden" claim categories, add positive/negative examples, and refine SecureRails and `$AGIALPHA` boundary statements.
- Overhauled `docs/DEVELOPER_GUIDE.md` to present a clearer repository structure, add a `Local setup` walkthrough with recommended `venv` commands, document docs-audit expectations, and add stepwise guidance for adding scripts, schemas, and workflows.
- Simplified and restructured `docs/START_HERE.md` with a one-sentence summary, concise core-term definitions, explicit "What this system is not" statements, clearer recommended first steps, and an updated non-negotiable doctrine line. 
- Adjusted wording throughout to consistently discourage AGI/ASI/top-tier benchmark claims, investment framing for `$AGIALPHA`, and autonomous claim promotion. 

### Testing
- No automated tests were executed as part of this PR because the changes are documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9c918a6883339c9107c49d602524)