### PR TITLE
Implement SecureRails GitHub App Connector 001

### DIFF
--- a/docs/secure-rails/webhook-security.md
+++ b/docs/secure-rails/webhook-security.md
@@ -1,3 +1,13 @@
 # webhook-security.md
 
 SecureRails GitHub App connector blueprint. Uses least-privilege GitHub App permissions and avoids broad classic PATs except temporary demo fallback. Human review required. No certification claim.
+
+## Local webhook simulator
+
+For local tests, generate a fake payload and matching signature:
+
+```bash
+python scripts/secure_rails_webhook_simulator.py --out tests/fixtures/securerails_github_app/webhook_payload.simulated.json
+```
+
+This simulator uses demo-only fake values and must not be used with production secrets.

--- a/scripts/secure_rails_webhook_simulator.py
+++ b/scripts/secure_rails_webhook_simulator.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate a fake GitHub webhook payload and matching signature for local SecureRails tests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+
+def build_payload(repo: str, sender: str, event_type: str) -> dict:
+    owner, name = repo.split("/", 1)
+    return {
+        "repository": {
+            "name": name,
+            "full_name": repo,
+            "visibility": "private",
+            "owner": {"login": owner},
+        },
+        "sender": {"login": sender, "email": "redacted@example.invalid"},
+        "pull_request": {
+            "number": 1,
+            "title": "example only",
+            "head": {"sha": "abc123", "repo": {"fork": False}},
+            "base": {"sha": "def456"},
+        },
+        "workflow_run": {
+            "id": 101,
+            "name": "SecureRails PR Guard",
+            "conclusion": "success",
+            "artifacts_url": "https://api.github.example/artifacts",
+        },
+        "event_type_hint": event_type,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create a fake webhook payload and HMAC signature for local testing.")
+    parser.add_argument("--secret", default="demo-webhook-secret", help="Demo secret used only for local simulation.")
+    parser.add_argument("--repo", default="octo-org/private-repo")
+    parser.add_argument("--sender", default="demo-user")
+    parser.add_argument("--event-type", default="pull_request")
+    parser.add_argument("--out", required=True, help="Path to write JSON payload.")
+    args = parser.parse_args()
+
+    payload = build_payload(args.repo, args.sender, args.event_type)
+    payload_bytes = json.dumps(payload, sort_keys=True).encode("utf-8")
+    signature = "sha256=" + hmac.new(args.secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps({
+        "payload_file": str(out),
+        "signature": signature,
+        "note": "Fake data only. Do not use in production.",
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secure_rails_webhook_simulator.py
+++ b/scripts/secure_rails_webhook_simulator.py
@@ -46,12 +46,13 @@ def main() -> int:
     args = parser.parse_args()
 
     payload = build_payload(args.repo, args.sender, args.event_type)
-    payload_bytes = json.dumps(payload, sort_keys=True).encode("utf-8")
+    payload_text = json.dumps(payload, indent=2) + "\n"
+    payload_bytes = payload_text.encode("utf-8")
     signature = "sha256=" + hmac.new(args.secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    out.write_text(payload_text, encoding="utf-8")
 
     print(json.dumps({
         "payload_file": str(out),


### PR DESCRIPTION
### Motivation

- Provide a safe local testing surface and documentation for the SecureRails GitHub App connector by adding a demo-only webhook simulator and documenting its use, enabling validation of webhook signature/normalization flows without production secrets.

### Description

- Add `scripts/secure_rails_webhook_simulator.py` to generate fake webhook payloads and matching `sha256=` HMAC signatures for local tests and add a `## Local webhook simulator` section to `docs/secure-rails/webhook-security.md` demonstrating usage and warning against production use.

### Testing

- Ran SecureRails safety and policy checks (`secure_rails_claim_boundary_check`, `secure_rails_safety_ledger_check`, `secure_rails_no_automerge_check`, `secure_rails_use_case_triage_check`, `secure_rails_work_vault_check`) which all passed; ran `python -m agialpha_docs audit-*` audits which passed; and ran the full unit test suite with `python -m unittest discover -s tests`, all tests passed (249 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff755b0a5c83338c2cf4dab0459010)