### PR TITLE
Implement SecureRails installable action and reusable workflow

### DIFF
--- a/.github/actions/securerails-pr-guard/README.md
+++ b/.github/actions/securerails-pr-guard/README.md
@@ -1,0 +1,7 @@
+# SecureRails PR Guard Composite Action
+
+Runs SecureRails defensive, data-only governance checks and generates advisory artifacts for human review.
+
+Boundary: SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, and not an investment product.
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.

--- a/.github/actions/securerails-pr-guard/action.yml
+++ b/.github/actions/securerails-pr-guard/action.yml
@@ -90,7 +90,7 @@ runs:
 
         REC="human_review_required"
         if [ -f "$OUT/pr_guard_report.json" ]; then
-          REC=$(python -c "import json;print(json.load(open('$OUT'/pr_guard_report.json')).get('recommendation','human_review_required'))")
+          REC=$(python -c "import json, pathlib; p=pathlib.Path(r'''$OUT''')/'pr_guard_report.json'; print(json.loads(p.read_text()).get('recommendation','human_review_required'))")
         fi
 
         echo "summary_path=$OUT/summary.md" >> "$GITHUB_OUTPUT"

--- a/.github/actions/securerails-pr-guard/action.yml
+++ b/.github/actions/securerails-pr-guard/action.yml
@@ -63,14 +63,16 @@ runs:
         ROOT='${{ inputs.repo-root }}'
         EVENT_PATH='${{ inputs.event-path }}'
         mkdir -p "$OUT/11_evidence_docket"
+        PROVIDER_ROOT="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)"
+        export PYTHONPATH="$PROVIDER_ROOT:${PYTHONPATH:-}"
 
-        python scripts/secure_rails_claim_boundary_check.py "$ROOT"
-        python scripts/secure_rails_no_automerge_check.py "$ROOT"
-        python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
-        python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
+        python "$PROVIDER_ROOT/scripts/secure_rails_claim_boundary_check.py" "$ROOT"
+        python "$PROVIDER_ROOT/scripts/secure_rails_no_automerge_check.py" "$ROOT"
+        python "$PROVIDER_ROOT/scripts/secure_rails_safety_ledger_check.py" "$PROVIDER_ROOT/docs/secure-rails/templates/safety-ledger-example.json"
+        python "$PROVIDER_ROOT/scripts/secure_rails_use_case_triage_check.py" "$PROVIDER_ROOT/docs/secure-rails/templates/deployment-intake-example.json"
 
-        if [ -f scripts/secure_rails_work_vault_check.py ]; then
-          python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json
+        if [ -f "$PROVIDER_ROOT/scripts/secure_rails_work_vault_check.py" ]; then
+          python "$PROVIDER_ROOT/scripts/secure_rails_work_vault_check.py" "$PROVIDER_ROOT/docs/secure-rails/templates/work-vault-example.json"
         fi
 
         if [ "$MODE" = "pr_guard" ] || [ "$MODE" = "compliance_guard" ] || [ "$MODE" = "work_vault" ] || [ "$MODE" = "supply_chain" ]; then
@@ -95,7 +97,7 @@ runs:
 
         echo "summary_path=$OUT/summary.md" >> "$GITHUB_OUTPUT"
         echo "evidence_docket_path=$OUT/11_evidence_docket" >> "$GITHUB_OUTPUT"
-        echo "work_vault_path=$OUT/work_vault.json" >> "$GITHUB_OUTPUT"
-        echo "safety_ledger_path=$OUT/safety_ledger.json" >> "$GITHUB_OUTPUT"
-        echo "evidence_run_manifest_path=$OUT/evidence_run_manifest.json" >> "$GITHUB_OUTPUT"
+        echo "work_vault_path=$OUT/01_work_vault.json" >> "$GITHUB_OUTPUT"
+        echo "safety_ledger_path=$OUT/09_safety_ledger.json" >> "$GITHUB_OUTPUT"
+        echo "evidence_run_manifest_path=$OUT/evidence-run-manifest.json" >> "$GITHUB_OUTPUT"
         echo "recommendation=$REC" >> "$GITHUB_OUTPUT"

--- a/.github/actions/securerails-pr-guard/action.yml
+++ b/.github/actions/securerails-pr-guard/action.yml
@@ -1,0 +1,101 @@
+name: SecureRails PR Guard Composite Action
+description: Run SecureRails defensive PR guard checks and generate advisory evidence artifacts.
+inputs:
+  mode:
+    description: "Execution mode: pr_guard|compliance_guard|work_vault|supply_chain"
+    required: false
+    default: "pr_guard"
+  repo-root:
+    description: "Repository root to analyze"
+    required: false
+    default: "."
+  output-dir:
+    description: "Output directory for SecureRails artifacts"
+    required: false
+    default: "securerails-output"
+  event-path:
+    description: "Optional GitHub event payload path"
+    required: false
+    default: ""
+  strict:
+    description: "Fail on governance/safety findings"
+    required: false
+    default: "true"
+  generate-evidence-docket:
+    required: false
+    default: "true"
+  generate-work-vault:
+    required: false
+    default: "true"
+  generate-settlement-record:
+    required: false
+    default: "true"
+  token-utility-mode:
+    description: "Token utility accounting mode: mock|disabled"
+    required: false
+    default: "mock"
+  allow-pr-comment:
+    description: "Reserved for future safe reporter; currently ignored"
+    required: false
+    default: "false"
+outputs:
+  summary-path:
+    value: ${{ steps.run.outputs.summary_path }}
+  evidence-docket-path:
+    value: ${{ steps.run.outputs.evidence_docket_path }}
+  work-vault-path:
+    value: ${{ steps.run.outputs.work_vault_path }}
+  safety-ledger-path:
+    value: ${{ steps.run.outputs.safety_ledger_path }}
+  evidence-run-manifest-path:
+    value: ${{ steps.run.outputs.evidence_run_manifest_path }}
+  recommendation:
+    value: ${{ steps.run.outputs.recommendation }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: |
+        set -euo pipefail
+        MODE='${{ inputs.mode }}'
+        OUT='${{ inputs.output-dir }}'
+        ROOT='${{ inputs.repo-root }}'
+        EVENT_PATH='${{ inputs.event-path }}'
+        mkdir -p "$OUT/11_evidence_docket"
+
+        python scripts/secure_rails_claim_boundary_check.py "$ROOT"
+        python scripts/secure_rails_no_automerge_check.py "$ROOT"
+        python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json
+        python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json
+
+        if [ -f scripts/secure_rails_work_vault_check.py ]; then
+          python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json
+        fi
+
+        if [ "$MODE" = "pr_guard" ] || [ "$MODE" = "compliance_guard" ] || [ "$MODE" = "work_vault" ] || [ "$MODE" = "supply_chain" ]; then
+          CMD=(python -m secure_rails_pr_guard analyze --repo-root "$ROOT" --out "$OUT")
+          if [ -n "$EVENT_PATH" ]; then CMD+=(--event-path "$EVENT_PATH"); fi
+          "${CMD[@]}"
+          python -m secure_rails_pr_guard validate --input "$OUT"
+          python -m secure_rails_pr_guard render-summary --input "$OUT" --out "$OUT/summary.md"
+          if [ '${{ inputs.generate-evidence-docket }}' = 'true' ]; then
+            python -m secure_rails_pr_guard build-evidence --input "$OUT" --out "$OUT/11_evidence_docket"
+          fi
+        fi
+
+        if [ "$MODE" = "supply_chain" ]; then
+          python -m secure_rails supply-chain validate --input "$OUT" || true
+        fi
+
+        REC="human_review_required"
+        if [ -f "$OUT/pr_guard_report.json" ]; then
+          REC=$(python -c "import json;print(json.load(open('$OUT'/pr_guard_report.json')).get('recommendation','human_review_required'))")
+        fi
+
+        echo "summary_path=$OUT/summary.md" >> "$GITHUB_OUTPUT"
+        echo "evidence_docket_path=$OUT/11_evidence_docket" >> "$GITHUB_OUTPUT"
+        echo "work_vault_path=$OUT/work_vault.json" >> "$GITHUB_OUTPUT"
+        echo "safety_ledger_path=$OUT/safety_ledger.json" >> "$GITHUB_OUTPUT"
+        echo "evidence_run_manifest_path=$OUT/evidence_run_manifest.json" >> "$GITHUB_OUTPUT"
+        echo "recommendation=$REC" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/securerails-pr-guard-demo.yml
+++ b/.github/workflows/securerails-pr-guard-demo.yml
@@ -1,0 +1,18 @@
+name: SecureRails PR Guard Demo
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+jobs:
+  demo:
+    uses: ./.github/workflows/securerails-pr-guard-reusable.yml
+    with:
+      mode: pr_guard
+      strict: true
+      generate_evidence_docket: true
+      generate_work_vault: true
+      generate_settlement_record: true
+      token_utility_mode: mock
+      upload_artifact: true

--- a/.github/workflows/securerails-pr-guard-reusable.yml
+++ b/.github/workflows/securerails-pr-guard-reusable.yml
@@ -62,12 +62,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - id: provider_ref
+        name: Resolve provider ref from workflow_call pin
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
       - name: Checkout SecureRails provider repo
         uses: actions/checkout@v4
         with:
           repository: MontrealAI/agialpha-first-real-loop
           path: securerails-provider
           fetch-depth: 1
+          ref: ${{ steps.provider_ref.outputs.ref }}
           persist-credentials: false
       - id: guard
         uses: ./securerails-provider/.github/actions/securerails-pr-guard

--- a/.github/workflows/securerails-pr-guard-reusable.yml
+++ b/.github/workflows/securerails-pr-guard-reusable.yml
@@ -1,0 +1,88 @@
+name: SecureRails PR Guard Reusable Workflow
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        required: false
+        type: string
+        default: pr_guard
+      strict:
+        required: false
+        type: boolean
+        default: true
+      generate_evidence_docket:
+        required: false
+        type: boolean
+        default: true
+      generate_work_vault:
+        required: false
+        type: boolean
+        default: true
+      generate_settlement_record:
+        required: false
+        type: boolean
+        default: true
+      token_utility_mode:
+        required: false
+        type: string
+        default: mock
+      upload_artifact:
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      recommendation:
+        value: ${{ jobs.securerails.outputs.recommendation }}
+      summary_path:
+        value: ${{ jobs.securerails.outputs.summary_path }}
+      evidence_docket_path:
+        value: ${{ jobs.securerails.outputs.evidence_docket_path }}
+      work_vault_path:
+        value: ${{ jobs.securerails.outputs.work_vault_path }}
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  securerails:
+    runs-on: ubuntu-latest
+    outputs:
+      recommendation: ${{ steps.guard.outputs.recommendation }}
+      summary_path: ${{ steps.guard.outputs.summary-path }}
+      evidence_docket_path: ${{ steps.guard.outputs.evidence-docket-path }}
+      work_vault_path: ${{ steps.guard.outputs.work-vault-path }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - id: guard
+        uses: ./.github/actions/securerails-pr-guard
+        with:
+          mode: ${{ inputs.mode }}
+          repo-root: .
+          output-dir: securerails-pr-guard-output
+          event-path: ${{ github.event_path }}
+          strict: ${{ inputs.strict }}
+          generate-evidence-docket: ${{ inputs.generate_evidence_docket }}
+          generate-work-vault: ${{ inputs.generate_work_vault }}
+          generate-settlement-record: ${{ inputs.generate_settlement_record }}
+          token-utility-mode: ${{ inputs.token_utility_mode }}
+      - if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: securerails-pr-guard-output
+          path: securerails-pr-guard-output
+      - name: Publish step summary
+        run: |
+          if [ -f securerails-pr-guard-output/summary.md ]; then
+            cat securerails-pr-guard-output/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "SecureRails summary not generated. Human review required." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/securerails-pr-guard-reusable.yml
+++ b/.github/workflows/securerails-pr-guard-reusable.yml
@@ -62,8 +62,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Checkout SecureRails provider repo
+        uses: actions/checkout@v4
+        with:
+          repository: MontrealAI/agialpha-first-real-loop
+          path: securerails-provider
+          fetch-depth: 1
+          persist-credentials: false
       - id: guard
-        uses: ./.github/actions/securerails-pr-guard
+        uses: ./securerails-provider/.github/actions/securerails-pr-guard
         with:
           mode: ${{ inputs.mode }}
           repo-root: .

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ See [docs/README.md](docs/README.md) for the full navigation index by role (oper
 
 
 - SecureRails supply-chain provenance: [docs/secure-rails/supply-chain-provenance.md](docs/secure-rails/supply-chain-provenance.md)
+
+- Installable SecureRails action: [docs/secure-rails/installable-action.md](docs/secure-rails/installable-action.md)
+- Reusable SecureRails workflow: [docs/secure-rails/reusable-workflow.md](docs/secure-rails/reusable-workflow.md)
+- Customer pilot installation: [docs/secure-rails/customer-pilot-installation.md](docs/secure-rails/customer-pilot-installation.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -94,3 +94,8 @@ Use this format for every incident: **Symptom → Likely cause → Fix → What 
 
 ## SecureRails Agentic PR Guard 001
 - Ensure `python -m secure_rails_pr_guard analyze` and `validate` pass locally.
+
+## SecureRails installable action / reusable workflow
+- Confirm caller workflow uses read-only permissions and does not use `pull_request_target`.
+- Confirm production callers pin to release tag or commit SHA (not `main`).
+- Review `securerails-pr-guard-output/summary.md` and Evidence Docket before any remediation decision.

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -131,3 +131,6 @@ Each row represents one workflow file and should be read with these fields:
 | `securerails-agentic-pr-guard-001.yml` | SecureRails | `pull_request`, `workflow_dispatch` | PR Guard artifact with Work Vault/MARK/Sovereign/ProofBundle/Evidence Docket | Advisory only; human review required; no auto-merge; no secrets; least privilege read-only. | no |
 
 | `securerails-supply-chain-provenance-001.yml` | SecureRails | `workflow_dispatch`, `schedule`, `push` (SecureRails paths) | Artifact manifest, provenance record, attestation record/status, repository health report, supply-chain report, summary, evidence-run-manifest. | Advisory supply-chain evidence only; no certification claim; no direct Pages deploy. | no |
+
+| `securerails-pr-guard-reusable.yml` | SecureRails | `workflow_call` | Reusable PR Guard output artifact (`securerails-pr-guard-output`) and workflow outputs (recommendation, summary, Evidence Docket path, Work Vault path). | Read-only permissions, no secrets required, no auto-merge, human review required. | no |
+| `securerails-pr-guard-demo.yml` | SecureRails | `workflow_dispatch` | Demo run of reusable PR Guard workflow and advisory artifact output. | Demo-only launcher; does not deploy pages and does not grant write permissions. | no |

--- a/docs/WORKFLOW_LAUNCHPAD.md
+++ b/docs/WORKFLOW_LAUNCHPAD.md
@@ -24,3 +24,9 @@ The Evidence Hub Launchpad is the operator entry point for running repository wo
 - No tokens are embedded in site pages.
 - Launchpad usage is bounded by the claim policy:  
   **No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**
+
+## SecureRails installable workflows
+- SecureRails PR Guard Reusable Workflow: `.github/workflows/securerails-pr-guard-reusable.yml`
+- SecureRails PR Guard Demo: `.github/workflows/securerails-pr-guard-demo.yml`
+- Install docs: `docs/secure-rails/installable-action.md`
+- Customer template: `docs/secure-rails/templates/customer-securerails-pr-guard.yml`

--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -23,3 +23,9 @@ Boundary: not autonomous certification, not offensive cyber, not high-risk decis
 - Supply-chain provenance: [supply-chain-provenance.md](supply-chain-provenance.md)
 - Artifact attestations: [artifact-attestations.md](artifact-attestations.md)
 - Repository health: [repository-security-health.md](repository-security-health.md)
+
+- Installable action: [installable-action.md](installable-action.md)
+- Reusable workflow: [reusable-workflow.md](reusable-workflow.md)
+- Customer pilot install: [customer-pilot-installation.md](customer-pilot-installation.md)
+- External repo security model: [external-repo-security-model.md](external-repo-security-model.md)
+- Release/versioning: [release-and-versioning.md](release-and-versioning.md)

--- a/docs/secure-rails/customer-pilot-installation.md
+++ b/docs/secure-rails/customer-pilot-installation.md
@@ -1,0 +1,14 @@
+# Customer Pilot Installation
+
+1. Copy `docs/secure-rails/templates/customer-securerails-pr-guard.yml` into `.github/workflows/` of your repository.
+2. Open a PR or run manually with `workflow_dispatch`.
+3. Review workflow checks and download `securerails-pr-guard-output`.
+4. Read `summary.md` and Evidence Docket files.
+5. Decide: accept, reject, or escalate to SecureRails operator.
+
+Use read-only permissions and no secrets. Do not enable auto-merge.
+
+For production, pin to a release tag or commit SHA (not `main`).
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+Human review is required for remediation decisions.

--- a/docs/secure-rails/external-repo-security-model.md
+++ b/docs/secure-rails/external-repo-security-model.md
@@ -1,0 +1,17 @@
+# SecureRails External Repository Security Model
+
+External repository PRs are untrusted input. SecureRails parses PR data as data and does not execute PR code.
+
+- no secrets required
+- least privilege read-only permissions
+- no write permissions by default
+- no auto-merge
+- no `pull_request_target` analysis
+- no external target scanning
+- no exploit execution
+- no secret printing
+- artifacts are advisory
+- human review required
+
+SecureRails outputs are not cybersecurity-certification, not legal approval, and not autonomous merge authorization.
+SecureRails is AI-agent security governance and proof-bound defensive remediation, not offensive cyber, and not an investment product.

--- a/docs/secure-rails/installable-action.md
+++ b/docs/secure-rails/installable-action.md
@@ -1,0 +1,30 @@
+# SecureRails Installable Action
+
+The installable action (`.github/actions/securerails-pr-guard`) runs SecureRails defensive checks and produces advisory artifacts (summary, Evidence Docket path, Work Vault path, safety-ledger path, evidence manifest path, recommendation).
+
+## Modes
+`pr_guard`, `compliance_guard`, `work_vault`, `supply_chain`.
+
+## Permissions and safety defaults
+- Read-only workflow permissions.
+- No secrets required.
+- No `pull_request_target`.
+- No auto-merge.
+- No untrusted PR code execution.
+- Human review required.
+
+## Using in this repo
+Use `.github/workflows/securerails-pr-guard-demo.yml` or `securerails-pr-guard-reusable.yml`.
+
+## Using in external repos
+Call the reusable workflow from `MontrealAI/agialpha-first-real-loop` and pin to a release tag or commit SHA for production.
+
+## Artifacts and interpretation
+Download the `securerails-pr-guard-output` artifact and review `summary.md`, Evidence Docket files, and recommendation as advisory only.
+
+## Claim boundary
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+SecureRails is AI-agent security governance and proof-bound defensive remediation, not autonomous cybersecurity-certification, not offensive cyber, and not an investment product.
+
+## Troubleshooting
+Run local checks in README and verify docs/workflow audits before release.

--- a/docs/secure-rails/release-and-versioning.md
+++ b/docs/secure-rails/release-and-versioning.md
@@ -1,0 +1,17 @@
+# SecureRails Release and Versioning
+
+Production users should pin reusable workflow/action references to a release tag (`v1`, `v1.0.0`) or commit SHA. `main` is for demos only.
+
+Use immutable releases when available. Include provenance/attestation artifacts where supported. Do not claim certification unless independently verified and documented.
+
+## Release checklist
+1. tests pass
+2. SecureRails Compliance Guard passes
+3. docs-audit passes
+4. PR Guard demo passes
+5. supply-chain provenance workflow passes if present
+6. artifact manifest generated
+7. release notes include claim boundary
+8. immutable release considered
+9. customer template updated
+10. version tag created

--- a/docs/secure-rails/reusable-workflow.md
+++ b/docs/secure-rails/reusable-workflow.md
@@ -1,0 +1,11 @@
+# SecureRails Reusable Workflow
+
+`securerails-pr-guard-reusable.yml` exposes `workflow_call` inputs for mode, strictness, artifact generation toggles, token utility mode, and artifact upload.
+
+- Outputs: `recommendation`, `summary_path`, `evidence_docket_path`, `work_vault_path`
+- Artifact: `securerails-pr-guard-output`
+- Permissions: `contents: read`, `pull-requests: read`, `actions: read`
+- No write permission required.
+- No secrets required.
+
+For production callers, pin to a release tag (`v1`) or immutable commit SHA; `main` is demo-only.

--- a/docs/secure-rails/templates/README.md
+++ b/docs/secure-rails/templates/README.md
@@ -49,3 +49,7 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 - artifact-manifest-example.json
 - provenance-record-example.json
 - repository-health-example.json
+
+- customer-securerails-pr-guard.yml
+  - Copy-paste external repository workflow caller for SecureRails PR Guard reusable workflow.
+  - For production, pin workflow reference to release tag or commit SHA, not main.

--- a/docs/secure-rails/templates/customer-securerails-pr-guard.yml
+++ b/docs/secure-rails/templates/customer-securerails-pr-guard.yml
@@ -1,0 +1,23 @@
+name: SecureRails Agentic PR Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  securerails:
+    uses: MontrealAI/agialpha-first-real-loop/.github/workflows/securerails-pr-guard-reusable.yml@main
+    with:
+      mode: pr_guard
+      strict: true
+      generate_evidence_docket: true
+      generate_work_vault: true
+      generate_settlement_record: true
+      token_utility_mode: mock
+      upload_artifact: true

--- a/evidence_registry/discovered.json
+++ b/evidence_registry/discovered.json
@@ -101,6 +101,8 @@
     ".github/workflows/rsi-governor-001-vnext-canary.yml",
     ".github/workflows/secure-rails-compliance-guard.yml",
     ".github/workflows/securerails-agentic-pr-guard-001.yml",
+    ".github/workflows/securerails-pr-guard-demo.yml",
+    ".github/workflows/securerails-pr-guard-reusable.yml",
     ".github/workflows/securerails-supply-chain-provenance-001.yml",
     ".github/workflows/securerails-work-vault-demo.yml",
     ".github/workflows/seed-runner-autonomous.yml",

--- a/tests/test_securerails_action_metadata.py
+++ b/tests/test_securerails_action_metadata.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import unittest
+
+class TestSecureRailsActionMetadata(unittest.TestCase):
+    def test_action_metadata(self):
+        p = Path('.github/actions/securerails-pr-guard/action.yml')
+        self.assertTrue(p.exists())
+        text = p.read_text(encoding='utf-8')
+        for token in ['name:', 'description:', 'inputs:', 'outputs:', 'mode:', 'summary-path:', 'recommendation:']:
+            self.assertIn(token, text)

--- a/tests/test_securerails_action_no_overclaim.py
+++ b/tests/test_securerails_action_no_overclaim.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import unittest
+
+FORBIDDEN = [
+    'certified secure', 'guaranteed security',
+    'eu ai act exempt', 'investment return', 'yield', 'dividends', 'profit rights', 'ownership rights'
+]
+
+class TestSecureRailsActionNoOverclaim(unittest.TestCase):
+    def test_no_overclaim_language(self):
+        files = [
+            '.github/actions/securerails-pr-guard/README.md',
+            'docs/secure-rails/installable-action.md',
+            'docs/secure-rails/reusable-workflow.md',
+            'docs/secure-rails/customer-pilot-installation.md',
+            'docs/secure-rails/external-repo-security-model.md',
+        ]
+        blob = '\n'.join(Path(f).read_text(encoding='utf-8').lower() for f in files)
+        for banned in FORBIDDEN:
+            self.assertNotIn(banned, blob)

--- a/tests/test_securerails_customer_template.py
+++ b/tests/test_securerails_customer_template.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import unittest
+
+class TestSecureRailsCustomerTemplate(unittest.TestCase):
+    def test_customer_template(self):
+        text = Path('docs/secure-rails/templates/customer-securerails-pr-guard.yml').read_text(encoding='utf-8')
+        self.assertIn('MontrealAI/agialpha-first-real-loop/.github/workflows/securerails-pr-guard-reusable.yml@main', text)
+        self.assertIn('contents: read', text)
+        self.assertIn('pull-requests: read', text)
+        self.assertIn('actions: read', text)

--- a/tests/test_securerails_external_security_model.py
+++ b/tests/test_securerails_external_security_model.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import unittest
+
+class TestSecureRailsExternalSecurityModel(unittest.TestCase):
+    def test_model_content(self):
+        text = Path('docs/secure-rails/external-repo-security-model.md').read_text(encoding='utf-8').lower()
+        for phrase in ['untrusted', 'no auto-merge', 'no secrets required', 'human review required', 'cybersecurity-certification']:
+            self.assertIn(phrase, text)

--- a/tests/test_securerails_install_docs.py
+++ b/tests/test_securerails_install_docs.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import unittest
+
+class TestSecureRailsInstallDocs(unittest.TestCase):
+    def test_install_docs_boundary(self):
+        text = Path('docs/secure-rails/installable-action.md').read_text(encoding='utf-8').lower()
+        self.assertIn('no secrets required', text)
+        self.assertIn('no auto-merge', text)
+        self.assertIn('human review required', text)
+        self.assertIn('no evidence docket, no empirical sota claim', text)
+
+    def test_release_doc_pinning(self):
+        text = Path('docs/secure-rails/release-and-versioning.md').read_text(encoding='utf-8').lower()
+        self.assertIn('commit sha', text)
+        self.assertIn('main', text)
+        self.assertIn('demos only', text)

--- a/tests/test_securerails_reusable_workflow.py
+++ b/tests/test_securerails_reusable_workflow.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import unittest
+
+class TestSecureRailsReusableWorkflow(unittest.TestCase):
+    def test_workflow_safety(self):
+        text = Path('.github/workflows/securerails-pr-guard-reusable.yml').read_text(encoding='utf-8')
+        self.assertIn('workflow_call', text)
+        self.assertIn('contents: read', text)
+        self.assertIn('pull-requests: read', text)
+        self.assertIn('actions: read', text)
+        self.assertNotIn('pull_request_target', text)
+        self.assertNotIn('secrets:', text)
+        self.assertNotIn(': write', text)


### PR DESCRIPTION
### Motivation
- Package SecureRails as a customer-facing, installable GitHub Action and a `workflow_call`-style reusable workflow so external repositories can run SecureRails PR Guard and produce advisory Evidence Docket / Work Vault outputs without copying the repo. 
- Preserve SecureRails safety and claim-boundary posture (read-only, no secrets, no untrusted PR code execution, no auto-merge, explicit human review). 

### Description
- Added a composite action at `.github/actions/securerails-pr-guard/action.yml` plus `README.md` that runs claim-boundary, safety-ledger, no-automerge, use-case triage checks and, when available, `python -m secure_rails_pr_guard analyze/validate/render-summary/build-evidence`; the action writes structured outputs into the configured `output-dir` and returns `summary-path`, `evidence-docket-path`, `work-vault-path`, `safety-ledger-path`, `evidence-run-manifest-path`, and `recommendation`. 
- Added a reusable workflow `.github/workflows/securerails-pr-guard-reusable.yml` that exposes `workflow_call` inputs, uses least-privilege read permissions (`contents: read`, `pull-requests: read`, `actions: read`), invokes the composite action locally, optionally uploads the `securerails-pr-guard-output` artifact, and exposes outputs (`recommendation`, `summary_path`, `evidence_docket_path`, `work_vault_path`). 
- Added a local demo workflow `.github/workflows/securerails-pr-guard-demo.yml` that calls the reusable workflow with safe defaults and `workflow_dispatch`. 
- Added a copy-paste customer template at `docs/secure-rails/templates/customer-securerails-pr-guard.yml` that external repos can use, with explicit pinning guidance to prefer release tags/SHAs for production. 
- Added documentation: `docs/secure-rails/installable-action.md`, `docs/secure-rails/reusable-workflow.md`, `docs/secure-rails/customer-pilot-installation.md`, `docs/secure-rails/release-and-versioning.md`, and `docs/secure-rails/external-repo-security-model.md`, and updated central docs/catalog/launchpad/readme entries to include the new workflows. 
- Added tests verifying action metadata, reusable-workflow safety posture, customer template content, install docs & claim-boundary language, external-repo security model, and no-overclaim language (`tests/test_securerails_action_metadata.py`, `tests/test_securerails_reusable_workflow.py`, `tests/test_securerails_customer_template.py`, `tests/test_securerails_install_docs.py`, `tests/test_securerails_external_security_model.py`, `tests/test_securerails_action_no_overclaim.py`). 
- Implementation is defensive: it calls existing scripts and packages in the repository, does not require secrets, does not write to the repository, does not auto-merge, and does not perform pull_request_target analysis or arbitrary network scans. 

### Testing
- Ran SecureRails local checks `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, and `python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json`, all of which completed successfully. 
- Executed the PR Guard CLI paths `python -m secure_rails_pr_guard analyze --repo-root . --out /tmp/securerails-pr-guard-demo` and `python -m secure_rails_pr_guard validate --input /tmp/securerails-pr-guard-demo`, which completed successfully. 
- Ran documentation audits `python -m agialpha_docs audit-workflows --repo-root .`, `python -m agialpha_docs audit-claims --repo-root .`, `python -m agialpha_docs audit-links --repo-root .`, and `python -m agialpha_docs audit-readmes --repo-root .`, which returned success. 
- Ran the automated test suite (`python -m unittest discover -s tests` and `pytest -q`), and all tests passed (full test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf16172dc833394872899a6ccdcb6)