### PR TITLE
Implement SecureRails supply-chain provenance and repository health evidence

### DIFF
--- a/.github/workflows/securerails-supply-chain-provenance-001.yml
+++ b/.github/workflows/securerails-supply-chain-provenance-001.yml
@@ -61,6 +61,9 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.11'}
       - uses: actions/download-artifact@v4
         with: {name: securerails-supply-chain-output, path: secure-rails-supply-chain-output}
       - name: Attempt artifact attestation

--- a/.github/workflows/securerails-supply-chain-provenance-001.yml
+++ b/.github/workflows/securerails-supply-chain-provenance-001.yml
@@ -31,15 +31,25 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: '3.11'}
       - run: python scripts/secure_rails_claim_boundary_check.py .
+      - run: python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+      - run: python scripts/secure_rails_no_automerge_check.py .
+      - run: python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
       - run: python -m secure_rails supply-chain collect --repo-root . --out secure-rails-supply-chain-output
       - run: python -m secure_rails supply-chain hash-artifacts --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/artifact_manifest.json
       - run: python -m secure_rails supply-chain provenance --repo-root . --artifact-manifest secure-rails-supply-chain-output/artifact_manifest.json --out secure-rails-supply-chain-output/provenance_record.json
       - run: python -m secure_rails supply-chain repository-health --repo-root . --out secure-rails-supply-chain-output/repository_health.json
+      - name: Optional OpenSSF Scorecard
+        if: ${{ inputs.run_scorecard == 'true' }}
+        continue-on-error: true
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: secure-rails-supply-chain-output/scorecard-results.sarif
       - run: python -m secure_rails supply-chain build-report --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/supply_chain_report.json
       - run: python -m secure_rails supply-chain render --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/summary.md
       - run: python -m secure_rails supply-chain validate --input secure-rails-supply-chain-output
       - uses: actions/upload-artifact@v4
         with: {name: securerails-supply-chain-output, path: secure-rails-supply-chain-output}
+
   attest:
     if: ${{ inputs.attempt_github_attestation == 'true' }}
     needs: [supply-chain]
@@ -51,16 +61,26 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
       - uses: actions/download-artifact@v4
         with: {name: securerails-supply-chain-output, path: secure-rails-supply-chain-output}
+      - name: Attempt artifact attestation
+        id: attest_step
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: secure-rails-supply-chain-output/**
       - run: |
           python - <<'PY2'
           import json
-          rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":"unavailable","method":"github_artifact_attestation","attestation_paths":[],"verification_instructions":"Artifact attestation attempted, but no attestation bundle was produced in this workflow run."}}
-          open('secure-rails-supply-chain-output/attestation_record.json','w').write(json.dumps(rec,indent=2))
+          from secure_rails.attestations import build_attestation_record
+          outcome = "generated" if "${{ steps.attest_step.outcome }}" == "success" else "unavailable"
+          rec = build_attestation_record(
+              'secure-rails-supply-chain-output/attestation_record.json',
+              attempt=True,
+              supported=(outcome == 'generated'),
+              reason='generated' if outcome == 'generated' else 'action unsupported, permissions unavailable, or local fallback',
+          )
+          print(json.dumps(rec, indent=2))
           PY2
       - run: python -m secure_rails supply-chain build-report --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/supply_chain_report.json
       - run: python -m secure_rails supply-chain render --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/summary.md

--- a/secure_rails/attestations.py
+++ b/secure_rails/attestations.py
@@ -1,10 +1,40 @@
 import json
+from datetime import datetime, timezone
 
-def build_attestation_record(out_path, attempt=False, supported=False, reason='local run'):
-    status='not_attempted'
-    if attempt and supported: status='generated'
-    elif attempt and not supported: status='unavailable'
-    rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":status,"method":"github_artifact_attestation" if supported else "local_provenance_record","reason":reason}}
-    with open(out_path,'w',encoding='utf-8') as f:
-        json.dump(rec,f,indent=2)
+
+def build_attestation_record(
+    out_path,
+    attempt=False,
+    supported=False,
+    reason='local run',
+    attestation_paths=None,
+):
+    status = 'not_attempted'
+    method = 'local_provenance_record'
+    if attempt and supported:
+        status = 'generated'
+        method = 'github_artifact_attestation'
+    elif attempt and not supported:
+        status = 'unavailable'
+        method = 'github_artifact_attestation'
+
+    rec = {
+        'schema_version': 'securerails.attestation_record.v1',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'attestation': {
+            'status': status,
+            'method': method,
+            'reason': reason,
+            'attestation_paths': attestation_paths or [],
+            'verification_instructions': (
+                'Use `gh attestation verify` when GitHub attestation is available; '
+                'otherwise validate file hashes against artifact_manifest.json.'
+            ),
+        },
+        'claim_boundary': (
+            'This attestation record is supply-chain evidence and does not certify security.'
+        ),
+    }
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(rec, f, indent=2)
     return rec


### PR DESCRIPTION
### Motivation
- Add supply-chain-grade evidence to SecureRails so artifacts and evidence records include verifiable provenance and repository security posture without introducing certification claims. 
- Provide graceful handling when GitHub Artifact Attestations or OpenSSF Scorecard are unavailable while preserving SecureRails claim boundaries.

### Description
- Hardened `secure_rails.attestations.build_attestation_record` to include `generated_at`, explicit `attestation_paths`, `verification_instructions`, `reason`, and a claim-boundary field while correctly reporting `generated`, `unavailable`, and `not_attempted` states (file: `secure_rails/attestations.py`).
- Updated the `SecureRails Supply-Chain Provenance 001` workflow to run additional safety checks, keep least-privilege base permissions, run an optional OpenSSF Scorecard in advisory mode, isolate elevated permissions to the attestation job, attempt GitHub artifact attestation via `actions/attest-build-provenance@v1`, and fall back to a local attestation record when attestation is unavailable (file: `.github/workflows/securerails-supply-chain-provenance-001.yml`).
- The attestation step now records honest outcome reasons and does not cause workflow failure when attestation or scorecard support is missing, and the workflow does not deploy GitHub Pages or add a second publisher.

### Testing
- Ran SecureRails checks `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, and `python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json`, all of which passed.
- Executed the supply-chain CLI sequence (`python -m secure_rails supply-chain collect`, `hash-artifacts`, `provenance`, `repository-health`, `build-report`, `render`, `validate`) and the commands completed and produced expected artifacts in `/tmp/securerails-supply-chain`.
- Ran docs audits with `python -m agialpha_docs audit-workflows`, `audit-claims`, `audit-links`, and `audit-readmes` which passed, and ran the full test suite with `python -m unittest discover -s tests` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4c313da48333a6cc11d46423e848)