### PR TITLE
Implement SecureRails repository security baseline

### DIFF
--- a/docs/secure-rails/repository-security-baseline.md
+++ b/docs/secure-rails/repository-security-baseline.md
@@ -5,3 +5,5 @@ This document defines advisory security-governance evidence for SecureRails Repo
 It does not provide cybersecurity certification and does not guarantee repository security.
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.


### PR DESCRIPTION
### Motivation

- Ensure the repository-security-baseline documentation explicitly preserves SecureRails doctrine and the product claim-boundary so evidence remains advisory and the project avoids overclaiming.

### Description

- Update `docs/secure-rails/repository-security-baseline.md` to add the doctrine reminder and an explicit SecureRails product boundary statement clarifying this is advisory evidence and not certification.

### Testing

- Ran SecureRails checks and audits (`python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json`, `python scripts/secure_rails_work_vault_check.py docs/secure-rails/templates/work-vault-example.json`), repo-security generators and validators (`python -m secure_rails repo-security inventory`, `code-scanning-readiness`, `secret-scanning-posture`, `sarif-readiness`, `baseline`, `validate`), documentation audits (`python -m agialpha_docs audit-workflows`, `audit-claims`, `audit-links`, `audit-readmes`), and unit tests (`python -m unittest discover -s tests` and `tests.test_securerails_repo_security_docs`, `tests.test_securerails_repo_security_no_overclaim`), and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0247d2393083339bb57994e1f89e4b)