### PR TITLE
Add GitHub webhook fixture and test for payload normalization/redaction

### DIFF
--- a/tests/fixtures/securerails_github_app/webhook_payload.json
+++ b/tests/fixtures/securerails_github_app/webhook_payload.json
@@ -1,0 +1,19 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 42,
+    "head": {"sha": "abc123", "repo": {"fork": false}},
+    "base": {"sha": "def456"},
+    "title": "[redacted-test] Example change"
+  },
+  "repository": {
+    "name": "agialpha-first-real-loop",
+    "full_name": "MontrealAI/agialpha-first-real-loop",
+    "private": false,
+    "owner": {"login": "MontrealAI"}
+  },
+  "sender": {
+    "login": "example-user",
+    "email": "not-retained@example.test"
+  }
+}

--- a/tests/test_securerails_webhook_normalization.py
+++ b/tests/test_securerails_webhook_normalization.py
@@ -1,5 +1,21 @@
+import json
+import pathlib
 import unittest
+
 from secure_rails.github_webhooks import normalize_webhook_payload
+
+
 class T(unittest.TestCase):
   def test_redact(self):
-    n=normalize_webhook_payload({'sender':{'login':'alice','email':'a@b.com'}},'pull_request','d');self.assertTrue(n['sender']['raw_login_redacted']);self.assertNotIn('email',str(n))
+    n = normalize_webhook_payload({'sender': {'login': 'alice', 'email': 'a@b.com'}}, 'pull_request', 'd')
+    self.assertTrue(n['sender']['raw_login_redacted'])
+    self.assertNotIn('email', str(n))
+
+  def test_fixture_payload_minimized(self):
+    fixture = pathlib.Path(__file__).resolve().parent / 'fixtures' / 'securerails_github_app' / 'webhook_payload.json'
+    payload = json.loads(fixture.read_text(encoding='utf-8'))
+    n = normalize_webhook_payload(payload, 'pull_request', 'delivery-001')
+    self.assertEqual(n['repository']['full_name'], 'MontrealAI/agialpha-first-real-loop')
+    self.assertEqual(n['pull_request']['is_fork'], False)
+    self.assertNotIn('not-retained@example.test', json.dumps(n))
+    self.assertNotIn('full_payload', n)


### PR DESCRIPTION
### Motivation

- Add a representative GitHub webhook fixture and corresponding test to validate payload normalization behavior, specifically to ensure sensitive fields are redacted and the payload is minimized.

### Description

- Add `tests/fixtures/securerails_github_app/webhook_payload.json` as a sample pull request webhook payload. 
- Add `test_fixture_payload_minimized` to `tests/test_securerails_webhook_normalization.py` that loads the fixture and asserts repository `full_name`, `pull_request.is_fork`, absence of the raw sender email, and that `full_payload` is not retained. 
- Tidy up existing `test_redact` formatting for readability.

### Testing

- Ran `pytest tests/test_securerails_webhook_normalization.py` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6692e6688333822dff9063327922)