### PR TITLE
Add MARK allocation and Sovereign policy rules, include in loader, and add tests

### DIFF
--- a/config/securerails_policy_rules_mark_allocation.json
+++ b/config/securerails_policy_rules_mark_allocation.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "securerails.policy_rules.v1",
+  "domain": "mark_allocation",
+  "rules": [
+    {
+      "rule_id": "mark-allocation-required-fields",
+      "domain": "mark_allocation",
+      "decision": "reject",
+      "missing_decision": "reject",
+      "required_terms": [
+        "assigned_sovereign",
+        "validators_required",
+        "human_review_required",
+        "proof_required",
+        "promotion_without_evidence_allowed",
+        "auto_merge_allowed",
+        "claim_boundary"
+      ],
+      "message": "MARK allocation must include required governance and claim-boundary fields."
+    },
+    {
+      "rule_id": "mark-allocation-no-automerge",
+      "domain": "mark_allocation",
+      "decision": "reject",
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_without_evidence_allowed\": true"],
+      "message": "MARK allocation must not allow auto-merge or autonomous promotion."
+    }
+  ]
+}

--- a/config/securerails_policy_rules_sovereign.json
+++ b/config/securerails_policy_rules_sovereign.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "securerails.policy_rules.v1",
+  "domain": "sovereign",
+  "rules": [
+    {
+      "rule_id": "sovereign-required-fields",
+      "domain": "sovereign",
+      "decision": "reject",
+      "missing_decision": "reject",
+      "required_terms": [
+        "allowed_work",
+        "forbidden_work",
+        "validators",
+        "proofbundle_policy",
+        "evidence_docket_policy",
+        "promotion_policy",
+        "human_review_required",
+        "auto_merge_allowed",
+        "claim_boundary"
+      ],
+      "message": "Sovereign records must include required governance, proof, and claim-boundary fields."
+    },
+    {
+      "rule_id": "sovereign-no-automerge",
+      "domain": "sovereign",
+      "decision": "reject",
+      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_policy\": \"autonomous\"", "\"autonomous_promotion_allowed\": true"],
+      "message": "Sovereign records must keep auto-merge disabled and preserve human review gates."
+    }
+  ]
+}

--- a/config/securerails_policy_rules_sovereign.json
+++ b/config/securerails_policy_rules_sovereign.json
@@ -14,8 +14,6 @@
         "proofbundle_policy",
         "evidence_docket_policy",
         "promotion_policy",
-        "human_review_required",
-        "auto_merge_allowed",
         "claim_boundary"
       ],
       "message": "Sovereign records must include required governance, proof, and claim-boundary fields."
@@ -24,7 +22,13 @@
       "rule_id": "sovereign-no-automerge",
       "domain": "sovereign",
       "decision": "reject",
-      "forbidden_terms": ["\"auto_merge_allowed\": true", "approved_to_merge", "\"human_review_required\": false", "\"promotion_policy\": \"autonomous\"", "\"autonomous_promotion_allowed\": true"],
+      "forbidden_terms": [
+        "\"auto_merge_allowed\": true",
+        "approved_to_merge",
+        "\"human_review_required\": false",
+        "\"promotion_policy\": \"autonomous\"",
+        "\"autonomous_promotion_allowed\": true"
+      ],
       "message": "Sovereign records must keep auto-merge disabled and preserve human review gates."
     }
   ]

--- a/secure_rails/policy_kernel.py
+++ b/secure_rails/policy_kernel.py
@@ -16,6 +16,12 @@ def _all_required_terms_present(context, required_terms):
     return all(t.lower() in hay for t in required_terms)
 
 
+def _required_keys_present(content, required_terms):
+    if not isinstance(content, dict):
+        return False
+    return all(k in content for k in required_terms)
+
+
 def _work_vault_flags_true(content, required_terms):
     if not isinstance(content, dict):
         return False
@@ -96,6 +102,8 @@ def evaluate_context(context, kernel, rules):
         has_required_terms = _all_required_terms_present(context, required_terms)
         if r.get("domain") == "work_vault" and required_terms:
             has_required_terms = has_required_terms and _work_vault_flags_true(context.get("content", {}), required_terms)
+        if r.get("domain") in {"mark_allocation", "sovereign"} and required_terms:
+            has_required_terms = has_required_terms and _required_keys_present(context.get("content", {}), required_terms)
         if has_required_terms is False and required_terms:
             matched.append(r["rule_id"]);viol.append("missing required terms: " + ",".join(required_terms))
             if r.get("missing_decision"): decision = r["missing_decision"]

--- a/secure_rails/policy_kernel.py
+++ b/secure_rails/policy_kernel.py
@@ -22,6 +22,22 @@ def _required_keys_present(content, required_terms):
     return all(k in content for k in required_terms)
 
 
+def _sovereign_promotion_policy_safe(content):
+    if not isinstance(content, dict):
+        return False
+    policy = content.get('promotion_policy')
+    if not isinstance(policy, dict):
+        return False
+    required = {'autonomous_promotion_allowed': False, 'human_review_required': True, 'auto_merge_allowed': False}
+    for k, expected in required.items():
+        v = policy.get(k)
+        if not isinstance(v, bool):
+            return False
+        if v is not expected:
+            return False
+    return True
+
+
 def _work_vault_flags_true(content, required_terms):
     if not isinstance(content, dict):
         return False
@@ -104,6 +120,8 @@ def evaluate_context(context, kernel, rules):
             has_required_terms = has_required_terms and _work_vault_flags_true(context.get("content", {}), required_terms)
         if r.get("domain") in {"mark_allocation", "sovereign"} and required_terms:
             has_required_terms = has_required_terms and _required_keys_present(context.get("content", {}), required_terms)
+        if r.get("domain") == "sovereign" and required_terms:
+            has_required_terms = has_required_terms and _sovereign_promotion_policy_safe(context.get("content", {}))
         if has_required_terms is False and required_terms:
             matched.append(r["rule_id"]);viol.append("missing required terms: " + ",".join(required_terms))
             if r.get("missing_decision"): decision = r["missing_decision"]

--- a/secure_rails/policy_kernel.py
+++ b/secure_rails/policy_kernel.py
@@ -77,6 +77,8 @@ def evaluate_context(context, kernel, rules):
         'release_train': {'release'},
         'trust_center': {'trust_center'},
         'repo_security_baseline': {'repo_security'},
+        'mark_allocation': {'mark_allocation'},
+        'sovereign': {'sovereign'},
     }
     for r in rules:
         allowed_contexts = domain_context.get(r.get('domain'), {context.get('context_type')})
@@ -97,6 +99,8 @@ def evaluate_context(context, kernel, rules):
         if has_required_terms is False and required_terms:
             matched.append(r["rule_id"]);viol.append("missing required terms: " + ",".join(required_terms))
             if r.get("missing_decision"): decision = r["missing_decision"]
+
+
     # allow negated boundary phrases
     if "does not claim achieved agi" in hay or "not empirical sota" in hay:
         if decision == "escalate": decision = "allow"

--- a/secure_rails/policy_rules.py
+++ b/secure_rails/policy_rules.py
@@ -7,6 +7,8 @@ RULE_FILES = [
     "securerails_policy_rules_eu_ai_act.json",
     "securerails_policy_rules_token_utility.json",
     "securerails_policy_rules_work_vault.json",
+    "securerails_policy_rules_mark_allocation.json",
+    "securerails_policy_rules_sovereign.json",
     "securerails_policy_rules_github_app.json",
     "securerails_policy_rules_release.json",
     "securerails_policy_rules_trust_center.json",

--- a/tests/fixtures/securerails_policy/valid_mark_allocation.json
+++ b/tests/fixtures/securerails_policy/valid_mark_allocation.json
@@ -1,1 +1,9 @@
-{"assigned_sovereign":"s1","validators_required":["v1"],"human_review_required":true,"proof_required":true,"auto_merge_allowed":false,"claim_boundary":"present"}
+{
+  "assigned_sovereign": "s1",
+  "validators_required": ["v1"],
+  "human_review_required": true,
+  "proof_required": true,
+  "promotion_without_evidence_allowed": false,
+  "auto_merge_allowed": false,
+  "claim_boundary": "MARK allocation governance only; no certification claim"
+}

--- a/tests/fixtures/securerails_policy/valid_sovereign.json
+++ b/tests/fixtures/securerails_policy/valid_sovereign.json
@@ -1,11 +1,19 @@
 {
-  "allowed_work": ["defensive"],
-  "forbidden_work": ["offensive"],
-  "validators": ["v1"],
+  "allowed_work": [
+    "defensive"
+  ],
+  "forbidden_work": [
+    "offensive"
+  ],
+  "validators": [
+    "v1"
+  ],
   "proofbundle_policy": "required",
   "evidence_docket_policy": "required",
-  "promotion_policy": "human_review_required",
-  "human_review_required": true,
-  "auto_merge_allowed": false,
+  "promotion_policy": {
+    "autonomous_promotion_allowed": false,
+    "human_review_required": true,
+    "auto_merge_allowed": false
+  },
   "claim_boundary": "Sovereign governance only; no certification claim"
 }

--- a/tests/fixtures/securerails_policy/valid_sovereign.json
+++ b/tests/fixtures/securerails_policy/valid_sovereign.json
@@ -1,1 +1,11 @@
-{"allowed_work":["defensive"],"forbidden_work":["offensive"],"validators":["v1"],"human_review_required":true,"auto_merge_allowed":false,"claim_boundary":"present"}
+{
+  "allowed_work": ["defensive"],
+  "forbidden_work": ["offensive"],
+  "validators": ["v1"],
+  "proofbundle_policy": "required",
+  "evidence_docket_policy": "required",
+  "promotion_policy": "human_review_required",
+  "human_review_required": true,
+  "auto_merge_allowed": false,
+  "claim_boundary": "Sovereign governance only; no certification claim"
+}

--- a/tests/test_securerails_policy_mark_allocation.py
+++ b/tests/test_securerails_policy_mark_allocation.py
@@ -19,6 +19,17 @@ class TestSecureRailsPolicyMarkAllocation(unittest.TestCase):
             d = evaluate_file(str(p), context_type='mark_allocation')
         self.assertEqual(d['decision'], 'reject')
 
+
+    def test_mark_required_terms_text_only_bypass_rejected(self):
+        obj = {
+            'note': 'assigned_sovereign validators_required human_review_required proof_required promotion_without_evidence_allowed auto_merge_allowed claim_boundary'
+        }
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'text_bypass.json'
+            p.write_text(json.dumps(obj), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'reject')
+
     def test_mark_negated_automerge_text_not_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_mark_allocation.json').read_text())
         base['claim_boundary'] = 'Auto merge allowed is not allowed; human review required remains true.'

--- a/tests/test_securerails_policy_mark_allocation.py
+++ b/tests/test_securerails_policy_mark_allocation.py
@@ -1,0 +1,37 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from secure_rails.policy_kernel import evaluate_file
+
+
+class TestSecureRailsPolicyMarkAllocation(unittest.TestCase):
+    def test_invalid_mark_automerge_rejected(self):
+        d = evaluate_file('tests/fixtures/securerails_policy/invalid_mark_automerge.json', context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_mark_human_review_false_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_mark_allocation.json').read_text())
+        base['human_review_required'] = False
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_human_review.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_mark_negated_automerge_text_not_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_mark_allocation.json').read_text())
+        base['claim_boundary'] = 'Auto merge allowed is not allowed; human review required remains true.'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'negated_text.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='mark_allocation')
+        self.assertNotEqual(d['decision'], 'reject')
+
+    def test_valid_mark_allocation_allow_or_warn(self):
+        d = evaluate_file('tests/fixtures/securerails_policy/valid_mark_allocation.json', context_type='mark_allocation')
+        self.assertEqual(d['decision'], 'escalate')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -22,6 +22,25 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
 
 
 
+
+    def test_sovereign_empty_promotion_policy_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['promotion_policy'] = {}
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'empty_promotion.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_sovereign_string_flag_promotion_policy_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['promotion_policy']['auto_merge_allowed'] = 'true'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'string_promotion.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
     def test_sovereign_required_terms_text_only_bypass_rejected(self):
         obj = {
             'note': 'allowed_work forbidden_work validators proofbundle_policy evidence_docket_policy promotion_policy claim_boundary'

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -21,6 +21,17 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
         self.assertEqual(d['decision'], 'reject')
 
 
+
+    def test_sovereign_required_terms_text_only_bypass_rejected(self):
+        obj = {
+            'note': 'allowed_work forbidden_work validators proofbundle_policy evidence_docket_policy promotion_policy human_review_required auto_merge_allowed claim_boundary'
+        }
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'text_bypass.json'
+            p.write_text(json.dumps(obj), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
     def test_sovereign_object_autonomous_promotion_flag_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
         base['promotion_policy'] = {'autonomous_promotion_allowed': True, 'human_review_required': True, 'auto_merge_allowed': False}

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -1,0 +1,62 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from secure_rails.policy_kernel import evaluate_file
+
+
+class TestSecureRailsPolicySovereign(unittest.TestCase):
+    def test_valid_sovereign_allow_or_warn(self):
+        d = evaluate_file('tests/fixtures/securerails_policy/valid_sovereign.json', context_type='sovereign')
+        self.assertEqual(d['decision'], 'escalate')
+
+
+    def test_sovereign_autonomous_promotion_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['promotion_policy'] = 'autonomous'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_promotion.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+
+    def test_sovereign_object_autonomous_promotion_flag_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['promotion_policy'] = {'autonomous_promotion_allowed': True, 'human_review_required': True, 'auto_merge_allowed': False}
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_object_promotion.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_sovereign_human_review_false_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['human_review_required'] = False
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad_human_review.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+    def test_sovereign_negated_autonomous_promotion_text_not_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['claim_boundary'] = 'Autonomous promotion is not allowed; governance remains human reviewed.'
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'negated_text.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertNotEqual(d['decision'], 'reject')
+
+    def test_sovereign_with_automerge_rejected(self):
+        base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
+        base['auto_merge_allowed'] = True
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / 'bad.json'
+            p.write_text(json.dumps(base), encoding='utf-8')
+            d = evaluate_file(str(p), context_type='sovereign')
+        self.assertEqual(d['decision'], 'reject')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_securerails_policy_sovereign.py
+++ b/tests/test_securerails_policy_sovereign.py
@@ -13,7 +13,7 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
 
     def test_sovereign_autonomous_promotion_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
-        base['promotion_policy'] = 'autonomous'
+        base['promotion_policy'] = {'autonomous_promotion_allowed': True, 'human_review_required': True, 'auto_merge_allowed': False}
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / 'bad_promotion.json'
             p.write_text(json.dumps(base), encoding='utf-8')
@@ -24,7 +24,7 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
 
     def test_sovereign_required_terms_text_only_bypass_rejected(self):
         obj = {
-            'note': 'allowed_work forbidden_work validators proofbundle_policy evidence_docket_policy promotion_policy human_review_required auto_merge_allowed claim_boundary'
+            'note': 'allowed_work forbidden_work validators proofbundle_policy evidence_docket_policy promotion_policy claim_boundary'
         }
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / 'text_bypass.json'
@@ -43,7 +43,7 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
 
     def test_sovereign_human_review_false_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
-        base['human_review_required'] = False
+        base['promotion_policy']['human_review_required'] = False
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / 'bad_human_review.json'
             p.write_text(json.dumps(base), encoding='utf-8')
@@ -61,7 +61,7 @@ class TestSecureRailsPolicySovereign(unittest.TestCase):
 
     def test_sovereign_with_automerge_rejected(self):
         base = json.loads(Path('tests/fixtures/securerails_policy/valid_sovereign.json').read_text())
-        base['auto_merge_allowed'] = True
+        base['promotion_policy']['auto_merge_allowed'] = True
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / 'bad.json'
             p.write_text(json.dumps(base), encoding='utf-8')


### PR DESCRIPTION
### Motivation

- Introduce explicit policy enforcement for MARK allocation and Sovereign records to ensure governance fields are present and to forbid autonomous promotion/auto-merge.

### Description

- Add new rule files `config/securerails_policy_rules_mark_allocation.json` and `config/securerails_policy_rules_sovereign.json` defining required and forbidden terms for the new domains.
- Register the new rule files in `secure_rails/policy_rules.py` by adding them to `RULE_FILES` so they are loaded by the rule loader.
- Extend `secure_rails/policy_kernel.py` domain context map to include `mark_allocation` and `sovereign` contexts so rules are only applied to appropriate context types.
- Add formatted fixtures `tests/fixtures/securerails_policy/valid_mark_allocation.json` and `valid_sovereign.json` and new unit tests `tests/test_securerails_policy_mark_allocation.py` and `tests/test_securerails_policy_sovereign.py` to validate the new rules and negation handling.

### Testing

- Ran the new policy unit tests with `pytest tests/test_securerails_policy_mark_allocation.py tests/test_securerails_policy_sovereign.py` and they passed.
- Ran the repository test suite with `pytest -q` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033d148d288333a0c38c66c4cadf2c)