### PR TITLE
Add MARK allocation and Sovereign policy rules and tests

### DIFF
--- a/config/securerails_policy_rules_mark_allocation.json
+++ b/config/securerails_policy_rules_mark_allocation.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "securerails.policy_rules.v1",
+  "domain": "mark_allocation",
+  "rules": [
+    {
+      "rule_id": "mark-allocation-required-fields",
+      "domain": "mark_allocation",
+      "decision": "reject",
+      "missing_decision": "reject",
+      "required_terms": [
+        "assigned_sovereign",
+        "validators_required",
+        "human_review_required",
+        "proof_required",
+        "promotion_without_evidence_allowed",
+        "auto_merge_allowed",
+        "claim_boundary"
+      ],
+      "message": "MARK allocation must include required governance and claim-boundary fields."
+    },
+    {
+      "rule_id": "mark-allocation-no-automerge",
+      "domain": "mark_allocation",
+      "decision": "reject",
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "auto merge allowed", "approved_to_merge", "\"human_review_required\": false", "human review required false", "\"promotion_without_evidence_allowed\": true", "promotion without evidence allowed"],
+      "message": "MARK allocation must not allow auto-merge or autonomous promotion."
+    }
+  ]
+}

--- a/config/securerails_policy_rules_mark_allocation.json
+++ b/config/securerails_policy_rules_mark_allocation.json
@@ -22,7 +22,7 @@
       "rule_id": "mark-allocation-no-automerge",
       "domain": "mark_allocation",
       "decision": "reject",
-      "forbidden_terms": ["\"auto_merge_allowed\": true", "auto merge allowed", "approved_to_merge", "\"human_review_required\": false", "human review required false", "\"promotion_without_evidence_allowed\": true", "promotion without evidence allowed"],
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_without_evidence_allowed\": true"],
       "message": "MARK allocation must not allow auto-merge or autonomous promotion."
     }
   ]

--- a/config/securerails_policy_rules_sovereign.json
+++ b/config/securerails_policy_rules_sovereign.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "securerails.policy_rules.v1",
+  "domain": "sovereign",
+  "rules": [
+    {
+      "rule_id": "sovereign-required-fields",
+      "domain": "sovereign",
+      "decision": "reject",
+      "missing_decision": "reject",
+      "required_terms": [
+        "allowed_work",
+        "forbidden_work",
+        "validators",
+        "proofbundle_policy",
+        "evidence_docket_policy",
+        "promotion_policy",
+        "human_review_required",
+        "auto_merge_allowed",
+        "claim_boundary"
+      ],
+      "message": "Sovereign records must include required governance, proof, and claim-boundary fields."
+    },
+    {
+      "rule_id": "sovereign-no-automerge",
+      "domain": "sovereign",
+      "decision": "reject",
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "human review required false", "\"promotion_policy\": \"autonomous\"", "autonomous promotion", "promotion without evidence"],
+      "message": "Sovereign records must keep auto-merge disabled and preserve human review gates."
+    }
+  ]
+}

--- a/config/securerails_policy_rules_sovereign.json
+++ b/config/securerails_policy_rules_sovereign.json
@@ -24,7 +24,7 @@
       "rule_id": "sovereign-no-automerge",
       "domain": "sovereign",
       "decision": "reject",
-      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "human review required false", "\"promotion_policy\": \"autonomous\"", "autonomous promotion", "promotion without evidence"],
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_policy\": \"autonomous\""],
       "message": "Sovereign records must keep auto-merge disabled and preserve human review gates."
     }
   ]

--- a/config/securerails_policy_rules_sovereign.json
+++ b/config/securerails_policy_rules_sovereign.json
@@ -24,7 +24,7 @@
       "rule_id": "sovereign-no-automerge",
       "domain": "sovereign",
       "decision": "reject",
-      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_policy\": \"autonomous\""],
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_policy\": \"autonomous\"", "\"autonomous_promotion_allowed\": true"],
       "message": "Sovereign records must keep auto-merge disabled and preserve human review gates."
     }
   ]

--- a/secure_rails/policy_kernel.py
+++ b/secure_rails/policy_kernel.py
@@ -77,6 +77,8 @@ def evaluate_context(context, kernel, rules):
         'release_train': {'release'},
         'trust_center': {'trust_center'},
         'repo_security_baseline': {'repo_security'},
+        'mark_allocation': {'mark_allocation'},
+        'sovereign': {'sovereign'},
     }
     for r in rules:
         allowed_contexts = domain_context.get(r.get('domain'), {context.get('context_type')})
@@ -97,6 +99,8 @@ def evaluate_context(context, kernel, rules):
         if has_required_terms is False and required_terms:
             matched.append(r["rule_id"]);viol.append("missing required terms: " + ",".join(required_terms))
             if r.get("missing_decision"): decision = r["missing_decision"]
+
+
     # allow negated boundary phrases
     if "does not claim achieved agi" in hay or "not empirical sota" in hay:
         if decision == "escalate": decision = "allow"

--- a/secure_rails/policy_rules.py
+++ b/secure_rails/policy_rules.py
@@ -7,6 +7,8 @@ RULE_FILES = [
     "securerails_policy_rules_eu_ai_act.json",
     "securerails_policy_rules_token_utility.json",
     "securerails_policy_rules_work_vault.json",
+    "securerails_policy_rules_mark_allocation.json",
+    "securerails_policy_rules_sovereign.json",
     "securerails_policy_rules_github_app.json",
     "securerails_policy_rules_release.json",
     "securerails_policy_rules_trust_center.json",

--- a/tests/fixtures/securerails_policy/valid_mark_allocation.json
+++ b/tests/fixtures/securerails_policy/valid_mark_allocation.json
@@ -1,1 +1,9 @@
-{"assigned_sovereign":"s1","validators_required":["v1"],"human_review_required":true,"proof_required":true,"auto_merge_allowed":false,"claim_boundary":"present"}
+{
+  "assigned_sovereign": "s1",
+  "validators_required": ["v1"],
+  "human_review_required": true,
+  "proof_required": true,
+  "promotion_without_evidence_allowed": false,
+  "auto_merge_allowed": false,
+  "claim_boundary": "MARK allocation governance only; no certification claim"
+}

--- a/tests/fixtures/securerails_policy/valid_sovereign.json
+++ b/tests/fixtures/securerails_policy/valid_sovereign.json
@@ -1,1 +1,11 @@
-{"allowed_work":["defensive"],"forbidden_work":["offensive"],"validators":["v1"],"human_review_required":true,"auto_merge_allowed":false,"claim_boundary":"present"}
+{
+  "allowed_work": ["defensive"],
+  "forbidden_work": ["offensive"],
+  "validators": ["v1"],
+  "proofbundle_policy": "required",
+  "evidence_docket_policy": "required",
+  "promotion_policy": "human_review_required",
+  "human_review_required": true,
+  "auto_merge_allowed": false,
+  "claim_boundary": "Sovereign governance only; no certification claim"
+}

--- a/tests/test_securerails_policy_mark_allocation.py
+++ b/tests/test_securerails_policy_mark_allocation.py
@@ -19,6 +19,15 @@ class TestSecureRailsPolicyMarkAllocation(unittest.TestCase):
             d = evaluate_file(str(p), context_type='mark_allocation')
         self.assertEqual(d['decision'], 'reject')
 
+    def test_mark_negated_automerge_text_not_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_mark_allocation.json').read_text())
+        base['claim_boundary'] = 'Auto merge allowed is not allowed; human review required remains true.'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'negated_text.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='mark_allocation')
+        self.assertNotEqual(d['decision'], 'reject')
+
     def test_valid_mark_allocation_allow_or_warn(self):
         d = evaluate_file('tests/fixtures/securerails_policy/valid_mark_allocation.json', context_type='mark_allocation')
         self.assertEqual(d['decision'], 'escalate')

--- a/tests/test_securerails_policy_mark_allocation.py
+++ b/tests/test_securerails_policy_mark_allocation.py
@@ -1,0 +1,28 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from secure_rails.policy_kernel import evaluate_file
+
+
+class TestSecureRailsPolicyMarkAllocation(unittest.TestCase):
+    def test_invalid_mark_automerge_rejected(self):
+        d = evaluate_file('tests/fixtures/securerails_policy/invalid_mark_automerge.json', context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_mark_human_review_false_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_mark_allocation.json').read_text())
+        base['human_review_required'] = False
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_human_review.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_valid_mark_allocation_allow_or_warn(self):
+        d = evaluate_file('tests/fixtures/securerails_policy/valid_mark_allocation.json', context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'escalate')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -29,6 +29,15 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
             d = evaluate_file(str(p), context_type='sovereign')
         self.assertEqual(d['decision'], 'reject')
 
+    def test_sovereign_negated_autonomous_promotion_text_not_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['claim_boundary'] = 'Autonomous promotion is not allowed; governance remains human reviewed.'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'negated_text.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertNotEqual(d['decision'], 'reject')
+
     def test_sovereign_with_automerge_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
         base['auto_merge_allowed'] = True

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -1,0 +1,43 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from secure_rails.policy_kernel import evaluate_file
+
+
+class TestSecureRailsPolicySovereign(unittest.TestCase):
+    def test_valid_sovereign_allow_or_warn(self):
+        d = evaluate_file('tests/fixtures/securerails_policy/valid_sovereign.json', context_type='sovereign')
+        self.assertEqual(d['decision'], 'escalate')
+
+
+    def test_sovereign_autonomous_promotion_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['promotion_policy'] = 'autonomous'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_promotion.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_sovereign_human_review_false_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['human_review_required'] = False
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_human_review.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_sovereign_with_automerge_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['auto_merge_allowed'] = True
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -11,6 +11,16 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
         self.assertEqual(d['decision'], 'escalate')
 
 
+
+    def test_sovereign_autonomous_promotion_flag_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['promotion_policy'] = {'autonomous_promotion_allowed': True, 'human_review_required': True, 'auto_merge_allowed': False}
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_promotion_flag.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
     def test_sovereign_autonomous_promotion_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
         base['promotion_policy'] = 'autonomous'


### PR DESCRIPTION
### Motivation
- Introduce policy checks for two new domains, `mark_allocation` and `sovereign`, to enforce governance, proof, and claim-boundary requirements.
- Prevent unsafe automation by rejecting records that enable auto-merge or autonomous promotion in these domains.
- Provide fixtures and unit tests to validate the new rule behavior during CI.

### Description
- Added two new rule files `config/securerails_policy_rules_mark_allocation.json` and `config/securerails_policy_rules_sovereign.json` containing required-terms and forbidden-term rules that produce `reject` decisions for violations. 
- Registered the new rule files in `secure_rails/policy_rules.py` by appending them to the `RULE_FILES` list.
- Extended the `domain_context` map in `secure_rails/policy_kernel.py` to allow evaluation of `mark_allocation` and `sovereign` contexts and reuse existing rule evaluation logic.
- Updated test fixtures `tests/fixtures/securerails_policy/valid_mark_allocation.json` and `tests/fixtures/securerails_policy/valid_sovereign.json` to include the newly required fields.
- Added unit tests `tests/test_securerails_policy_mark_allocation.py` and `tests/test_securerails_policy_sovereign.py` to exercise valid and failing cases for the new policies.

### Testing
- Ran the added unit tests `tests/test_securerails_policy_mark_allocation.py` and `tests/test_securerails_policy_sovereign.py` which exercise accept/reject scenarios for both domains and they passed successfully.
- Existing rule-loading via `load_rules()` was exercised by the tests to ensure the new config files are discovered and parsed correctly and this succeeded.
- Policy evaluation behavior was validated end-to-end via `secure_rails.policy_kernel.evaluate_file` in the tests and produced expected decisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033d148d288333a0c38c66c4cadf2c)