### PR TITLE
Add local webhook simulator and docs for SecureRails webhook security

### DIFF
--- a/docs/secure-rails/webhook-security.md
+++ b/docs/secure-rails/webhook-security.md
@@ -1,3 +1,13 @@
 # webhook-security.md
 
 SecureRails GitHub App connector blueprint. Uses least-privilege GitHub App permissions and avoids broad classic PATs except temporary demo fallback. Human review required. No certification claim.
+
+## Local webhook simulator
+
+For local tests, generate a fake payload and matching signature:
+
+```bash
+python scripts/secure_rails_webhook_simulator.py --out tests/fixtures/securerails_github_app/webhook_payload.simulated.json
+```
+
+This simulator uses demo-only fake values and must not be used with production secrets.

--- a/scripts/secure_rails_webhook_simulator.py
+++ b/scripts/secure_rails_webhook_simulator.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Generate a fake GitHub webhook payload and matching signature for local SecureRails tests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+
+def build_payload(repo: str, sender: str, event_type: str) -> dict:
+    owner, name = repo.split("/", 1)
+    return {
+        "repository": {
+            "name": name,
+            "full_name": repo,
+            "visibility": "private",
+            "owner": {"login": owner},
+        },
+        "sender": {"login": sender, "email": "redacted@example.invalid"},
+        "pull_request": {
+            "number": 1,
+            "title": "example only",
+            "head": {"sha": "abc123", "repo": {"fork": False}},
+            "base": {"sha": "def456"},
+        },
+        "workflow_run": {
+            "id": 101,
+            "name": "SecureRails PR Guard",
+            "conclusion": "success",
+            "artifacts_url": "https://api.github.example/artifacts",
+        },
+        "event_type_hint": event_type,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create a fake webhook payload and HMAC signature for local testing.")
+    parser.add_argument("--secret", default="demo-webhook-secret", help="Demo secret used only for local simulation.")
+    parser.add_argument("--repo", default="octo-org/private-repo")
+    parser.add_argument("--sender", default="demo-user")
+    parser.add_argument("--event-type", default="pull_request")
+    parser.add_argument("--out", required=True, help="Path to write JSON payload.")
+    args = parser.parse_args()
+
+    payload = build_payload(args.repo, args.sender, args.event_type)
+    rendered_payload = json.dumps(payload, indent=2) + "\n"
+    payload_bytes = rendered_payload.encode("utf-8")
+    signature = "sha256=" + hmac.new(args.secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(payload_bytes)
+
+    print(json.dumps({
+        "payload_file": str(out),
+        "signature": signature,
+        "note": "Fake data only. Do not use in production.",
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a simple, local way to generate fake GitHub webhook payloads and matching HMAC signatures for SecureRails testing without using real secrets.
- Document the simulator usage in the webhook security guide so contributors can reproduce webhook-based tests locally.

### Description

- Added a new script `scripts/secure_rails_webhook_simulator.py` that builds a demo webhook payload, computes an HMAC-SHA256 signature using a default `demo-webhook-secret`, writes the payload to the specified path, and prints the matching signature.
- Updated `docs/secure-rails/webhook-security.md` with a `Local webhook simulator` section and an example command to run `python scripts/secure_rails_webhook_simulator.py --out tests/fixtures/securerails_github_app/webhook_payload.simulated.json`.
- The simulator intentionally uses demo-only fake values and includes a clear note that it must not be used with production secrets.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff755b0a5c83338c2cf4dab0459010)