### PR TITLE
Implement SecureRails GitHub App Connector 001

### DIFF
--- a/tests/fixtures/securerails_github_app/webhook_payload.json
+++ b/tests/fixtures/securerails_github_app/webhook_payload.json
@@ -1,0 +1,20 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 42,
+    "head": {"sha": "abc123"},
+    "base": {"sha": "def456"},
+    "title": "[redacted-test] Example change",
+    "head_repo": {"fork": false}
+  },
+  "repository": {
+    "name": "agialpha-first-real-loop",
+    "full_name": "MontrealAI/agialpha-first-real-loop",
+    "private": false,
+    "owner": {"login": "MontrealAI"}
+  },
+  "sender": {
+    "login": "example-user",
+    "email": "not-retained@example.test"
+  }
+}

--- a/tests/fixtures/securerails_github_app/webhook_payload.json
+++ b/tests/fixtures/securerails_github_app/webhook_payload.json
@@ -2,10 +2,9 @@
   "action": "opened",
   "pull_request": {
     "number": 42,
-    "head": {"sha": "abc123"},
+    "head": {"sha": "abc123", "repo": {"fork": false}},
     "base": {"sha": "def456"},
-    "title": "[redacted-test] Example change",
-    "head_repo": {"fork": false}
+    "title": "[redacted-test] Example change"
   },
   "repository": {
     "name": "agialpha-first-real-loop",

--- a/tests/test_securerails_webhook_normalization.py
+++ b/tests/test_securerails_webhook_normalization.py
@@ -1,5 +1,20 @@
+import json
+import pathlib
 import unittest
+
 from secure_rails.github_webhooks import normalize_webhook_payload
+
+
 class T(unittest.TestCase):
   def test_redact(self):
-    n=normalize_webhook_payload({'sender':{'login':'alice','email':'a@b.com'}},'pull_request','d');self.assertTrue(n['sender']['raw_login_redacted']);self.assertNotIn('email',str(n))
+    n = normalize_webhook_payload({'sender': {'login': 'alice', 'email': 'a@b.com'}}, 'pull_request', 'd')
+    self.assertTrue(n['sender']['raw_login_redacted'])
+    self.assertNotIn('email', str(n))
+
+  def test_fixture_payload_minimized(self):
+    fixture = pathlib.Path('tests/fixtures/securerails_github_app/webhook_payload.json')
+    payload = json.loads(fixture.read_text(encoding='utf-8'))
+    n = normalize_webhook_payload(payload, 'pull_request', 'delivery-001')
+    self.assertEqual(n['repository']['full_name'], 'MontrealAI/agialpha-first-real-loop')
+    self.assertNotIn('not-retained@example.test', json.dumps(n))
+    self.assertNotIn('full_payload', n)

--- a/tests/test_securerails_webhook_normalization.py
+++ b/tests/test_securerails_webhook_normalization.py
@@ -12,9 +12,10 @@ class T(unittest.TestCase):
     self.assertNotIn('email', str(n))
 
   def test_fixture_payload_minimized(self):
-    fixture = pathlib.Path('tests/fixtures/securerails_github_app/webhook_payload.json')
+    fixture = pathlib.Path(__file__).resolve().parent / 'fixtures' / 'securerails_github_app' / 'webhook_payload.json'
     payload = json.loads(fixture.read_text(encoding='utf-8'))
     n = normalize_webhook_payload(payload, 'pull_request', 'delivery-001')
     self.assertEqual(n['repository']['full_name'], 'MontrealAI/agialpha-first-real-loop')
     self.assertNotIn('not-retained@example.test', json.dumps(n))
+    self.assertEqual(n['pull_request']['is_fork'], False)
     self.assertNotIn('full_payload', n)


### PR DESCRIPTION
### Motivation
- Add a deterministic webhook fixture and extend normalization tests so SecureRails can validate redaction/minimization behavior for GitHub App webhook intake without any real secrets.

### Description
- Add `tests/fixtures/securerails_github_app/webhook_payload.json` containing a minimal, non-secret pull request webhook payload.
- Update `tests/test_securerails_webhook_normalization.py` to load the fixture, run `normalize_webhook_payload`, and assert that repository metadata is preserved while sender email and full payload are not retained.

### Testing
- Ran SecureRails safety and claim checks: `scripts/secure_rails_claim_boundary_check.py`, `scripts/secure_rails_safety_ledger_check.py`, `scripts/secure_rails_no_automerge_check.py`, `scripts/secure_rails_use_case_triage_check.py`, and `scripts/secure_rails_work_vault_check.py` (all passed).
- Ran connector validators: `python -m secure_rails github-app validate-permissions`, `validate-events`, and `validate-installation` plus `python -m secure_rails github-app build-data` (no errors).
- Ran docs audits via `python -m agialpha_docs` (all OK).
- Ran unit test suite `python -m unittest discover -s tests` and observed all tests pass (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6692e6688333822dff9063327922)