### PR TITLE
Add attestation record builder and expand supply-chain workflow with extra checks and optional Scorecard

### DIFF
--- a/.github/workflows/securerails-supply-chain-provenance-001.yml
+++ b/.github/workflows/securerails-supply-chain-provenance-001.yml
@@ -31,15 +31,25 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: '3.11'}
       - run: python scripts/secure_rails_claim_boundary_check.py .
+      - run: python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+      - run: python scripts/secure_rails_no_automerge_check.py .
+      - run: python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
       - run: python -m secure_rails supply-chain collect --repo-root . --out secure-rails-supply-chain-output
       - run: python -m secure_rails supply-chain hash-artifacts --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/artifact_manifest.json
       - run: python -m secure_rails supply-chain provenance --repo-root . --artifact-manifest secure-rails-supply-chain-output/artifact_manifest.json --out secure-rails-supply-chain-output/provenance_record.json
       - run: python -m secure_rails supply-chain repository-health --repo-root . --out secure-rails-supply-chain-output/repository_health.json
+      - name: Optional OpenSSF Scorecard
+        if: ${{ inputs.run_scorecard == 'true' }}
+        continue-on-error: true
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: secure-rails-supply-chain-output/scorecard-results.sarif
       - run: python -m secure_rails supply-chain build-report --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/supply_chain_report.json
       - run: python -m secure_rails supply-chain render --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/summary.md
       - run: python -m secure_rails supply-chain validate --input secure-rails-supply-chain-output
       - uses: actions/upload-artifact@v4
         with: {name: securerails-supply-chain-output, path: secure-rails-supply-chain-output}
+
   attest:
     if: ${{ inputs.attempt_github_attestation == 'true' }}
     needs: [supply-chain]
@@ -56,11 +66,24 @@ jobs:
         with: {python-version: '3.11'}
       - uses: actions/download-artifact@v4
         with: {name: securerails-supply-chain-output, path: secure-rails-supply-chain-output}
+      - name: Attempt artifact attestation
+        id: attest_step
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: secure-rails-supply-chain-output/**
       - run: |
           python - <<'PY2'
           import json
-          rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":"unavailable","method":"github_artifact_attestation","attestation_paths":[],"verification_instructions":"Artifact attestation attempted, but no attestation bundle was produced in this workflow run."}}
-          open('secure-rails-supply-chain-output/attestation_record.json','w').write(json.dumps(rec,indent=2))
+          from secure_rails.attestations import build_attestation_record
+          outcome = "generated" if "${{ steps.attest_step.outcome }}" == "success" else "unavailable"
+          rec = build_attestation_record(
+              'secure-rails-supply-chain-output/attestation_record.json',
+              attempt=True,
+              supported=(outcome == 'generated'),
+              reason='generated' if outcome == 'generated' else 'action unsupported, permissions unavailable, or local fallback',
+          )
+          print(json.dumps(rec, indent=2))
           PY2
       - run: python -m secure_rails supply-chain build-report --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/supply_chain_report.json
       - run: python -m secure_rails supply-chain render --input secure-rails-supply-chain-output --out secure-rails-supply-chain-output/summary.md

--- a/secure_rails/attestations.py
+++ b/secure_rails/attestations.py
@@ -1,10 +1,40 @@
 import json
+from datetime import datetime, timezone
 
-def build_attestation_record(out_path, attempt=False, supported=False, reason='local run'):
-    status='not_attempted'
-    if attempt and supported: status='generated'
-    elif attempt and not supported: status='unavailable'
-    rec={"schema_version":"securerails.attestation_record.v1","attestation":{"status":status,"method":"github_artifact_attestation" if supported else "local_provenance_record","reason":reason}}
-    with open(out_path,'w',encoding='utf-8') as f:
-        json.dump(rec,f,indent=2)
+
+def build_attestation_record(
+    out_path,
+    attempt=False,
+    supported=False,
+    reason='local run',
+    attestation_paths=None,
+):
+    status = 'not_attempted'
+    method = 'local_provenance_record'
+    if attempt and supported:
+        status = 'generated'
+        method = 'github_artifact_attestation'
+    elif attempt and not supported:
+        status = 'unavailable'
+        method = 'github_artifact_attestation'
+
+    rec = {
+        'schema_version': 'securerails.attestation_record.v1',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'attestation': {
+            'status': status,
+            'method': method,
+            'reason': reason,
+            'attestation_paths': attestation_paths or [],
+            'verification_instructions': (
+                'Use `gh attestation verify` when GitHub attestation is available; '
+                'otherwise validate file hashes against artifact_manifest.json.'
+            ),
+        },
+        'claim_boundary': (
+            'This attestation record is supply-chain evidence and does not certify security.'
+        ),
+    }
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(rec, f, indent=2)
     return rec


### PR DESCRIPTION
### Motivation

- Improve supply-chain provenance collection by adding more pre-checks and an attempt to produce GitHub artifact attestations.  
- Provide a standardized attestation record with richer metadata and guidance for verification.  
- Allow optional OpenSSF Scorecard runs without failing the workflow when unavailable.

### Description

- Update `.github/workflows/securerails-supply-chain-provenance-001.yml` to run additional validation scripts: `scripts/secure_rails_safety_ledger_check.py`, `scripts/secure_rails_no_automerge_check.py`, and `scripts/secure_rails_use_case_triage_check.py`.  
- Add an optional OpenSSF Scorecard step gated by the `inputs.run_scorecard` input and configured to continue on error and write `secure-rails-supply-chain-output/scorecard-results.sarif`.  
- Add a step to attempt artifact attestation using `actions/attest-build-provenance@v1` with `subject-path: secure-rails-supply-chain-output/**` and adapt the inline Python to call `secure_rails.attestations.build_attestation_record` using `steps.attest_step.outcome`.  
- Replace `secure_rails.attestations.build_attestation_record` with a new implementation that writes a richer JSON attestation record including `generated_at`, `attestation.status`, `method`, `reason`, `attestation_paths`, `verification_instructions`, and `claim_boundary`, and that returns the record object.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4c313da48333a6cc11d46423e848)