### PR TITLE
Implement SecureRails repository security baseline

### DIFF
--- a/secure_rails/release_manifest.py
+++ b/secure_rails/release_manifest.py
@@ -15,7 +15,7 @@ def build_manifest(release_version:str, release_channel:str, repo:str, commit_sh
       "release_id":rid,
       "release_version":release_version,
       "release_channel":release_channel,
-      "generated_at":__import__('datetime').datetime.utcnow().isoformat()+"Z",
+      "generated_at":__import__('datetime').datetime.now(__import__('datetime').timezone.utc).isoformat().replace('+00:00','Z'),
       "repository":repo,
       "commit_sha":commit_sha,
       "branch":branch,

--- a/secure_rails/template_health.py
+++ b/secure_rails/template_health.py
@@ -13,7 +13,7 @@ def build_template_health(repo_root:Path, repository:str)->dict:
     warns=[]
     if not (repo_root/'docs/START_HERE.md').exists() and not (repo_root/'README.md').exists(): warns.append('missing START_HERE or equivalent')
     status='pass' if not missing else 'fail'
-    return {'schema_version':'securerails.template_health.v1','generated_at':datetime.datetime.utcnow().isoformat()+'Z','repository':repository,
+    return {'schema_version':'securerails.template_health.v1','generated_at':datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00','Z'),'repository':repository,
             'status':status,'checks':['required_files'],'missing_required_files':missing,'warnings':warns,'next_steps':['Run SecureRails Compliance Guard'],'claim_boundary':'SecureRails is AI-agent security governance and proof-bound defensive remediation.'}
 
 def write_template_health(repo_root:Path, repository:str, out:Path)->dict:


### PR DESCRIPTION
### Motivation
- Remove deprecation warnings and produce timezone-aware UTC timestamps for SecureRails-generated artifacts by replacing `datetime.utcnow()` with `datetime.now(datetime.timezone.utc)` while preserving the ISO `Z` format.

### Description
- Updated `generated_at` in `secure_rails/release_manifest.py` to use `__import__('datetime').datetime.now(__import__('datetime').timezone.utc).isoformat().replace('+00:00','Z')` instead of the deprecated `utcnow()` pattern.
- Updated `generated_at` in `secure_rails/template_health.py` to use `datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00','Z')` instead of `utcnow()`.

### Testing
- Ran SecureRails checks: `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_safety_ledger_check.py docs/secure-rails/templates/safety-ledger-example.json`, `python scripts/secure_rails_no_automerge_check.py .`, and `python scripts/secure_rails_use_case_triage_check.py docs/secure-rails/templates/deployment-intake-example.json` and all passed.
- Executed repo-security CLI flows `python -m secure_rails repo-security inventory`, `code-scanning-readiness`, `secret-scanning-posture`, `sarif-readiness`, `baseline`, and `validate` and they completed successfully.
- Ran docs audits via `python -m agialpha_docs audit-*` and the full test suite with `python -m unittest discover -s tests`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0247d2393083339bb57994e1f89e4b)