### PR TITLE
Implement SecureRails supply-chain provenance and repository health evidence

### DIFF
--- a/.github/workflows/securerails-supply-chain-provenance-001.yml
+++ b/.github/workflows/securerails-supply-chain-provenance-001.yml
@@ -35,6 +35,17 @@ jobs:
       - run: python -m secure_rails supply-chain hash-artifacts --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/artifact_manifest.json
       - run: python -m secure_rails supply-chain provenance --repo-root . --artifact-manifest secure-rails-supply-chain-output/artifact_manifest.json --out secure-rails-supply-chain-output/provenance_record.json
       - run: python -m secure_rails supply-chain repository-health --repo-root . --out secure-rails-supply-chain-output/repository_health.json
+      - name: Optional OpenSSF Scorecard note
+        if: ${{ inputs.run_scorecard == 'true' }}
+        run: |
+          python - <<'PY2'
+          import json
+          p='secure-rails-supply-chain-output/repository_health.json'
+          data=json.load(open(p))
+          data['checks']['scorecard_status']='unavailable'
+          data['scorecard']={'enabled':True,'raw_output_path':None,'summary':{'note':'OpenSSF Scorecard is an advisory repository security-health signal and does not certify SecureRails.'}}
+          json.dump(data,open(p,'w'),indent=2)
+          PY2
       - run: python -m secure_rails supply-chain build-report --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/supply_chain_report.json
       - run: python -m secure_rails supply-chain render --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/summary.md
       - run: python -m secure_rails supply-chain validate --input secure-rails-supply-chain-output
@@ -56,10 +67,16 @@ jobs:
         with: {python-version: '3.11'}
       - uses: actions/download-artifact@v4
         with: {name: securerails-supply-chain-output, path: secure-rails-supply-chain-output}
+      - name: Attempt GitHub Artifact Attestation
+        continue-on-error: true
+        id: attest
+        uses: actions/attest@v1
+        with:
+          subject-path: secure-rails-supply-chain-output/**
       - run: |
           python - <<'PY2'
           import json
-          rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":"unavailable","method":"github_artifact_attestation","attestation_paths":[],"verification_instructions":"Artifact attestation attempted, but no attestation bundle was produced in this workflow run."}}
+          rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":"unavailable","method":"github_artifact_attestation","attestation_paths":[],"verification_instructions":"Artifact attestation unavailable; local provenance record generated."}}
           open('secure-rails-supply-chain-output/attestation_record.json','w').write(json.dumps(rec,indent=2))
           PY2
       - run: python -m secure_rails supply-chain build-report --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/supply_chain_report.json

--- a/secure_rails/artifact_manifest.py
+++ b/secure_rails/artifact_manifest.py
@@ -1,31 +1,68 @@
-import hashlib, json, os, glob
+import glob
+import hashlib
+import json
+import os
 from datetime import datetime, timezone
 
 OPTIONAL_GLOBS = [
-    'docs/secure-rails/*.md','docs/secure-rails/templates/*.json','secure_rails_registry/*.json',
-    'docs/_generated/secure-rails/*.json','docs/_generated/secure-rails/supply-chain/*.json',
-    '**/evidence-run-manifest.json','**/safety-ledger*.json','**/*work-vault*.json','**/*proofbundle*.json','**/*evidence-docket*.json'
+    'docs/secure-rails/*.md',
+    'docs/secure-rails/templates/*.json',
+    'secure_rails_registry/*.json',
+    'docs/_generated/secure-rails/*.json',
+    'docs/_generated/secure-rails/supply-chain/*.json',
+    '**/evidence-run-manifest.json',
+    '**/safety-ledger*.json',
+    '**/*work-vault*.json',
+    '**/*proofbundle*.json',
+    '**/*evidence-docket*.json',
 ]
 
+
 def _sha256(path):
-    h=hashlib.sha256()
-    with open(path,'rb') as f:
-        for c in iter(lambda:f.read(65536),b''): h.update(c)
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for c in iter(lambda: f.read(65536), b''):
+            h.update(c)
     return h.hexdigest()
 
+
 def build_manifest(repo_root, out_dir, workflow_name='local', workflow_run_id='local'):
-    artifacts=[]; missing=[]; seen=set()
+    artifacts = []
+    missing = []
+    seen = set()
     for pattern in OPTIONAL_GLOBS:
-        matches=glob.glob(os.path.join(repo_root, pattern), recursive=True)
+        matches = glob.glob(os.path.join(repo_root, pattern), recursive=True)
         if not matches:
             missing.append(pattern)
         for p in matches:
             if os.path.isfile(p):
-                rel=os.path.relpath(p, repo_root)
-                if rel in seen: continue
+                rel = os.path.relpath(p, repo_root)
+                if rel in seen:
+                    continue
                 seen.add(rel)
-                artifacts.append({"path":rel,"sha256":_sha256(p),"size_bytes":os.path.getsize(p),"artifact_type":"evidence","claim_boundary_present":True})
-    m={"schema_version":"securerails.artifact_manifest.v1","generated_at":datetime.now(timezone.utc).isoformat(),"repository":os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop'),"commit_sha":os.getenv('GITHUB_SHA','local'),"workflow_run_id":str(workflow_run_id),"workflow_name":workflow_name,"artifact_scope":"secure_rails_supply_chain_provenance_001","artifacts":sorted(artifacts,key=lambda x:x['path']),"not_found":missing,"claim_boundary":"This artifact manifest records hashes and provenance metadata. It does not certify security or claim empirical SOTA."}
-    os.makedirs(out_dir,exist_ok=True)
-    p=os.path.join(out_dir,'artifact_manifest.json');json.dump(m,open(p,'w'),indent=2)
+                artifacts.append({
+                    'path': rel,
+                    'sha256': _sha256(p),
+                    'size_bytes': os.path.getsize(p),
+                    'artifact_type': 'evidence',
+                    'claim_boundary_present': True,
+                })
+
+    m = {
+        'schema_version': 'securerails.artifact_manifest.v1',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'repository': os.getenv('GITHUB_REPOSITORY', 'MontrealAI/agialpha-first-real-loop'),
+        'commit_sha': os.getenv('GITHUB_SHA', 'local'),
+        'workflow_run_id': str(workflow_run_id),
+        'workflow_name': workflow_name,
+        'artifact_scope': 'secure_rails_supply_chain_provenance_001',
+        'artifacts': sorted(artifacts, key=lambda x: x['path']),
+        'not_found': missing,
+        'claim_boundary': 'This artifact manifest records hashes and provenance metadata. It does not certify security or claim empirical SOTA.',
+    }
+
+    os.makedirs(out_dir, exist_ok=True)
+    p = os.path.join(out_dir, 'artifact_manifest.json')
+    with open(p, 'w', encoding='utf-8') as f:
+        json.dump(m, f, indent=2)
     return m

--- a/secure_rails/attestations.py
+++ b/secure_rails/attestations.py
@@ -1,9 +1,20 @@
 import json
 
+
 def build_attestation_record(out_path, attempt=False, supported=False, reason='local run'):
-    status='not_attempted'
-    if attempt and supported: status='generated'
-    elif attempt and not supported: status='unavailable'
-    rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":status,"method":"github_artifact_attestation" if supported else "local_provenance_record","reason":reason}}
-    json.dump(rec,open(out_path,'w'),indent=2)
+    status = 'not_attempted'
+    if attempt and supported:
+        status = 'generated'
+    elif attempt and not supported:
+        status = 'unavailable'
+    rec = {
+        'schema_version': 'securerails.attestation_record.v1',
+        'attestation': {
+            'status': status,
+            'method': 'github_artifact_attestation' if supported else 'local_provenance_record',
+            'reason': reason,
+        },
+    }
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(rec, f, indent=2)
     return rec

--- a/secure_rails/provenance.py
+++ b/secure_rails/provenance.py
@@ -1,8 +1,50 @@
-import hashlib, json, os
+import hashlib
+import json
+import os
 from datetime import datetime, timezone
 
+
+def _workflow_run_url() -> str:
+    repo = os.getenv('GITHUB_REPOSITORY', 'MontrealAI/agialpha-first-real-loop')
+    run_id = os.getenv('GITHUB_RUN_ID', '0')
+    return f"https://github.com/{repo}/actions/runs/{run_id}"
+
+
 def build_provenance(repo_root, manifest_path, out_path):
-    data=open(manifest_path,'rb').read()
-    rec={"schema_version":"securerails.provenance_record.v1","generated_at":datetime.now(timezone.utc).isoformat(),"repository":os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop'),"commit_sha":os.getenv('GITHUB_SHA','local'),"branch":os.getenv('GITHUB_REF_NAME','local'),"workflow_name":os.getenv('GITHUB_WORKFLOW','local'),"workflow_file":'.github/workflows/securerails-supply-chain-provenance-001.yml',"workflow_run_id":os.getenv('GITHUB_RUN_ID','local'),"workflow_run_url":f"https://github.com/{os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop')}/actions/runs/{os.getenv('GITHUB_RUN_ID','0')}","event_name":os.getenv('GITHUB_EVENT_NAME','local'),"actor":os.getenv('GITHUB_ACTOR','local'),"artifact_manifest_sha256":hashlib.sha256(data).hexdigest(),"builder":{"type":"github_actions" if os.getenv('GITHUB_ACTIONS') else 'local','runner':os.getenv('RUNNER_NAME','local'),'permissions_summary':{}},"attestation":{"status":"unavailable" if not os.getenv('GITHUB_ACTIONS') else "not_attempted","method":"local_provenance_record","attestation_paths":[],"verification_instructions":"Use sha256sum on artifact files and compare to artifact_manifest.json."},"claim_boundary":"This provenance record documents where and how artifacts were produced. It is not a security certification."}
-    json.dump(rec,open(out_path,'w'),indent=2)
+    with open(manifest_path, 'rb') as f:
+        data = f.read()
+
+    attestation_status = 'not_attempted' if os.getenv('GITHUB_ACTIONS') else 'unavailable'
+    attestation_reason = 'local run' if not os.getenv('GITHUB_ACTIONS') else 'skipped by input'
+
+    rec = {
+        'schema_version': 'securerails.provenance_record.v1',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'repository': os.getenv('GITHUB_REPOSITORY', 'MontrealAI/agialpha-first-real-loop'),
+        'commit_sha': os.getenv('GITHUB_SHA', 'local'),
+        'branch': os.getenv('GITHUB_REF_NAME', 'local'),
+        'workflow_name': os.getenv('GITHUB_WORKFLOW', 'local'),
+        'workflow_file': '.github/workflows/securerails-supply-chain-provenance-001.yml',
+        'workflow_run_id': os.getenv('GITHUB_RUN_ID', 'local'),
+        'workflow_run_url': _workflow_run_url(),
+        'event_name': os.getenv('GITHUB_EVENT_NAME', 'local'),
+        'actor': os.getenv('GITHUB_ACTOR', 'local'),
+        'artifact_manifest_sha256': hashlib.sha256(data).hexdigest(),
+        'builder': {
+            'type': 'github_actions' if os.getenv('GITHUB_ACTIONS') else 'local',
+            'runner': os.getenv('RUNNER_NAME', 'local'),
+            'permissions_summary': {},
+        },
+        'attestation': {
+            'status': attestation_status,
+            'method': 'local_provenance_record',
+            'attestation_paths': [],
+            'verification_instructions': f'Use sha256sum and compare hashes against artifact_manifest.json ({attestation_reason}).',
+        },
+        'claim_boundary': 'This provenance record documents where and how artifacts were produced. It is not a security certification.',
+    }
+
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(rec, f, indent=2)
+
     return rec

--- a/secure_rails/repository_health.py
+++ b/secure_rails/repository_health.py
@@ -1,8 +1,32 @@
-import json, os
+import json
+import os
+from datetime import datetime, timezone
+
 
 def build_repository_health(repo_root, out_path):
-    has_catalog=os.path.exists(os.path.join(repo_root,'docs/WORKFLOW_CATALOG.md'))
-    has_guard=os.path.exists(os.path.join(repo_root,'.github/workflows/secure-rails-compliance-guard.yml'))
-    rec={"schema_version":"securerails.repository_health.v1","generated_at":"","repository":os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop'),"commit_sha":os.getenv('GITHUB_SHA','local'),"checks":{"workflow_catalog_documented":"pass" if has_catalog else "fail","secure_rails_compliance_guard_present":"pass" if has_guard else "fail","no_direct_pages_deploy_except_central_publisher":"pass","branch_protection_status":"not_reported","scorecard_status":"not_run","scorecard_score":"not_reported","artifact_attestation_status":"unavailable","claim_boundary_check":"pass","safety_ledger_check":"pass","no_automerge_check":"pass","use_case_triage_check":"pass"},"scorecard":{"enabled":False,"raw_output_path":None,"summary":{}},"claim_boundary":"This repository health report is an advisory security-governance artifact. It is not a certification."}
-    json.dump(rec,open(out_path,'w'),indent=2)
+    has_catalog = os.path.exists(os.path.join(repo_root, 'docs/WORKFLOW_CATALOG.md'))
+    has_guard = os.path.exists(os.path.join(repo_root, '.github/workflows/secure-rails-compliance-guard.yml'))
+    rec = {
+        'schema_version': 'securerails.repository_health.v1',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'repository': os.getenv('GITHUB_REPOSITORY', 'MontrealAI/agialpha-first-real-loop'),
+        'commit_sha': os.getenv('GITHUB_SHA', 'local'),
+        'checks': {
+            'workflow_catalog_documented': 'pass' if has_catalog else 'fail',
+            'secure_rails_compliance_guard_present': 'pass' if has_guard else 'fail',
+            'no_direct_pages_deploy_except_central_publisher': 'pass',
+            'branch_protection_status': 'not_reported',
+            'scorecard_status': 'not_run',
+            'scorecard_score': 'not_reported',
+            'artifact_attestation_status': 'unavailable',
+            'claim_boundary_check': 'pass',
+            'safety_ledger_check': 'pass',
+            'no_automerge_check': 'pass',
+            'use_case_triage_check': 'pass',
+        },
+        'scorecard': {'enabled': False, 'raw_output_path': None, 'summary': {}},
+        'claim_boundary': 'This repository health report is an advisory security-governance artifact. It is not a certification.',
+    }
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(rec, f, indent=2)
     return rec


### PR DESCRIPTION
### Motivation
- Extend SecureRails from PR governance into supply-chain-grade evidence so artifacts have verifiable hash manifests, provenance, attestations (or honest fallback), and repository health signals.
- Ensure evidence generation is deterministic, bound to commit/workflow metadata, preserves SecureRails claim boundaries, and isolates elevated permissions to attestation steps.

### Description
- Add and harden artifact manifest generation in `secure_rails/artifact_manifest.py` to compute deterministic `sha256` hashes, collect optional artifact globs, record `not_found` patterns, and emit `artifact_manifest.json` with UTC timestamps.
- Improve provenance generation in `secure_rails/provenance.py` to bind the manifest SHA, include `workflow_run_url`, builder summary, explicit attestation `status` (`unavailable` vs `not_attempted`), and safe file I/O via `with open`.
- Implement safe attestation record writer in `secure_rails/attestations.py` and advisory repository checks in `secure_rails/repository_health.py` that emit `attestation_record.json` and `repository_health.json` respectively with claim-boundary language.
- Update the `SecureRails Supply-Chain Provenance 001` workflow `.github/workflows/securerails-supply-chain-provenance-001.yml` to preserve least-privilege base permissions, isolate `id-token`/`attestations`/`artifact-metadata` only to the `attest` job, attempt `actions/attest@v1` with `continue-on-error`, and add an optional OpenSSF Scorecard advisory note without failing the run.

### Testing
- Ran local SecureRails checks `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, and `python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json`, all of which passed.
- Exercised the supply-chain CLI end-to-end with `python -m secure_rails supply-chain collect`, `hash-artifacts`, `provenance`, `repository-health`, `build-report`, `render`, and `validate` to produce the expected output files, which succeeded.
- Ran documentation audits `python -m agialpha_docs audit-workflows`, `audit-claims`, `audit-links`, and `audit-readmes`, and executed the unit test suite with `python -m unittest discover -s tests`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43ee4c6c833399bbc1a0c3714b62)