### PR TITLE
Implement SecureRails Trust Center and vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,4 +47,7 @@ No bounty is promised unless separately approved in writing.
 ## Claim boundary
 SecureRails reports and Evidence Dockets are advisory governance artifacts. They do not certify security.
 
-SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybercertification claim, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cyber assurance authority, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+
+
+Doctrine boundary: "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."

--- a/docs/_generated/secure-rails/trust-center/status.json
+++ b/docs/_generated/secure-rails/trust-center/status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "securerails.trust_center_status.v1",
-  "generated_at": "2026-05-11T17:17:21.227126+00:00",
+  "generated_at": "2026-05-11T18:50:08.707582+00:00",
   "security_policy_present": true,
   "vulnerability_disclosure_present": true,
   "security_txt_status": "pending_contact",


### PR DESCRIPTION
### Motivation

- Tighten and clarify the SecureRails claim-boundary language in the root security policy so it matches repository doctrine and reviewer expectations. 
- Surface the doctrine boundary explicitly so that reviewers, customers, and researchers see the "No Evidence Docket, no empirical SOTA claim" constraint at the top level. 
- Keep the non-production placeholder contact and coordinated-disclosure posture to avoid publishing a fake production contact.

### Description

- Updated `SECURITY.md` to refine claim-boundary wording and add the doctrine boundary statement. 
- Replaced the previous phrasing with clearer language: "not autonomous cyber assurance authority" and appended the doctrine: "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.". 
- Regenerated the trust-center status output at `docs/_generated/secure-rails/trust-center/status.json` so generated timestamps and validation flags reflect the repository state. 
- Ran the SecureRails validation scripts (`scripts/secure_rails_trust_center_check.py`, `scripts/secure_rails_security_txt_check.py`, `scripts/secure_rails_incident_record_check.py`) as part of the update cycle.

### Testing

- Ran the targeted unit tests with `python -m unittest` for the SecureRails trust-center suite (selected trust-center tests), and all executed tests passed. 
- Executed the repository validation checks with `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py`, `python scripts/secure_rails_no_automerge_check.py .`, and `python scripts/secure_rails_trust_center_check.py .`, and all checks passed. 
- Ran `python -m secure_rails trust-center validate --repo-root .` and `python -m secure_rails trust-center build-data --repo-root . --out docs/_generated/secure-rails/trust-center` successfully to regenerate status artifacts. 
- Ran `python -m agialpha_docs audit-workflows --repo-root .`, `python -m agialpha_docs audit-claims --repo-root .`, `python -m agialpha_docs audit-links --repo-root .`, and `python -m agialpha_docs audit-readmes --repo-root .`, and the audits returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022476209083338df1fb2e20022b90)