### PR TITLE
Improve SecureRails release workflows with additional checks, reports, and structured steps

### DIFF
--- a/.github/workflows/securerails-release-candidate-001.yml
+++ b/.github/workflows/securerails-release-candidate-001.yml
@@ -1,28 +1,70 @@
 name: SecureRails Release Candidate 001
+
 on:
   workflow_dispatch:
     inputs:
-      release_version: {description: "Release version, e.g. 0.1.0-rc1", required: true}
-      release_channel: {description: "rc, internal, pilot, or stable", required: true, default: "rc"}
-      create_draft_release: {description: "Create GitHub draft release", required: false, default: "false"}
-permissions: {contents: read, actions: read}
+      release_version:
+        description: "Release version, e.g. 0.1.0-rc1"
+        required: true
+      release_channel:
+        description: "rc, internal, pilot, or stable"
+        required: true
+        default: "rc"
+      create_draft_release:
+        description: "Create GitHub draft release"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
-      - run: python scripts/secure_rails_claim_boundary_check.py .
-      - run: python -m agialpha_docs audit-workflows --repo-root .
-      - run: python -m secure_rails release-train build --repo-root . --release-version "${{ inputs.release_version }}" --release-channel "${{ inputs.release_channel }}" --out /tmp/securerails-release
-      - run: python -m secure_rails release-train validate --input /tmp/securerails-release
-      - uses: actions/upload-artifact@v4
-        with: {name: securerails-release-bundle, path: /tmp/securerails-release}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: SecureRails Compliance Guard checks
+        run: |
+          python scripts/secure_rails_claim_boundary_check.py .
+          python scripts/secure_rails_no_automerge_check.py .
+      - name: Docs audit
+        run: |
+          python -m agialpha_docs audit-workflows --repo-root .
+          python -m agialpha_docs audit-claims --repo-root .
+      - name: Build release bundle
+        run: |
+          python -m secure_rails release-train build             --repo-root .             --release-version "${{ inputs.release_version }}"             --release-channel "${{ inputs.release_channel }}"             --out /tmp/securerails-release
+      - name: Generate marketplace readiness report
+        run: |
+          python -m secure_rails release-train marketplace-readiness             --repo-root .             --out /tmp/securerails-release/MARKETPLACE_READINESS.md
+      - name: Generate release notes
+        run: |
+          python -m secure_rails release-train render-notes             --input /tmp/securerails-release             --out /tmp/securerails-release/RELEASE_NOTES.md
+      - name: Validate release bundle
+        run: |
+          python -m secure_rails release-train validate --input /tmp/securerails-release
+      - name: Upload release bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: securerails-release-bundle
+          path: /tmp/securerails-release
+      - name: Print summary
+        run: |
+          echo "SecureRails RC bundle path: /tmp/securerails-release"
+          echo "Draft release requested: ${{ inputs.create_draft_release }}"
+
   draft_release:
     if: ${{ inputs.create_draft_release == 'true' }}
     needs: [build]
-    permissions: {contents: write}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Draft release creation is guarded and manual-only."
+      - name: Guarded draft-release placeholder
+        run: echo "Draft release creation is guarded and manual-only."

--- a/.github/workflows/securerails-release-validate-001.yml
+++ b/.github/workflows/securerails-release-validate-001.yml
@@ -1,4 +1,5 @@
 name: SecureRails Release Validate 001
+
 on:
   pull_request:
     paths:
@@ -12,12 +13,32 @@ on:
       - "config/securerails_marketplace_readiness_policy.json"
       - ".github/workflows/securerails-release*.yml"
   workflow_dispatch:
-permissions: {contents: read, actions: read}
+
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
-      - run: python -m unittest discover -s tests
+        with:
+          python-version: '3.11'
+      - name: Validate release manifest examples
+        run: python -m unittest tests.test_securerails_release_manifest
+      - name: Build and validate ephemeral release bundle
+        run: |
+          python -m secure_rails release-train build --repo-root . --release-version 0.1.0-rc1 --release-channel rc --out /tmp/securerails-release-validate
+          python -m secure_rails release-train validate --input /tmp/securerails-release-validate
+      - name: No overclaim checks
+        run: |
+          python scripts/secure_rails_claim_boundary_check.py .
+          python scripts/secure_rails_no_automerge_check.py .
+      - name: Token utility boundary checks
+        run: python -m agialpha_docs audit-claims --repo-root .
+      - name: Marketplace readiness language check
+        run: python -m unittest tests.test_securerails_marketplace_readiness
+      - name: Run release tests
+        run: python -m unittest discover -s tests

--- a/.github/workflows/securerails-release-validate-001.yml
+++ b/.github/workflows/securerails-release-validate-001.yml
@@ -6,6 +6,7 @@ on:
       - "releases/securerails/**"
       - "docs/secure-rails/**"
       - "secure_rails/**"
+      - "scripts/secure_rails_*.py"
       - "schemas/securerails_release*.json"
       - "schemas/securerails_marketplace_readiness.schema.json"
       - "schemas/securerails_export_plan.schema.json"


### PR DESCRIPTION
### Motivation
- Harden and standardize the SecureRails release and validation workflows by adding explicit guard checks and generation of release artifacts and reports.
- Make workflow steps more readable and maintainable by converting inline step shorthand to named steps and expanding permissions into explicit keys.
- Add additional automated validations to catch claim/marketplace issues earlier in the release process.

### Description
- Updated `.github/workflows/securerails-release-candidate-001.yml` to replace compact steps with named steps, add `secure_rails_no_automerge_check.py`, run `agialpha_docs audit-claims`, generate a `MARKETPLACE_READINESS.md`, render `RELEASE_NOTES.md`, and print a summary; upload of `/tmp/securerails-release` remains as an artifact and draft release creation is kept as a guarded placeholder.
- Updated `.github/workflows/securerails-release-validate-001.yml` to expand permissions, add explicit path filters, and add focused validation steps including `tests.test_securerails_release_manifest`, an ephemeral build-and-validate (`secure_rails release-train build` and `validate`), `secure_rails` claim/no-automerge checks, `agialpha_docs audit-claims`, `tests.test_securerails_marketplace_readiness`, and a full `python -m unittest discover -s tests` run.
- Normalized YAML formatting for readability and made the `draft_release` job use explicit `contents: write` permission with a named placeholder step.

### Testing
- Ran `python -m unittest tests.test_securerails_release_manifest` which completed successfully.
- Executed an ephemeral build and validation with `python -m secure_rails release-train build` and `python -m secure_rails release-train validate` which passed.
- Ran claim and token audits with `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_no_automerge_check.py .`, and `python -m agialpha_docs audit-claims --repo-root .` which completed without errors.
- Ran `python -m unittest tests.test_securerails_marketplace_readiness` and a full test discovery `python -m unittest discover -s tests`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00911e027c8333a7298901cd308525)