### PR TITLE
Implement SecureRails release train and Marketplace readiness

### DIFF
--- a/secure_rails/release_bundle.py
+++ b/secure_rails/release_bundle.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json, hashlib, shutil
 from .release_notes import render_notes
 from .marketplace_readiness import write_reports
+from .release_export import build_export_plan
 
 def _sha(p: Path) -> str:
     h = hashlib.sha256(); h.update(p.read_bytes()); return h.hexdigest()
@@ -16,6 +17,7 @@ def build_bundle(repo_root: Path, out: Path, manifest: dict):
     (out / 'CUSTOMER_INSTALL.md').write_text((repo_root / 'docs/secure-rails/customer-install-bundle.md').read_text(encoding='utf-8'), encoding='utf-8')
     write_reports(repo_root, out / 'MARKETPLACE_READINESS.md', out / 'marketplace_readiness.json')
     (out / 'EXPORT_PLAN.md').write_text('Future dedicated repository: MontrealAI/securerails-pr-guard-action with root action.yml and no workflow files.\n', encoding='utf-8')
+    build_export_plan(manifest.get('release_id', 'unknown-release'), out / 'export_plan.json')
     cust = out / 'customer'; cust.mkdir(exist_ok=True)
     for f in ['customer-securerails-pr-guard.yml', 'customer-pilot-intake-example.json', 'deployment-intake-example.json', 'safety-ledger-example.json']:
         shutil.copy2(repo_root / f'docs/secure-rails/templates/{f}', cust / f)

--- a/secure_rails/release_bundle.py
+++ b/secure_rails/release_bundle.py
@@ -17,7 +17,7 @@ def build_bundle(repo_root: Path, out: Path, manifest: dict):
     (out / 'CUSTOMER_INSTALL.md').write_text((repo_root / 'docs/secure-rails/customer-install-bundle.md').read_text(encoding='utf-8'), encoding='utf-8')
     write_reports(repo_root, out / 'MARKETPLACE_READINESS.md', out / 'marketplace_readiness.json')
     (out / 'EXPORT_PLAN.md').write_text('Future dedicated repository: MontrealAI/securerails-pr-guard-action with root action.yml and no workflow files.\n', encoding='utf-8')
-    build_export_plan(manifest.get('release_id', 'unknown-release'), out / 'export_plan.json')
+    build_export_plan(manifest, out / 'export_plan.json')
     cust = out / 'customer'; cust.mkdir(exist_ok=True)
     for f in ['customer-securerails-pr-guard.yml', 'customer-pilot-intake-example.json', 'deployment-intake-example.json', 'safety-ledger-example.json']:
         shutil.copy2(repo_root / f'docs/secure-rails/templates/{f}', cust / f)

--- a/secure_rails/release_export.py
+++ b/secure_rails/release_export.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def build_export_plan(release_id: str, out: Path) -> dict:
+    """Build a Marketplace-ready export plan for a future dedicated action repository."""
+    plan = {
+        "schema_version": "securerails.export_plan.v1",
+        "release_id": release_id,
+        "marketplace_publication_allowed_now": False,
+        "recommended_target_repository": "MontrealAI/securerails-pr-guard-action",
+        "required_repository_shape": {
+            "public_repository": True,
+            "root_action_yml": True,
+            "workflow_files_present": False,
+            "action_only_scope": True,
+        },
+        "required_release_controls": [
+            "semantic_version_tags",
+            "release_notes",
+            "checksums",
+            "provenance_record_when_available",
+            "claim_boundary",
+            "no_certification_claims",
+        ],
+        "next_step": "export to dedicated action repository",
+    }
+    out.write_text(json.dumps(plan, indent=2), encoding="utf-8")
+    return plan

--- a/secure_rails/release_export.py
+++ b/secure_rails/release_export.py
@@ -4,11 +4,14 @@ import json
 from pathlib import Path
 
 
-def build_export_plan(release_id: str, out: Path) -> dict:
+def build_export_plan(release_manifest: dict, out: Path) -> dict:
     """Build a Marketplace-ready export plan for a future dedicated action repository."""
     plan = {
         "schema_version": "securerails.export_plan.v1",
-        "release_id": release_id,
+        "release_id": release_manifest.get("release_id", "unknown-release"),
+        "release_version": release_manifest.get("release_version", "unknown-version"),
+        "release_channel": release_manifest.get("release_channel", "unknown-channel"),
+        "claim_boundary": release_manifest.get("claim_boundary", ""),
         "marketplace_publication_allowed_now": False,
         "recommended_target_repository": "MontrealAI/securerails-pr-guard-action",
         "required_repository_shape": {

--- a/tests/test_securerails_release_bundle.py
+++ b/tests/test_securerails_release_bundle.py
@@ -26,3 +26,13 @@ class T(unittest.TestCase):
             self.assertFalse((out / 'leftover.txt').exists())
             manifest = json.loads((out / 'artifact_manifest.json').read_text(encoding='utf-8'))
             self.assertNotIn('leftover.txt', manifest['artifacts'])
+
+    def test_export_plan_contains_required_schema_fields(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / 'x'
+            build(Path('.'), '0.1.0-rc1', 'rc', out)
+            export_plan = json.loads((out / 'export_plan.json').read_text(encoding='utf-8'))
+            self.assertEqual('0.1.0-rc1', export_plan['release_version'])
+            self.assertEqual('rc', export_plan['release_channel'])
+            self.assertTrue(export_plan['claim_boundary'])
+


### PR DESCRIPTION
### Motivation
- Emit an explicit Marketplace export plan with every SecureRails release bundle so release candidates include a conservative, non-publishing export roadmap that preserves claim boundaries and recommends a dedicated action repo for Marketplace publication.

### Description
- Add `secure_rails/release_export.py` to build `export_plan.json` containing `marketplace_publication_allowed_now: false`, a recommended target repository, required repository shape (public, root `action.yml`, no workflow files), and required release controls, and integrate it into `secure_rails/release_bundle.build_bundle` so `export_plan.json` is generated alongside existing `EXPORT_PLAN.md`.

### Testing
- Ran claim/safety checks and release train flows (for example `python scripts/secure_rails_claim_boundary_check.py .`, `python -m secure_rails release-train build --repo-root . --release-version 0.1.0-rc1 --release-channel rc --out /tmp/securerails-release`, and `python -m secure_rails release-train validate --input /tmp/securerails-release`), executed docs audits with `python -m agialpha_docs ...`, and ran the test suite with `python -m unittest discover -s tests` and `pytest -q`, and all automated tests passed (full test run reported `293 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000609b7fc83338c0dce20c063a5ff)