### PR TITLE
Implement AGI ALPHA Recursive Substrate 002

### DIFF
--- a/docs/_generated/recursive-substrate/category_context.json
+++ b/docs/_generated/recursive-substrate/category_context.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "agialpha.recursive_category_context.v1",
+  "category": "self-improving AI / recursive AI labor / open-ended automated discovery",
+  "external_context_summary": [
+    "The public self-improving AI category is moving toward open-ended algorithms, automated scientific discovery, and AI systems that improve AI.",
+    "Open-ended discovery is described as a process that produces and preserves an archive of discoveries that build on one another.",
+    "A major public category thesis is AI improving AI first, then applying the playbook to broader science."
+  ],
+  "reference_families": [
+    "AI-generating algorithms",
+    "open-ended discovery",
+    "quality-diversity algorithms",
+    "Darwin G\u00f6del Machine",
+    "ADAS",
+    "AI Scientist",
+    "PromptBreeder",
+    "Rainbow Teaming",
+    "Automated Capability Discovery",
+    "self-improving coding agents",
+    "automated red teaming",
+    "meta-agentic orchestration",
+    "recursive AI labor"
+  ],
+  "agialpha_original_position": "AGI ALPHA implements this category as a governed substrate for proof-bound machine labor: Work Vaults, MARK allocation, Sovereigns, AGI Jobs, validators, ProofBundles, Evidence Dockets, policy decisions, settlement, human review, and vNext recursive cycles.",
+  "claim_boundary": "This category context is positioning and research context. It does not claim AGI ALPHA has achieved AGI, ASI, superintelligence, empirical SOTA, or external validation."
+}

--- a/docs/_generated/recursive-substrate/research_reference_map.json
+++ b/docs/_generated/recursive-substrate/research_reference_map.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "agialpha.recursive_reference_map.v1",
+  "references": [
+    "AI-generating algorithms",
+    "open-ended discovery",
+    "quality-diversity algorithms",
+    "Darwin G\u00f6del Machine",
+    "ADAS",
+    "AI Scientist",
+    "PromptBreeder",
+    "Rainbow Teaming",
+    "Automated Capability Discovery",
+    "self-improving coding agents",
+    "automated red teaming",
+    "meta-agentic orchestration",
+    "recursive AI labor"
+  ],
+  "label": "Reference map only. Not a claim that all systems are implemented here.",
+  "claim_boundary": "This category context is positioning and research context. It does not claim AGI ALPHA has achieved AGI, ASI, superintelligence, empirical SOTA, or external validation."
+}

--- a/recursive_substrate_registry/category_context.json
+++ b/recursive_substrate_registry/category_context.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "agialpha.recursive_category_context.v1",
+  "category": "self-improving AI / recursive AI labor / open-ended automated discovery",
+  "external_context_summary": [
+    "The public self-improving AI category is moving toward open-ended algorithms, automated scientific discovery, and AI systems that improve AI.",
+    "Open-ended discovery is described as a process that produces and preserves an archive of discoveries that build on one another.",
+    "A major public category thesis is AI improving AI first, then applying the playbook to broader science."
+  ],
+  "reference_families": [
+    "AI-generating algorithms",
+    "open-ended discovery",
+    "quality-diversity algorithms",
+    "Darwin G\u00f6del Machine",
+    "ADAS",
+    "AI Scientist",
+    "PromptBreeder",
+    "Rainbow Teaming",
+    "Automated Capability Discovery",
+    "self-improving coding agents",
+    "automated red teaming",
+    "meta-agentic orchestration",
+    "recursive AI labor"
+  ],
+  "agialpha_original_position": "AGI ALPHA implements this category as a governed substrate for proof-bound machine labor: Work Vaults, MARK allocation, Sovereigns, AGI Jobs, validators, ProofBundles, Evidence Dockets, policy decisions, settlement, human review, and vNext recursive cycles.",
+  "claim_boundary": "This category context is positioning and research context. It does not claim AGI ALPHA has achieved AGI, ASI, superintelligence, empirical SOTA, or external validation."
+}

--- a/recursive_substrate_registry/research_reference_map.json
+++ b/recursive_substrate_registry/research_reference_map.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "agialpha.recursive_reference_map.v1",
+  "references": [
+    "AI-generating algorithms",
+    "open-ended discovery",
+    "quality-diversity algorithms",
+    "Darwin G\u00f6del Machine",
+    "ADAS",
+    "AI Scientist",
+    "PromptBreeder",
+    "Rainbow Teaming",
+    "Automated Capability Discovery",
+    "self-improving coding agents",
+    "automated red teaming",
+    "meta-agentic orchestration",
+    "recursive AI labor"
+  ],
+  "label": "Reference map only. Not a claim that all systems are implemented here.",
+  "claim_boundary": "This category context is positioning and research context. It does not claim AGI ALPHA has achieved AGI, ASI, superintelligence, empirical SOTA, or external validation."
+}

--- a/tests/test_recursive_substrate_ai_improves_ai.py
+++ b/tests/test_recursive_substrate_ai_improves_ai.py
@@ -1,0 +1,29 @@
+import json
+import pathlib
+import subprocess
+import unittest
+
+
+class TestRecursiveSubstrateAiImprovesAi(unittest.TestCase):
+    def test_ai_improves_ai_outputs_lock_before_heldout(self):
+        out_dir = pathlib.Path('/tmp/recursive-substrate-test/ai_improves_ai')
+        subprocess.check_call([
+            'python', '-m', 'agialpha_recursive_substrate', 'ai-improves-ai',
+            '--repo-root', '.', '--registry', 'recursive_substrate_registry',
+            '--out', str(out_dir), '--candidate-mechanisms', '6', '--heldout-fixtures', '8'
+        ])
+        lock_path = out_dir / 'candidate_lock.json'
+        heldout_path = out_dir / 'heldout_fixtures.json'
+        self.assertTrue(lock_path.exists())
+        self.assertTrue(heldout_path.exists())
+
+        lock = json.loads(lock_path.read_text(encoding='utf-8'))
+        heldout = json.loads(heldout_path.read_text(encoding='utf-8'))
+        self.assertIn('locked_at', lock)
+        self.assertIsInstance(heldout, list)
+        self.assertGreater(len(heldout), 0)
+        self.assertTrue(all(item.get('generated_after_lock') for item in heldout))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recursive_substrate_automated_scientific_method.py
+++ b/tests/test_recursive_substrate_automated_scientific_method.py
@@ -1,12 +1,15 @@
-import json
 import pathlib
+import shutil
 import subprocess
+import tempfile
 import unittest
 
 
 class TestRecursiveSubstrateAutomatedScientificMethod(unittest.TestCase):
     def test_scientific_method_artifacts_exist(self):
-        out_dir = pathlib.Path('/tmp/recursive-substrate-test/ai_improves_ai')
+        temp_root = pathlib.Path(tempfile.mkdtemp(prefix='recursive-substrate-scimethod-'))
+        self.addCleanup(lambda: shutil.rmtree(temp_root, ignore_errors=True))
+        out_dir = temp_root / 'ai_improves_ai'
         subprocess.check_call([
             'python', '-m', 'agialpha_recursive_substrate', 'ai-improves-ai',
             '--repo-root', '.', '--registry', 'recursive_substrate_registry',

--- a/tests/test_recursive_substrate_automated_scientific_method.py
+++ b/tests/test_recursive_substrate_automated_scientific_method.py
@@ -1,0 +1,26 @@
+import json
+import pathlib
+import subprocess
+import unittest
+
+
+class TestRecursiveSubstrateAutomatedScientificMethod(unittest.TestCase):
+    def test_scientific_method_artifacts_exist(self):
+        out_dir = pathlib.Path('/tmp/recursive-substrate-test/ai_improves_ai')
+        subprocess.check_call([
+            'python', '-m', 'agialpha_recursive_substrate', 'ai-improves-ai',
+            '--repo-root', '.', '--registry', 'recursive_substrate_registry',
+            '--out', str(out_dir), '--candidate-mechanisms', '4', '--heldout-fixtures', '5'
+        ])
+        for rel in [
+            'scientific_method_report.json',
+            'replay_report.json',
+            'falsification_audit.json',
+            'promotion_dossier.md',
+            'safe_pr_plan.json',
+        ]:
+            self.assertTrue((out_dir / rel).exists(), rel)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recursive_substrate_category_context.py
+++ b/tests/test_recursive_substrate_category_context.py
@@ -1,0 +1,18 @@
+import json
+import pathlib
+import unittest
+
+
+class TestRecursiveSubstrateCategoryContext(unittest.TestCase):
+    def test_category_context_registry_shape(self):
+        path = pathlib.Path('recursive_substrate_registry/category_context.json')
+        self.assertTrue(path.exists())
+        data = json.loads(path.read_text(encoding='utf-8'))
+        self.assertEqual(data.get('schema_version'), 'agialpha.recursive_category_context.v1')
+        self.assertIn('claim_boundary', data)
+        self.assertIn('reference_families', data)
+        self.assertIsInstance(data['reference_families'], list)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recursive_substrate_reference_map.py
+++ b/tests/test_recursive_substrate_reference_map.py
@@ -1,0 +1,17 @@
+import json
+import pathlib
+import unittest
+
+
+class TestRecursiveSubstrateReferenceMap(unittest.TestCase):
+    def test_reference_map_is_context_only(self):
+        path = pathlib.Path('recursive_substrate_registry/research_reference_map.json')
+        self.assertTrue(path.exists())
+        data = json.loads(path.read_text(encoding='utf-8'))
+        text = json.dumps(data)
+        self.assertIn('Reference map only', text)
+        self.assertNotIn('implemented all', text.lower())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recursive_substrate_reference_map.py
+++ b/tests/test_recursive_substrate_reference_map.py
@@ -10,7 +10,7 @@ class TestRecursiveSubstrateReferenceMap(unittest.TestCase):
         data = json.loads(path.read_text(encoding='utf-8'))
         text = json.dumps(data)
         self.assertIn('Reference map only', text)
-        self.assertNotIn('implemented all', text.lower())
+        self.assertNotRegex(text.lower(), r'(?<!not a claim that )all systems are implemented')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation

- Provide explicit category-context and research-reference artifacts plus matching generated docs so the Recursive Substrate feature set has a claim-bounded, repository-local context record and Evidence Mission Control exports. 
- Add focused tests that verify the AI-improves-AI lock/heldout sequencing, automated scientific-method artifacts, and the presence and shape of category/context registries while preserving the claim boundary. 

### Description

- Add `recursive_substrate_registry/category_context.json` and `recursive_substrate_registry/research_reference_map.json` containing `schema_version`, `reference_families`, and explicit `claim_boundary` text. 
- Add generated Evidence Mission Control artifacts under `docs/_generated/recursive-substrate/` for `category_context.json` and `research_reference_map.json`. 
- Add unit tests `tests/test_recursive_substrate_ai_improves_ai.py`, `tests/test_recursive_substrate_automated_scientific_method.py`, `tests/test_recursive_substrate_category_context.py`, and `tests/test_recursive_substrate_reference_map.py` to validate lock-before-heldout sequencing, expected artifact outputs, and context-only framing. 

### Testing

- Ran the focused test set with `python -m unittest tests.test_recursive_substrate_ai_improves_ai tests.test_recursive_substrate_automated_scientific_method tests.test_recursive_substrate_category_context tests.test_recursive_substrate_reference_map` and all tests passed. 
- Ran `python -m unittest discover -s tests -p 'test_recursive_substrate*.py'` to exercise recursive-substrate tests and the pattern run passed (11 tests). 
- A full `python -m unittest discover -s tests` run previously surfaced unrelated failures in other suites (an environment secret and other unrelated test domains), but the recursive-substrate additions themselves pass and include the required claim-boundary language.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d84c65948333af0698fc9b7dceed)