### PR TITLE
Implement SecureRails supply-chain provenance and repository health evidence

### DIFF
--- a/secure_rails/artifact_manifest.py
+++ b/secure_rails/artifact_manifest.py
@@ -27,5 +27,7 @@ def build_manifest(repo_root, out_dir, workflow_name='local', workflow_run_id='l
                 artifacts.append({"path":rel,"sha256":_sha256(p),"size_bytes":os.path.getsize(p),"artifact_type":"evidence","claim_boundary_present":True})
     m={"schema_version":"securerails.artifact_manifest.v1","generated_at":datetime.now(timezone.utc).isoformat(),"repository":os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop'),"commit_sha":os.getenv('GITHUB_SHA','local'),"workflow_run_id":str(workflow_run_id),"workflow_name":workflow_name,"artifact_scope":"secure_rails_supply_chain_provenance_001","artifacts":sorted(artifacts,key=lambda x:x['path']),"not_found":missing,"claim_boundary":"This artifact manifest records hashes and provenance metadata. It does not certify security or claim empirical SOTA."}
     os.makedirs(out_dir,exist_ok=True)
-    p=os.path.join(out_dir,'artifact_manifest.json');json.dump(m,open(p,'w'),indent=2)
+    p=os.path.join(out_dir,'artifact_manifest.json')
+    with open(p,'w',encoding='utf-8') as f:
+        json.dump(m,f,indent=2)
     return m

--- a/secure_rails/attestations.py
+++ b/secure_rails/attestations.py
@@ -5,5 +5,6 @@ def build_attestation_record(out_path, attempt=False, supported=False, reason='l
     if attempt and supported: status='generated'
     elif attempt and not supported: status='unavailable'
     rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":status,"method":"github_artifact_attestation" if supported else "local_provenance_record","reason":reason}}
-    json.dump(rec,open(out_path,'w'),indent=2)
+    with open(out_path,'w',encoding='utf-8') as f:
+        json.dump(rec,f,indent=2)
     return rec

--- a/secure_rails/provenance.py
+++ b/secure_rails/provenance.py
@@ -2,7 +2,9 @@ import hashlib, json, os
 from datetime import datetime, timezone
 
 def build_provenance(repo_root, manifest_path, out_path):
-    data=open(manifest_path,'rb').read()
+    with open(manifest_path,'rb') as f:
+        data=f.read()
     rec={"schema_version":"securerails.provenance_record.v1","generated_at":datetime.now(timezone.utc).isoformat(),"repository":os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop'),"commit_sha":os.getenv('GITHUB_SHA','local'),"branch":os.getenv('GITHUB_REF_NAME','local'),"workflow_name":os.getenv('GITHUB_WORKFLOW','local'),"workflow_file":'.github/workflows/securerails-supply-chain-provenance-001.yml',"workflow_run_id":os.getenv('GITHUB_RUN_ID','local'),"workflow_run_url":f"https://github.com/{os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop')}/actions/runs/{os.getenv('GITHUB_RUN_ID','0')}","event_name":os.getenv('GITHUB_EVENT_NAME','local'),"actor":os.getenv('GITHUB_ACTOR','local'),"artifact_manifest_sha256":hashlib.sha256(data).hexdigest(),"builder":{"type":"github_actions" if os.getenv('GITHUB_ACTIONS') else 'local','runner':os.getenv('RUNNER_NAME','local'),'permissions_summary':{}},"attestation":{"status":"unavailable" if not os.getenv('GITHUB_ACTIONS') else "not_attempted","method":"local_provenance_record","attestation_paths":[],"verification_instructions":"Use sha256sum on artifact files and compare to artifact_manifest.json."},"claim_boundary":"This provenance record documents where and how artifacts were produced. It is not a security certification."}
-    json.dump(rec,open(out_path,'w'),indent=2)
+    with open(out_path,'w',encoding='utf-8') as f:
+        json.dump(rec,f,indent=2)
     return rec

--- a/secure_rails/repository_health.py
+++ b/secure_rails/repository_health.py
@@ -4,5 +4,6 @@ def build_repository_health(repo_root, out_path):
     has_catalog=os.path.exists(os.path.join(repo_root,'docs/WORKFLOW_CATALOG.md'))
     has_guard=os.path.exists(os.path.join(repo_root,'.github/workflows/secure-rails-compliance-guard.yml'))
     rec={"schema_version":"securerails.repository_health.v1","generated_at":"","repository":os.getenv('GITHUB_REPOSITORY','MontrealAI/agialpha-first-real-loop'),"commit_sha":os.getenv('GITHUB_SHA','local'),"checks":{"workflow_catalog_documented":"pass" if has_catalog else "fail","secure_rails_compliance_guard_present":"pass" if has_guard else "fail","no_direct_pages_deploy_except_central_publisher":"pass","branch_protection_status":"not_reported","scorecard_status":"not_run","scorecard_score":"not_reported","artifact_attestation_status":"unavailable","claim_boundary_check":"pass","safety_ledger_check":"pass","no_automerge_check":"pass","use_case_triage_check":"pass"},"scorecard":{"enabled":False,"raw_output_path":None,"summary":{}},"claim_boundary":"This repository health report is an advisory security-governance artifact. It is not a certification."}
-    json.dump(rec,open(out_path,'w'),indent=2)
+    with open(out_path,'w',encoding='utf-8') as f:
+        json.dump(rec,f,indent=2)
     return rec


### PR DESCRIPTION
### Motivation

- Prevent file-descriptor/resource leaks and make supply-chain writers deterministic and encoding-safe when producing JSON evidence artifacts for SecureRails Supply-Chain Provenance 001.

### Description

- Replace ad-hoc `open(...).read()` / `json.dump(..., open(...))` usages with context-managed file operations (`with open(..., encoding='utf-8'):`) to ensure files are closed and written with UTF-8 encoding in `secure_rails/artifact_manifest.py`, `secure_rails/provenance.py`, `secure_rails/attestations.py`, and `secure_rails/repository_health.py`.
- Switch `build_provenance` to read the artifact manifest using a `with open(...,'rb')` context to avoid leaked readers and make SHA256 calculation robust.
- Preserve existing manifest/provenance/attestation/repository-health JSON shapes and CLI behavior; no schema changes or behavioral changes to outputs.

### Testing

- Ran the full unit test suite with `python -m unittest discover -s tests`, which executed 209 tests and completed with `OK`.
- Executed supply-chain CLI sequence including `python -m secure_rails supply-chain collect`, `hash-artifacts`, `provenance`, `repository-health`, `build-report`, `render`, and `validate`, and each command completed successfully and produced the expected output files.
- Ran repository checks `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py ...`, `python scripts/secure_rails_no_automerge_check.py .`, and `python scripts/secure_rails_use_case_triage_check.py ...`, all of which reported `PASS`.
- Ran docs audits with `python -m agialpha_docs audit-workflows`, `audit-claims`, `audit-links`, and `audit-readmes`, all returning OK/green results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43ee4c6c833399bbc1a0c3714b62)