### PR TITLE
Implement SecureRails Policy Kernel 001

### DIFF
--- a/docs/secure-rails/README.md
+++ b/docs/secure-rails/README.md
@@ -1,6 +1,6 @@
 # SecureRails Documentation
 
-SecureRails is AI-agent security governance and proof-bound defensive remediation, with human-reviewed promotion, excluded high-risk uses, and executable guardrails.
+SecureRails is AI-agent security governance and proof-bound defensive remediation, with human-reviewed promotion, excluded high-risk uses, and executable guardrails. SecureRails is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
 
 - Operator runbook: [operator-runbook.md](operator-runbook.md)
 - Work Vaults/MARK/Sovereigns: [work-vaults-mark-sovereigns.md](work-vaults-mark-sovereigns.md)

--- a/docs/secure-rails/policy-kernel.md
+++ b/docs/secure-rails/policy-kernel.md
@@ -6,4 +6,4 @@ SecureRails Policy Kernel 001 provides deterministic policy-as-code evaluation w
 - No auto-merge.
 - Hard boundaries cannot be waived.
 - "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not."
-- SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cyberautonomous cybersecurity-certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.
+- SecureRails is AI-agent security governance and proof-bound defensive remediation. It is not autonomous cybersecurity certification, not offensive cyber, not a high-risk decision system by intended purpose, not a GPAI model provider by default, and not an investment product.


### PR DESCRIPTION
### Motivation
- Fix malformed doctrine wording and make the SecureRails boundary statement explicit in top-level SecureRails docs so the policy kernel doctrine reads cleanly as “not autonomous cybersecurity certification” and to reinforce that SecureRails is governance and not a certification or investment product.

### Description
- Corrected wording in `docs/secure-rails/policy-kernel.md` and added the explicit boundary sentence to `docs/secure-rails/README.md` to preserve the SecureRails doctrine and wording consistency.

### Testing
- Ran unit tests for the SecureRails policy suite with `python -m unittest discover -s tests -p 'test_securerails_policy*.py'`, which executed 40 tests and returned OK.
- Validated the policy kernel and exercised evaluation with `python -m secure_rails policy validate-kernel --kernel config/securerails_policy_kernel.json` and `python -m secure_rails policy evaluate --input tests/fixtures/securerails_policy/forbidden_positive_overclaim.md --context-type generic_text --out /tmp/decision.json` followed by `python scripts/secure_rails_policy_decision_check.py /tmp/decision.json`, which reported the kernel and decision as valid.
- Ran claim-boundary and no-auto-merge checks (`scripts/secure_rails_claim_boundary_check.py` and `scripts/secure_rails_no_automerge_check.py`) which passed; a broader `scripts/secure_rails_policy_check.py` run reported existing repository-wide policy violations unrelated to this documentation wording fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0382b7f73c8333b9e42075bfdbda0e)