### PR TITLE
Implement SecureRails template bootstrap and first-run setup wizard

### DIFF
--- a/.github/workflows/securerails-template-bootstrap-001.yml
+++ b/.github/workflows/securerails-template-bootstrap-001.yml
@@ -1,0 +1,46 @@
+name: SecureRails Template Bootstrap 001
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: Repository owner or organization
+        required: true
+      repository:
+        description: Repository name
+        required: true
+      instance_name:
+        description: Human-readable instance name
+        required: true
+      instance_type:
+        description: pilot, customer, internal, canonical, or demo
+        required: true
+        default: pilot
+      pages_url:
+        description: GitHub Pages URL
+        required: false
+      create_pr:
+        description: Create a PR with generated setup files if supported
+        required: false
+        default: 'false'
+permissions:
+  contents: read
+  actions: read
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m secure_rails template-bootstrap detect --repo-root . --out /tmp/securerails-detected-context.json
+      - run: python -m secure_rails template-bootstrap init --repo-root . --owner "${{ inputs.owner }}" --repository "${{ inputs.repository }}" --instance-name "${{ inputs.instance_name }}" --instance-type "${{ inputs.instance_type }}" --pages-url "${{ inputs.pages_url }}" --out docs/_generated/template-bootstrap/securerails_instance_config.json
+      - run: python scripts/secure_rails_claim_boundary_check.py .
+      - run: python scripts/secure_rails_no_automerge_check.py .
+      - run: python -m secure_rails template-bootstrap health-check --repo-root . --config docs/_generated/template-bootstrap/securerails_instance_config.json --out docs/_generated/template-bootstrap/template_health.json
+      - run: python -m secure_rails template-bootstrap report --repo-root . --config docs/_generated/template-bootstrap/securerails_instance_config.json --out docs/_generated/template-bootstrap/setup_report.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: securerails-template-bootstrap
+          path: docs/_generated/template-bootstrap

--- a/.github/workflows/securerails-template-health-check-001.yml
+++ b/.github/workflows/securerails-template-health-check-001.yml
@@ -1,0 +1,32 @@
+name: SecureRails Template Health Check 001
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "config/securerails_instance_config.json"
+      - ".github/workflows/**"
+      - "scripts/**"
+      - "secure_rails/**"
+  schedule:
+    - cron: "0 10 * * 1"
+permissions:
+  contents: read
+  actions: read
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python scripts/secure_rails_claim_boundary_check.py .
+      - run: python scripts/secure_rails_no_automerge_check.py .
+      - run: test ! -f config/securerails_instance_config.json || python -m secure_rails template-bootstrap validate --repo-root . --config config/securerails_instance_config.json
+      - run: python -m secure_rails template-bootstrap health-check --repo-root . --config config/securerails_instance_config.example.json --out docs/_generated/template-bootstrap/template_health.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: securerails-template-health
+          path: docs/_generated/template-bootstrap/template_health.json

--- a/.github/workflows/securerails-template-health-check-001.yml
+++ b/.github/workflows/securerails-template-health-check-001.yml
@@ -6,6 +6,7 @@ on:
       - "README.md"
       - "docs/**"
       - "config/securerails_instance_config.json"
+      - "config/securerails_instance_config.example.json"
       - ".github/workflows/**"
       - "scripts/**"
       - "secure_rails/**"

--- a/README.md
+++ b/README.md
@@ -84,3 +84,17 @@ See [docs/README.md](docs/README.md) for the full navigation index by role (oper
 - SecureRails Customer Pilot Intake 001: see docs/secure-rails/customer-pilot-intake.md.
 
 - SecureRails GitHub App Connector 001: docs/secure-rails/github-app-connector.md
+
+## Using this repository as a template
+
+If this is the canonical repo, enable **Template repository** in GitHub settings.
+Create a new repo from the template, then run **SecureRails Template Bootstrap 001** or local CLI:
+`python -m secure_rails template-bootstrap init ...`.
+See:
+- docs/secure-rails/quebecai-template-setup.md
+- docs/secure-rails/customer-template-setup.md
+- docs/secure-rails/github-pages-setup.md
+- docs/secure-rails/actions-and-checks-setup.md
+
+## Template Instance Status
+Generated artifacts: `docs/_generated/template-bootstrap/`.

--- a/config/securerails_instance_config.example.json
+++ b/config/securerails_instance_config.example.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "securerails.instance_config.v1",
+  "instance_id": "quebecai-securerails-pilot-hub",
+  "instance_name": "QuebecAI SecureRails Pilot Hub",
+  "owner": "QuebecAI",
+  "repository": "securerails-pilot-hub",
+  "full_repository": "QuebecAI/securerails-pilot-hub",
+  "source_template": "MontrealAI/agialpha-first-real-loop",
+  "instance_type": "pilot",
+  "visibility": "unknown",
+  "public_pages_url": "https://quebecai.github.io/securerails-pilot-hub/",
+  "evidence_mission_control_url": "https://quebecai.github.io/securerails-pilot-hub/",
+  "secure_rails": {
+    "enabled": true,
+    "compliance_guard_required": true,
+    "work_vaults_enabled": true,
+    "agentic_pr_guard_enabled": false,
+    "customer_pilot_intake_enabled": false,
+    "github_app_connector_enabled": false
+  },
+  "claim_boundary": "SecureRails is AI-agent security governance and proof-bound defensive remediation. This instance does not certify security, does not perform offensive cyber activity, and does not make autonomous decisions about natural persons.",
+  "forbidden_use_acknowledgement": {
+    "no_hr_worker_evaluation": true,
+    "no_profiling_natural_persons": true,
+    "no_automated_decisions_about_natural_persons": true,
+    "no_critical_infrastructure_safety_component_reliance": true,
+    "no_offensive_cyber": true,
+    "no_auto_merge": true,
+    "no_investment_product_framing": true
+  },
+  "token_boundary": {
+    "agialpha_utility_only": true,
+    "no_yield": true,
+    "no_dividends": true,
+    "no_ownership": true,
+    "no_profit_rights": true,
+    "no_guaranteed_appreciation": true
+  }
+}

--- a/config/securerails_required_checks.json
+++ b/config/securerails_required_checks.json
@@ -1,0 +1,7 @@
+{
+  "required_checks": [
+    "SecureRails Compliance Guard",
+    "docs-audit",
+    "SecureRails Template Health Check 001"
+  ]
+}

--- a/config/securerails_ruleset_recommendation.json
+++ b/config/securerails_ruleset_recommendation.json
@@ -1,0 +1,5 @@
+{
+  "require_pull_request": true,
+  "require_status_checks": true,
+  "allow_auto_merge": false
+}

--- a/config/securerails_template_policy.json
+++ b/config/securerails_template_policy.json
@@ -1,0 +1,4 @@
+{
+  "no_auto_merge": true,
+  "human_review_required": true
+}

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -138,3 +138,6 @@ Each row represents one workflow file and should be read with these fields:
 | `securerails-customer-pilot-intake-001.yml` | SecureRails | `repository_dispatch`, `workflow_dispatch` | Customer pilot intake artifacts + generated summaries | Data-only ingestion, no pages deploy, human review required. | no |
 | `securerails-customer-pilot-manual-ingest-001.yml` | SecureRails | `workflow_dispatch` | Manual intake report artifacts | Data-only ingestion, no pages deploy, human review required. | no |
 | `securerails-customer-pilot-artifact-sync-001.yml` | SecureRails | `workflow_dispatch` | Optional configured external artifact pointer sync | Read-only Actions/contents permissions, no pages deploy, no broad secrets required. | no |
+
+- `securerails-template-bootstrap-001.yml`: Guided first-run setup workflow for template instances.
+- `securerails-template-health-check-001.yml`: Recurring template health and boundary checks.

--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -34,3 +34,12 @@ Boundary: not autonomous certification, not offensive cyber, not high-risk decis
 See customer-pilot-intake.md and multi-repo-evidence-ingestion.md.
 
 - GitHub App Connector docs added.
+
+## Template bootstrap guides
+- template-bootstrap.md
+- first-run-setup.md
+- quebecai-template-setup.md
+- customer-template-setup.md
+- github-pages-setup.md
+- actions-and-checks-setup.md
+- rulesets-and-branch-protection.md

--- a/docs/secure-rails/actions-and-checks-setup.md
+++ b/docs/secure-rails/actions-and-checks-setup.md
@@ -1,0 +1,5 @@
+# Actions and Checks Setup
+Enable Actions after creating from template.
+Use read-only default workflow permissions.
+Required checks: SecureRails Compliance Guard, docs-audit, SecureRails Template Health Check 001, and Evidence Mission Control validation (if present).
+Do not allow actions to auto-approve PRs unless deliberately configured.

--- a/docs/secure-rails/customer-template-setup.md
+++ b/docs/secure-rails/customer-template-setup.md
@@ -1,0 +1,4 @@
+# Customer Template Setup
+Create repo from template, keep private by default, enable workflows, run first setup, configure Pages only through the central publisher pattern, run compliance guard, and share evidence artifacts without secrets.
+Avoid HR/worker evaluation, profiling natural persons, and automated decisions about natural persons.
+Keep $AGIALPHA utility-only and avoid investment framing.

--- a/docs/secure-rails/first-run-setup.md
+++ b/docs/secure-rails/first-run-setup.md
@@ -1,0 +1,2 @@
+# First-Run Setup
+Run workflow **SecureRails Template Bootstrap 001** and keep human review required before merge.

--- a/docs/secure-rails/github-pages-setup.md
+++ b/docs/secure-rails/github-pages-setup.md
@@ -1,0 +1,6 @@
+# GitHub Pages Setup
+Set Pages source to GitHub Actions when using Evidence Mission Control publisher.
+Only the central Evidence Mission Control publisher should deploy Pages.
+Experiment workflows must not deploy Pages directly.
+If Pages is stale, rerun publisher and validate artifact paths.
+Never expose private customer data in public Pages output.

--- a/docs/secure-rails/quebecai-template-setup.md
+++ b/docs/secure-rails/quebecai-template-setup.md
@@ -1,0 +1,16 @@
+# QuebecAI Template Setup
+Recommended repo name: `securerails-pilot-hub`.
+Recommended visibility: private for pilots.
+Do not include all branches unless needed.
+Enable Actions and GitHub Pages (GitHub Actions source).
+Run **SecureRails Template Bootstrap 001**, then **SecureRails Compliance Guard**, then Evidence Mission Control publisher.
+Open first PR and do not merge without human review.
+
+Copy/paste values:
+- owner: QuebecAI
+- repository: securerails-pilot-hub
+- instance name: QuebecAI SecureRails Pilot Hub
+- instance type: pilot
+- pages URL: https://quebecai.github.io/securerails-pilot-hub/
+
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity assurance, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.

--- a/docs/secure-rails/rulesets-and-branch-protection.md
+++ b/docs/secure-rails/rulesets-and-branch-protection.md
@@ -1,0 +1,4 @@
+# Rulesets and Branch Protection
+Protect `main`, require PRs and status checks, disable force pushes, disable auto-merge by default, and require human review.
+If rulesets are unavailable, use branch protection.
+Repository settings are admin-managed and not copied automatically by templates.

--- a/docs/secure-rails/template-bootstrap.md
+++ b/docs/secure-rails/template-bootstrap.md
@@ -1,0 +1,2 @@
+# SecureRails Template Bootstrap 001
+Use `python -m secure_rails template-bootstrap` to detect context, initialize instance configuration, validate boundaries, generate template health, and generate setup reports.

--- a/docs/secure-rails/templates/README.md
+++ b/docs/secure-rails/templates/README.md
@@ -59,3 +59,5 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 - repository-dispatch-payload-example.json
 
 - Added connector templates: customer-installation and dispatch bridge.
+
+- `instance-config-example.json`: SecureRails Template Bootstrap example instance configuration.

--- a/docs/secure-rails/templates/instance-config-example.json
+++ b/docs/secure-rails/templates/instance-config-example.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "securerails.instance_config.v1",
+  "instance_id": "quebecai-securerails-pilot-hub",
+  "instance_name": "QuebecAI SecureRails Pilot Hub",
+  "owner": "QuebecAI",
+  "repository": "securerails-pilot-hub",
+  "full_repository": "QuebecAI/securerails-pilot-hub",
+  "source_template": "MontrealAI/agialpha-first-real-loop",
+  "instance_type": "pilot",
+  "visibility": "unknown",
+  "public_pages_url": "https://quebecai.github.io/securerails-pilot-hub/",
+  "evidence_mission_control_url": "https://quebecai.github.io/securerails-pilot-hub/",
+  "secure_rails": {
+    "enabled": true,
+    "compliance_guard_required": true,
+    "work_vaults_enabled": true,
+    "agentic_pr_guard_enabled": false,
+    "customer_pilot_intake_enabled": false,
+    "github_app_connector_enabled": false
+  },
+  "claim_boundary": "SecureRails is AI-agent security governance and proof-bound defensive remediation. This instance does not certify security, does not perform offensive cyber activity, and does not make autonomous decisions about natural persons.",
+  "forbidden_use_acknowledgement": {
+    "no_hr_worker_evaluation": true,
+    "no_profiling_natural_persons": true,
+    "no_automated_decisions_about_natural_persons": true,
+    "no_critical_infrastructure_safety_component_reliance": true,
+    "no_offensive_cyber": true,
+    "no_auto_merge": true,
+    "no_investment_product_framing": true
+  },
+  "token_boundary": {
+    "agialpha_utility_only": true,
+    "no_yield": true,
+    "no_dividends": true,
+    "no_ownership": true,
+    "no_profit_rights": true,
+    "no_guaranteed_appreciation": true
+  }
+}

--- a/evidence_registry/discovered.json
+++ b/evidence_registry/discovered.json
@@ -107,6 +107,8 @@
     ".github/workflows/securerails-pr-guard-demo.yml",
     ".github/workflows/securerails-pr-guard-reusable.yml",
     ".github/workflows/securerails-supply-chain-provenance-001.yml",
+    ".github/workflows/securerails-template-bootstrap-001.yml",
+    ".github/workflows/securerails-template-health-check-001.yml",
     ".github/workflows/securerails-work-vault-demo.yml",
     ".github/workflows/seed-runner-autonomous.yml",
     "agiga-foundry-runs/test/agiga-foundry-evidence-docket/00_manifest.json",

--- a/schemas/securerails_instance_config.schema.json
+++ b/schemas/securerails_instance_config.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "owner",
+    "repository",
+    "full_repository",
+    "claim_boundary",
+    "instance_type",
+    "forbidden_use_acknowledgement",
+    "token_boundary"
+  ]
+}

--- a/schemas/securerails_ruleset_recommendation.schema.json
+++ b/schemas/securerails_ruleset_recommendation.schema.json
@@ -1,0 +1,3 @@
+{
+  "type": "object"
+}

--- a/schemas/securerails_template_bootstrap_report.schema.json
+++ b/schemas/securerails_template_bootstrap_report.schema.json
@@ -1,0 +1,3 @@
+{
+  "type": "object"
+}

--- a/schemas/securerails_template_health.schema.json
+++ b/schemas/securerails_template_health.schema.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "required": [
+    "schema_version",
+    "status"
+  ]
+}

--- a/scripts/securerails_template_bootstrap.py
+++ b/scripts/securerails_template_bootstrap.py
@@ -1,0 +1,3 @@
+from secure_rails.cli import main
+if __name__=="__main__":
+    main()

--- a/scripts/securerails_template_health_check.py
+++ b/scripts/securerails_template_health_check.py
@@ -1,0 +1,3 @@
+from secure_rails.cli import main
+if __name__=="__main__":
+    main()

--- a/secure_rails/cli.py
+++ b/secure_rails/cli.py
@@ -21,6 +21,7 @@ from .github_webhooks import normalize_webhook_payload
 from .repository_dispatch_bridge import build_dispatch_from_webhook_event, validate_dispatch_payload
 from .connector_intake import validate_installation_record
 from .connector_registry import update_registry, build_connector_data
+from .template_bootstrap import detect as tb_detect, init as tb_init, validate as tb_validate, health_check as tb_health_check, report as tb_report
 
 
 
@@ -68,6 +69,15 @@ def main():
     cbd = cpsp.add_parser('build-data'); cbd.add_argument('--registry', required=True); cbd.add_argument('--out', required=True)
     cr = cpsp.add_parser('render'); cr.add_argument('--registry', required=True); cr.add_argument('--out', required=True)
     ccb = cpsp.add_parser('check-boundary'); ccb.add_argument('--registry', required=True)
+
+    tb = sp.add_parser('template-bootstrap')
+    tbsp = tb.add_subparsers(dest='tb_sub', required=True)
+    tbd = tbsp.add_parser('detect'); tbd.add_argument('--repo-root', required=True); tbd.add_argument('--out', required=True)
+    tbi = tbsp.add_parser('init'); tbi.add_argument('--repo-root', required=True); tbi.add_argument('--owner', required=True); tbi.add_argument('--repository', required=True); tbi.add_argument('--instance-name', required=True); tbi.add_argument('--instance-type', required=True); tbi.add_argument('--pages-url', default=''); tbi.add_argument('--out', required=True)
+    tbr = tbsp.add_parser('render'); tbr.add_argument('--repo-root', required=True); tbr.add_argument('--config', required=True); tbr.add_argument('--out', required=True)
+    tbh = tbsp.add_parser('health-check'); tbh.add_argument('--repo-root', required=True); tbh.add_argument('--config', required=True); tbh.add_argument('--out', required=True)
+    tbp = tbsp.add_parser('report'); tbp.add_argument('--repo-root', required=True); tbp.add_argument('--config', required=True); tbp.add_argument('--out', required=True)
+    tbv = tbsp.add_parser('validate'); tbv.add_argument('--repo-root', required=True); tbv.add_argument('--config', required=True)
 
     a = p.parse_args()
 
@@ -128,6 +138,22 @@ def main():
             update_registry(Path(a.input), Path(a.registry)); return
         if a.gh_sub == 'build-data':
             build_connector_data(Path(a.registry), Path(a.out)); return
+
+    if a.cmd == 'template-bootstrap':
+        repo_root = Path(a.repo_root)
+        if a.tb_sub == 'detect':
+            tb_detect(repo_root, Path(a.out)); return
+        if a.tb_sub == 'init':
+            tb_init(repo_root, a.owner, a.repository, a.instance_name, a.instance_type, a.pages_url, Path(a.out)); return
+        if a.tb_sub == 'render':
+            out = Path(a.out); out.mkdir(parents=True, exist_ok=True)
+            tb_report(repo_root, Path(a.config), out / 'setup_report.md'); return
+        if a.tb_sub == 'health-check':
+            tb_health_check(repo_root, Path(a.config), Path(a.out)); return
+        if a.tb_sub == 'report':
+            tb_report(repo_root, Path(a.config), Path(a.out)); return
+        if a.tb_sub == 'validate':
+            errs = tb_validate(Path(a.config)); [print(e) for e in errs]; raise SystemExit(0 if not errs else 1)
 
     if a.cmd == 'customer-pilots':
         if a.cp_sub == 'validate-intake':

--- a/secure_rails/instance_config.py
+++ b/secure_rails/instance_config.py
@@ -1,0 +1,36 @@
+
+from __future__ import annotations
+import json
+from pathlib import Path
+ALLOWED_INSTANCE_TYPES = {'pilot','customer','internal','canonical','demo'}
+
+def build_instance_config(owner:str, repository:str, instance_name:str, instance_type:str, pages_url:str='') -> dict:
+    if instance_type not in ALLOWED_INSTANCE_TYPES:
+        raise ValueError('invalid instance_type')
+    full = f"{owner}/{repository}"
+    return {
+      'schema_version':'securerails.instance_config.v1','instance_id':f"{owner.lower()}-{repository}".replace('_','-'),'instance_name':instance_name,
+      'owner':owner,'repository':repository,'full_repository':full,'source_template':'MontrealAI/agialpha-first-real-loop','instance_type':instance_type,
+      'visibility':'unknown','public_pages_url':pages_url,'evidence_mission_control_url':pages_url,
+      'secure_rails':{'enabled':True,'compliance_guard_required':True,'work_vaults_enabled':True,'agentic_pr_guard_enabled':False,'customer_pilot_intake_enabled':False,'github_app_connector_enabled':False},
+      'claim_boundary':'SecureRails is AI-agent security governance and proof-bound defensive remediation. This instance does not certify security, does not perform offensive cyber activity, and does not make autonomous decisions about natural persons.',
+      'forbidden_use_acknowledgement':{'no_hr_worker_evaluation':True,'no_profiling_natural_persons':True,'no_automated_decisions_about_natural_persons':True,'no_critical_infrastructure_safety_component_reliance':True,'no_offensive_cyber':True,'no_auto_merge':True,'no_investment_product_framing':True},
+      'token_boundary':{'agialpha_utility_only':True,'no_yield':True,'no_dividends':True,'no_ownership':True,'no_profit_rights':True,'no_guaranteed_appreciation':True}
+    }
+
+def validate_instance_config(cfg:dict)->list[str]:
+    errs=[]
+    for k in ('owner','repository','full_repository','claim_boundary'):
+        if not cfg.get(k): errs.append(f'missing {k}')
+    if cfg.get('instance_type') not in ALLOWED_INSTANCE_TYPES: errs.append('invalid instance_type')
+    fua = cfg.get('forbidden_use_acknowledgement',{})
+    for k,v in fua.items():
+        if v is not True: errs.append(f'{k} must be true')
+    if fua.get('no_auto_merge') is not True: errs.append('no_auto_merge must be true')
+    tb=cfg.get('token_boundary',{})
+    for k in ('agialpha_utility_only','no_yield','no_dividends','no_ownership','no_profit_rights','no_guaranteed_appreciation'):
+        if tb.get(k) is not True: errs.append(f'{k} must be true')
+    return errs
+
+def load_and_validate(path:Path)->list[str]:
+    return validate_instance_config(json.loads(path.read_text(encoding='utf-8')))

--- a/secure_rails/instance_config.py
+++ b/secure_rails/instance_config.py
@@ -3,6 +3,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 ALLOWED_INSTANCE_TYPES = {'pilot','customer','internal','canonical','demo'}
+REQUIRED_FORBIDDEN_USE_FLAGS = (
+    'no_hr_worker_evaluation',
+    'no_profiling_natural_persons',
+    'no_automated_decisions_about_natural_persons',
+    'no_critical_infrastructure_safety_component_reliance',
+    'no_offensive_cyber',
+    'no_auto_merge',
+    'no_investment_product_framing',
+)
 
 def build_instance_config(owner:str, repository:str, instance_name:str, instance_type:str, pages_url:str='') -> dict:
     if instance_type not in ALLOWED_INSTANCE_TYPES:
@@ -24,9 +33,11 @@ def validate_instance_config(cfg:dict)->list[str]:
         if not cfg.get(k): errs.append(f'missing {k}')
     if cfg.get('instance_type') not in ALLOWED_INSTANCE_TYPES: errs.append('invalid instance_type')
     fua = cfg.get('forbidden_use_acknowledgement',{})
-    for k,v in fua.items():
-        if v is not True: errs.append(f'{k} must be true')
-    if fua.get('no_auto_merge') is not True: errs.append('no_auto_merge must be true')
+    for k in REQUIRED_FORBIDDEN_USE_FLAGS:
+        if k not in fua:
+            errs.append(f'missing forbidden_use_acknowledgement.{k}')
+        elif fua[k] is not True:
+            errs.append(f'{k} must be true')
     tb=cfg.get('token_boundary',{})
     for k in ('agialpha_utility_only','no_yield','no_dividends','no_ownership','no_profit_rights','no_guaranteed_appreciation'):
         if tb.get(k) is not True: errs.append(f'{k} must be true')

--- a/secure_rails/pages_config.py
+++ b/secure_rails/pages_config.py
@@ -1,0 +1,2 @@
+def infer_pages_url(owner:str, repository:str)->str:
+    return f"https://{owner.lower()}.github.io/{repository}/"

--- a/secure_rails/repo_context.py
+++ b/secure_rails/repo_context.py
@@ -1,0 +1,36 @@
+
+from __future__ import annotations
+import json
+import subprocess
+from pathlib import Path
+
+def detect_repo_context(repo_root: Path) -> dict:
+    owner = "unknown"
+    repository = repo_root.resolve().name
+    full_repository = f"{owner}/{repository}"
+    try:
+        remote = subprocess.check_output(['git','-C',str(repo_root),'config','--get','remote.origin.url'], text=True).strip()
+        if remote:
+            if remote.endswith('.git'):
+                remote = remote[:-4]
+            if 'github.com' in remote:
+                tail = remote.split('github.com')[-1].lstrip(':/')
+                if '/' in tail:
+                    owner, repository = tail.split('/',1)
+                    full_repository = f"{owner}/{repository}"
+    except Exception:
+        pass
+    pages = f"https://{owner.lower()}.github.io/{repository}/" if owner != 'unknown' else ''
+    return {
+        'owner': owner,
+        'repository': repository,
+        'full_repository': full_repository,
+        'public_pages_url': pages,
+        'evidence_mission_control_url': pages,
+    }
+
+def write_detected_context(repo_root: Path, out: Path) -> dict:
+    ctx = detect_repo_context(repo_root)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(ctx, indent=2), encoding='utf-8')
+    return ctx

--- a/secure_rails/ruleset_recommendations.py
+++ b/secure_rails/ruleset_recommendations.py
@@ -1,0 +1,2 @@
+def default_ruleset():
+    return {"require_pull_request": True, "require_human_review": True, "allow_auto_merge": False}

--- a/secure_rails/setup_report.py
+++ b/secure_rails/setup_report.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+def write_setup_report(config:dict, health:dict, out:Path)->None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(f"# SecureRails Template Bootstrap Setup Report\n\n- Instance: {config['full_repository']}\n- Type: {config['instance_type']}\n- Pages: {config.get('public_pages_url','')}\n- Template health: {health['status']}\n\n## Doctrine\nNo Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.\n", encoding='utf-8')

--- a/secure_rails/template_bootstrap.py
+++ b/secure_rails/template_bootstrap.py
@@ -1,0 +1,32 @@
+
+from __future__ import annotations
+import json
+from pathlib import Path
+from .repo_context import write_detected_context
+from .instance_config import build_instance_config, load_and_validate
+from .template_health import write_template_health
+from .setup_report import write_setup_report
+
+def detect(repo_root:Path, out:Path):
+    return write_detected_context(repo_root, out)
+
+def init(repo_root:Path, owner:str, repository:str, instance_name:str, instance_type:str, pages_url:str, out:Path):
+    cfg=build_instance_config(owner, repository, instance_name, instance_type, pages_url)
+    out.parent.mkdir(parents=True, exist_ok=True); out.write_text(json.dumps(cfg, indent=2), encoding='utf-8'); return cfg
+
+def validate(config:Path):
+    return load_and_validate(config)
+
+def health_check(repo_root:Path, config:Path, out:Path):
+    cfg=json.loads(config.read_text())
+    return write_template_health(repo_root, cfg.get('full_repository','unknown'), out)
+
+def report(repo_root:Path, config:Path, out:Path):
+    cfg=json.loads(config.read_text())
+    health_path=out.parent/'template_health.json'
+    health=write_template_health(repo_root, cfg.get('full_repository','unknown'), health_path)
+    write_setup_report(cfg, health, out)
+    (out.parent/'next_steps.md').write_text(
+        "## Next Steps\n- Run SecureRails Compliance Guard\n- Require human review before merge\n",
+        encoding='utf-8',
+    )

--- a/secure_rails/template_health.py
+++ b/secure_rails/template_health.py
@@ -1,0 +1,23 @@
+
+from __future__ import annotations
+import json, datetime
+from pathlib import Path
+REQUIRED_FILES = [
+'README.md','docs/secure-rails/README.md','docs/secure-rails/product-boundary.md','docs/secure-rails/eu-ai-act-positioning.md',
+'docs/secure-rails/foreseeable-misuse-and-excluded-uses.md','docs/secure-rails/work-vaults-mark-sovereigns.md','docs/secure-rails/templates/README.md',
+'scripts/secure_rails_claim_boundary_check.py','scripts/secure_rails_safety_ledger_check.py','scripts/secure_rails_no_automerge_check.py','scripts/secure_rails_use_case_triage_check.py',
+'.github/workflows/secure-rails-compliance-guard.yml']
+
+def build_template_health(repo_root:Path, repository:str)->dict:
+    missing=[f for f in REQUIRED_FILES if not (repo_root/f).exists()]
+    warns=[]
+    if not (repo_root/'docs/START_HERE.md').exists() and not (repo_root/'README.md').exists(): warns.append('missing START_HERE or equivalent')
+    status='pass' if not missing else 'fail'
+    return {'schema_version':'securerails.template_health.v1','generated_at':datetime.datetime.utcnow().isoformat()+'Z','repository':repository,
+            'status':status,'checks':['required_files'],'missing_required_files':missing,'warnings':warns,'next_steps':['Run SecureRails Compliance Guard'],'claim_boundary':'SecureRails is AI-agent security governance and proof-bound defensive remediation.'}
+
+def write_template_health(repo_root:Path, repository:str, out:Path)->dict:
+    h=build_template_health(repo_root, repository)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(h, indent=2), encoding='utf-8')
+    return h

--- a/secure_rails/workflow_requirements.py
+++ b/secure_rails/workflow_requirements.py
@@ -1,0 +1,1 @@
+REQUIRED_CHECKS=["SecureRails Compliance Guard","docs-audit","SecureRails Template Health Check 001"]

--- a/tests/test_securerails_instance_config.py
+++ b/tests/test_securerails_instance_config.py
@@ -1,0 +1,10 @@
+import unittest
+from secure_rails.instance_config import build_instance_config, validate_instance_config
+
+class T(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(validate_instance_config(build_instance_config('QuebecAI','securerails-pilot-hub','n','pilot','')),[])
+    def test_missing_owner(self):
+        c=build_instance_config('QuebecAI','repo','n','pilot',''); c.pop('owner'); self.assertTrue(validate_instance_config(c))
+    def test_no_auto_merge_false(self):
+        c=build_instance_config('QuebecAI','repo','n','pilot',''); c['forbidden_use_acknowledgement']['no_auto_merge']=False; self.assertTrue(validate_instance_config(c))

--- a/tests/test_securerails_template_bootstrap.py
+++ b/tests/test_securerails_template_bootstrap.py
@@ -1,0 +1,7 @@
+import unittest, tempfile
+from pathlib import Path
+from secure_rails.template_bootstrap import init, validate
+class T(unittest.TestCase):
+    def test_init_validate(self):
+        with tempfile.TemporaryDirectory() as d:
+            p=Path(d)/'cfg.json'; init(Path('.'),'QuebecAI','securerails-pilot-hub','name','pilot','',p); self.assertEqual(validate(p),[])

--- a/tests/test_securerails_template_docs.py
+++ b/tests/test_securerails_template_docs.py
@@ -1,0 +1,6 @@
+import unittest
+from pathlib import Path
+class T(unittest.TestCase):
+    def test_docs_exist(self):
+        for p in ['docs/secure-rails/quebecai-template-setup.md','docs/secure-rails/customer-template-setup.md','docs/secure-rails/github-pages-setup.md','docs/secure-rails/actions-and-checks-setup.md','docs/secure-rails/rulesets-and-branch-protection.md']:
+            self.assertTrue(Path(p).exists(), p)

--- a/tests/test_securerails_template_health.py
+++ b/tests/test_securerails_template_health.py
@@ -1,0 +1,7 @@
+import unittest, tempfile, json
+from pathlib import Path
+from secure_rails.template_health import write_template_health
+class T(unittest.TestCase):
+    def test_health_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            o=Path(d)/'h.json'; h=write_template_health(Path('.'),'x/y',o); self.assertTrue(o.exists()); self.assertIn(h['status'],('pass','fail','warning'))

--- a/tests/test_securerails_template_no_overclaim.py
+++ b/tests/test_securerails_template_no_overclaim.py
@@ -1,0 +1,7 @@
+import unittest
+from pathlib import Path
+class T(unittest.TestCase):
+    def test_no_overclaim(self):
+        txt='\n'.join(Path(p).read_text(errors='ignore') for p in ['docs/secure-rails/template-bootstrap.md','docs/secure-rails/quebecai-template-setup.md'])
+        for bad in ['EU AI Act exempt','certified secure','achieved AGI','achieved ASI']:
+            self.assertNotIn(bad, txt)

--- a/tests/test_securerails_template_required_checks.py
+++ b/tests/test_securerails_template_required_checks.py
@@ -1,0 +1,6 @@
+import unittest, json
+from pathlib import Path
+class T(unittest.TestCase):
+    def test_required(self):
+        d=json.loads(Path('config/securerails_required_checks.json').read_text())
+        self.assertIn('SecureRails Compliance Guard', d['required_checks'])

--- a/tests/test_securerails_template_workflows.py
+++ b/tests/test_securerails_template_workflows.py
@@ -1,0 +1,6 @@
+import unittest
+from pathlib import Path
+class T(unittest.TestCase):
+    def test_workflows(self):
+        for p in ['.github/workflows/securerails-template-bootstrap-001.yml','.github/workflows/securerails-template-health-check-001.yml']:
+            self.assertTrue(Path(p).exists())


### PR DESCRIPTION
### Motivation

- Provide a guided first-run bootstrap and health-check workflow so repositories created from this template can be configured safely and consistently. 
- Preserve SecureRails claim and token boundaries while making it easy to generate an instance config, health report, and setup report for QuebecAI, customers, and pilots. 
- Avoid dangerous automation (no auto-merge, no direct Pages deploy, minimal workflow permissions) while surfacing required checks and next steps. 

### Description

- Added a minimal SecureRails template-bootstrap subsystem under `secure_rails/` with `template_bootstrap.py`, `instance_config.py`, `repo_context.py`, `template_health.py`, `setup_report.py`, `pages_config.py`, `workflow_requirements.py`, and `ruleset_recommendations.py`, and wired CLI commands under `python -m secure_rails template-bootstrap` (`detect`, `init`, `render`, `health-check`, `report`, `validate`). 
- Added JSON schemas and example configs in `schemas/` and `config/` (`securerails_instance_config.schema.json`, `securerails_template_health.schema.json`, `config/securerails_instance_config.example.json`, `config/securerails_required_checks.json`, etc.) and implemented instance config validation rules (required fields, allowed `instance_type`, all forbidden-use acknowledgements and token-boundary flags must be true, `no_auto_merge` must be true). 
- Created first-run and recurring workflows `.github/workflows/securerails-template-bootstrap-001.yml` and `.github/workflows/securerails-template-health-check-001.yml` that run the CLI and checks, upload artifacts, use read-only default permissions, do not deploy Pages, and do not auto-merge; added small wrapper scripts `scripts/securerails_template_bootstrap.py` and `scripts/securerails_template_health_check.py`. 
- Added operator docs and examples under `docs/secure-rails/` (QuebecAI guide, customer guide, Pages setup, actions/checks setup, ruleset guidance, template bootstrap docs and instance-config example) and updated README and workflow catalog to reference the new guides. 
- Added unit tests under `tests/` covering instance-config validation, bootstrap init/validate, health JSON generation, docs/workflow presence, no-overclaim checks, and required-checks config. 

### Testing

- Ran the SecureRails local checks: `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, and `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, all of which passed. 
- Exercised the bootstrap CLI end-to-end with `python -m secure_rails template-bootstrap init/validate/health-check/report` using the QuebecAI example and verified each step produced the expected JSON/MD artifacts. 
- Ran `python -m agialpha_docs audit-claims --repo-root .` to ensure no disallowed overclaims were introduced and fixed one phrasing instance until the audit passed. 
- Ran unit tests with `python -m unittest discover -s tests` and verified the new tests passed (final run: all tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff81874ed48333975b355f9e155496)