### PR TITLE
Enhance SecureRails release workflows with additional checks, docs audits, and artifact/report generation

### DIFF
--- a/.github/workflows/securerails-release-candidate-001.yml
+++ b/.github/workflows/securerails-release-candidate-001.yml
@@ -1,28 +1,70 @@
 name: SecureRails Release Candidate 001
+
 on:
   workflow_dispatch:
     inputs:
-      release_version: {description: "Release version, e.g. 0.1.0-rc1", required: true}
-      release_channel: {description: "rc, internal, pilot, or stable", required: true, default: "rc"}
-      create_draft_release: {description: "Create GitHub draft release", required: false, default: "false"}
-permissions: {contents: read, actions: read}
+      release_version:
+        description: "Release version, e.g. 0.1.0-rc1"
+        required: true
+      release_channel:
+        description: "rc, internal, pilot, or stable"
+        required: true
+        default: "rc"
+      create_draft_release:
+        description: "Create GitHub draft release"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
-      - run: python scripts/secure_rails_claim_boundary_check.py .
-      - run: python -m agialpha_docs audit-workflows --repo-root .
-      - run: python -m secure_rails release-train build --repo-root . --release-version "${{ inputs.release_version }}" --release-channel "${{ inputs.release_channel }}" --out /tmp/securerails-release
-      - run: python -m secure_rails release-train validate --input /tmp/securerails-release
-      - uses: actions/upload-artifact@v4
-        with: {name: securerails-release-bundle, path: /tmp/securerails-release}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: SecureRails Compliance Guard checks
+        run: |
+          python scripts/secure_rails_claim_boundary_check.py .
+          python scripts/secure_rails_no_automerge_check.py .
+      - name: Docs audit
+        run: |
+          python -m agialpha_docs audit-workflows --repo-root .
+          python -m agialpha_docs audit-claims --repo-root .
+      - name: Build release bundle
+        run: |
+          python -m secure_rails release-train build             --repo-root .             --release-version "${{ inputs.release_version }}"             --release-channel "${{ inputs.release_channel }}"             --out /tmp/securerails-release
+      - name: Generate marketplace readiness report
+        run: |
+          python -m secure_rails release-train marketplace-readiness             --repo-root .             --out /tmp/securerails-release/MARKETPLACE_READINESS.md
+      - name: Generate release notes
+        run: |
+          python -m secure_rails release-train render-notes             --input /tmp/securerails-release             --out /tmp/securerails-release/RELEASE_NOTES.md
+      - name: Validate release bundle
+        run: |
+          python -m secure_rails release-train validate --input /tmp/securerails-release
+      - name: Upload release bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: securerails-release-bundle
+          path: /tmp/securerails-release
+      - name: Print summary
+        run: |
+          echo "SecureRails RC bundle path: /tmp/securerails-release"
+          echo "Draft release requested: ${{ inputs.create_draft_release }}"
+
   draft_release:
     if: ${{ inputs.create_draft_release == 'true' }}
     needs: [build]
-    permissions: {contents: write}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Draft release creation is guarded and manual-only."
+      - name: Guarded draft-release placeholder
+        run: echo "Draft release creation is guarded and manual-only."

--- a/.github/workflows/securerails-release-validate-001.yml
+++ b/.github/workflows/securerails-release-validate-001.yml
@@ -1,10 +1,12 @@
 name: SecureRails Release Validate 001
+
 on:
   pull_request:
     paths:
       - "releases/securerails/**"
       - "docs/secure-rails/**"
       - "secure_rails/**"
+      - "scripts/secure_rails_*.py"
       - "schemas/securerails_release*.json"
       - "schemas/securerails_marketplace_readiness.schema.json"
       - "schemas/securerails_export_plan.schema.json"
@@ -12,12 +14,32 @@ on:
       - "config/securerails_marketplace_readiness_policy.json"
       - ".github/workflows/securerails-release*.yml"
   workflow_dispatch:
-permissions: {contents: read, actions: read}
+
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
-      - run: python -m unittest discover -s tests
+        with:
+          python-version: '3.11'
+      - name: Validate release manifest examples
+        run: python -m unittest tests.test_securerails_release_manifest
+      - name: Build and validate ephemeral release bundle
+        run: |
+          python -m secure_rails release-train build --repo-root . --release-version 0.1.0-rc1 --release-channel rc --out /tmp/securerails-release-validate
+          python -m secure_rails release-train validate --input /tmp/securerails-release-validate
+      - name: No overclaim checks
+        run: |
+          python scripts/secure_rails_claim_boundary_check.py .
+          python scripts/secure_rails_no_automerge_check.py .
+      - name: Token utility boundary checks
+        run: python -m agialpha_docs audit-claims --repo-root .
+      - name: Marketplace readiness language check
+        run: python -m unittest tests.test_securerails_marketplace_readiness
+      - name: Run release tests
+        run: python -m unittest discover -s tests


### PR DESCRIPTION
### Motivation

- Improve release automation by adding explicit compliance and claim boundary checks and by surfacing docs and marketplace readiness issues earlier. 
- Make the release workflow steps more explicit and robust, and extend validation triggers to include release-related scripts.

### Description

- Rewrote the `securerails-release-candidate-001.yml` job steps into named steps and added `secure_rails_no_automerge_check.py`, `agialpha_docs audit-claims`, marketplace readiness generation, and release-notes rendering before validation. 
- Standardized `permissions` formatting and cleaned up the artifact upload step to use named inputs for `actions/upload-artifact@v4`. 
- Made the draft release job explicitly guarded by naming the placeholder step and kept `contents: write` permissions only when `create_draft_release` is requested. 
- Updated `securerails-release-validate-001.yml` to include `scripts/secure_rails_*.py` in path filters and to run targeted validation commands and unit tests including ephemeral release build/validate flows.

### Testing

- The validate workflow runs `python -m unittest tests.test_securerails_release_manifest`, `python -m unittest tests.test_securerails_marketplace_readiness`, and `python -m unittest discover -s tests`, and those were executed as part of the validation steps and completed successfully. 
- The validate job also executes `python -m secure_rails release-train build` and `python -m secure_rails release-train validate` to build and validate an ephemeral release bundle, and those commands completed successfully. 
- Additional checks run in workflows include `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_no_automerge_check.py .`, and `python -m agialpha_docs audit-claims --repo-root .`, and these checks ran and returned successful results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00911e027c8333a7298901cd308525)