### PR TITLE
Implement SecureRails repository security baseline

### DIFF
--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -153,7 +153,5 @@ See `docs/secure-rails/e2e-pilot-canary.md` and workflow `securerails-e2e-pilot-
 
 
 - `securerails-trust-center-001.yml` — SecureRails Trust Center 001 validation workflow.
-| \ | SecureRails | workflow_dispatch, pull_request, schedule | Repository security baseline evidence bundle + Evidence Docket + ProofBundle artifacts. | Advisory security-governance evidence only; human review required; no Pages deploy. | no |
-| \ | SecureRails | pull_request, workflow_dispatch | Dependency review advisory artifact and local dependency inventory evidence. | Advisory only; no certification claim. | no |
 | `securerails-repo-security-baseline-001.yml` | SecureRails | workflow_dispatch, pull_request, schedule | Repository security baseline evidence bundle + Evidence Docket + ProofBundle artifacts. | Advisory security-governance evidence only; human review required; no Pages deploy. | no |
 | `securerails-dependency-review-001.yml` | SecureRails | pull_request, workflow_dispatch | Dependency review advisory artifact and local dependency inventory evidence. | Advisory only; no certification claim. | no |


### PR DESCRIPTION
### Motivation
- Ensure the workflow catalog accurately and canonically lists the SecureRails repository-security baseline and dependency-review workflows by removing malformed duplicate rows that could confuse audits and operators.

### Description
- Remove malformed duplicate table rows in `docs/WORKFLOW_CATALOG.md` so the canonical `securerails-repo-security-baseline-001.yml` and `securerails-dependency-review-001.yml` entries remain and render correctly.
- The repository already contains SecureRails repo-security modules, schemas, workflows, docs, and tests that implement the Repository Security Baseline 001 evidence generators and artifacts, and this PR leaves that implementation in place while fixing the catalog entry.

### Testing
- Ran SecureRails governance checks with `python scripts/secure_rails_claim_boundary_check.py . && python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json && python scripts/secure_rails_no_automerge_check.py . && python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json && python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json`, which all passed.
- Exercised the SecureRails repo-security commands with `python -m secure_rails repo-security inventory`, `code-scanning-readiness`, `secret-scanning-posture`, `sarif-readiness`, `baseline`, and `validate`, and the baseline/validation sequence ran without errors.
- Ran documentation audits and the full test suite with `python -m agialpha_docs audit-workflows --repo-root . && python -m agialpha_docs audit-claims --repo-root . && python -m agialpha_docs audit-links --repo-root . && python -m agialpha_docs audit-readmes --repo-root .` and `python -m unittest discover -s tests`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023509d60083338e8a8fb67b0f465f)