### PR TITLE
Add generated registry entries and schemas; avoid duplicate vnext entry in CLI

### DIFF
--- a/agialpha_recursive_substrate/cli.py
+++ b/agialpha_recursive_substrate/cli.py
@@ -119,7 +119,9 @@ def ai_improves_ai(repo_root, registry, out, candidate_mechanisms, heldout_fixtu
     (outp/'promotion_dossier.md').write_text('# Promotion Dossier\n\nPending human review.\n')
     _jwrite(outp/'safe_pr_plan.json', {"autopersist":False,"auto_merge":False,"claim_boundary":CLAIM_SHORT})
     reg=pathlib.Path(registry); reg.mkdir(parents=True, exist_ok=True)
-    _append_registry(reg,'vnext.json',[{"candidate_id":"ai-improves-ai","status":"pending_human_review","claim_boundary":CLAIM_SHORT}])
+    existing_vnext=_jread(reg/'vnext.json',[])
+    if not any(v.get('candidate_id')=='ai-improves-ai' for v in existing_vnext):
+        _append_registry(reg,'vnext.json',[{"candidate_id":"ai-improves-ai","status":"pending_human_review","claim_boundary":CLAIM_SHORT}])
     return {"candidates":candidate_mechanisms,"fixtures":heldout_fixtures}
 
 def main(argv=None):

--- a/recursive_substrate_registry/capabilities.json
+++ b/recursive_substrate_registry/capabilities.json
@@ -718,5 +718,1025 @@
     "capability_id": "recursive-cycle-024-cap-006",
     "job_id": "recursive-cycle-024-job-006",
     "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-025-cap-001",
+    "job_id": "recursive-cycle-025-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-025-cap-002",
+    "job_id": "recursive-cycle-025-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-025-cap-003",
+    "job_id": "recursive-cycle-025-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-025-cap-004",
+    "job_id": "recursive-cycle-025-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-025-cap-005",
+    "job_id": "recursive-cycle-025-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-025-cap-006",
+    "job_id": "recursive-cycle-025-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-026-cap-001",
+    "job_id": "recursive-cycle-026-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-026-cap-002",
+    "job_id": "recursive-cycle-026-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-026-cap-003",
+    "job_id": "recursive-cycle-026-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-026-cap-004",
+    "job_id": "recursive-cycle-026-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-026-cap-005",
+    "job_id": "recursive-cycle-026-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-026-cap-006",
+    "job_id": "recursive-cycle-026-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-027-cap-001",
+    "job_id": "recursive-cycle-027-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-027-cap-002",
+    "job_id": "recursive-cycle-027-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-027-cap-003",
+    "job_id": "recursive-cycle-027-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-027-cap-004",
+    "job_id": "recursive-cycle-027-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-027-cap-005",
+    "job_id": "recursive-cycle-027-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-027-cap-006",
+    "job_id": "recursive-cycle-027-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-028-cap-001",
+    "job_id": "recursive-cycle-028-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-028-cap-002",
+    "job_id": "recursive-cycle-028-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-028-cap-003",
+    "job_id": "recursive-cycle-028-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-028-cap-004",
+    "job_id": "recursive-cycle-028-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-028-cap-005",
+    "job_id": "recursive-cycle-028-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-028-cap-006",
+    "job_id": "recursive-cycle-028-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-029-cap-001",
+    "job_id": "recursive-cycle-029-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-029-cap-002",
+    "job_id": "recursive-cycle-029-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-029-cap-003",
+    "job_id": "recursive-cycle-029-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-029-cap-004",
+    "job_id": "recursive-cycle-029-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-029-cap-005",
+    "job_id": "recursive-cycle-029-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-029-cap-006",
+    "job_id": "recursive-cycle-029-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-030-cap-001",
+    "job_id": "recursive-cycle-030-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-030-cap-002",
+    "job_id": "recursive-cycle-030-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-030-cap-003",
+    "job_id": "recursive-cycle-030-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-030-cap-004",
+    "job_id": "recursive-cycle-030-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-030-cap-005",
+    "job_id": "recursive-cycle-030-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-030-cap-006",
+    "job_id": "recursive-cycle-030-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-031-cap-001",
+    "job_id": "recursive-cycle-031-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-031-cap-002",
+    "job_id": "recursive-cycle-031-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-031-cap-003",
+    "job_id": "recursive-cycle-031-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-031-cap-004",
+    "job_id": "recursive-cycle-031-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-031-cap-005",
+    "job_id": "recursive-cycle-031-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-031-cap-006",
+    "job_id": "recursive-cycle-031-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-032-cap-001",
+    "job_id": "recursive-cycle-032-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-032-cap-002",
+    "job_id": "recursive-cycle-032-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-032-cap-003",
+    "job_id": "recursive-cycle-032-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-032-cap-004",
+    "job_id": "recursive-cycle-032-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-032-cap-005",
+    "job_id": "recursive-cycle-032-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-032-cap-006",
+    "job_id": "recursive-cycle-032-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-033-cap-001",
+    "job_id": "recursive-cycle-033-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-033-cap-002",
+    "job_id": "recursive-cycle-033-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-033-cap-003",
+    "job_id": "recursive-cycle-033-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-033-cap-004",
+    "job_id": "recursive-cycle-033-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-033-cap-005",
+    "job_id": "recursive-cycle-033-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-033-cap-006",
+    "job_id": "recursive-cycle-033-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-034-cap-001",
+    "job_id": "recursive-cycle-034-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-034-cap-002",
+    "job_id": "recursive-cycle-034-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-034-cap-003",
+    "job_id": "recursive-cycle-034-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-034-cap-004",
+    "job_id": "recursive-cycle-034-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-034-cap-005",
+    "job_id": "recursive-cycle-034-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-034-cap-006",
+    "job_id": "recursive-cycle-034-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-035-cap-001",
+    "job_id": "recursive-cycle-035-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-035-cap-002",
+    "job_id": "recursive-cycle-035-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-035-cap-003",
+    "job_id": "recursive-cycle-035-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-035-cap-004",
+    "job_id": "recursive-cycle-035-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-035-cap-005",
+    "job_id": "recursive-cycle-035-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-035-cap-006",
+    "job_id": "recursive-cycle-035-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-036-cap-001",
+    "job_id": "recursive-cycle-036-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-036-cap-002",
+    "job_id": "recursive-cycle-036-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-036-cap-003",
+    "job_id": "recursive-cycle-036-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-036-cap-004",
+    "job_id": "recursive-cycle-036-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-036-cap-005",
+    "job_id": "recursive-cycle-036-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-036-cap-006",
+    "job_id": "recursive-cycle-036-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-037-cap-001",
+    "job_id": "recursive-cycle-037-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-037-cap-002",
+    "job_id": "recursive-cycle-037-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-037-cap-003",
+    "job_id": "recursive-cycle-037-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-037-cap-004",
+    "job_id": "recursive-cycle-037-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-037-cap-005",
+    "job_id": "recursive-cycle-037-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-037-cap-006",
+    "job_id": "recursive-cycle-037-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-038-cap-001",
+    "job_id": "recursive-cycle-038-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-038-cap-002",
+    "job_id": "recursive-cycle-038-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-038-cap-003",
+    "job_id": "recursive-cycle-038-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-038-cap-004",
+    "job_id": "recursive-cycle-038-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-038-cap-005",
+    "job_id": "recursive-cycle-038-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-038-cap-006",
+    "job_id": "recursive-cycle-038-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-039-cap-001",
+    "job_id": "recursive-cycle-039-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-039-cap-002",
+    "job_id": "recursive-cycle-039-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-039-cap-003",
+    "job_id": "recursive-cycle-039-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-039-cap-004",
+    "job_id": "recursive-cycle-039-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-039-cap-005",
+    "job_id": "recursive-cycle-039-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-039-cap-006",
+    "job_id": "recursive-cycle-039-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-040-cap-001",
+    "job_id": "recursive-cycle-040-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-040-cap-002",
+    "job_id": "recursive-cycle-040-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-040-cap-003",
+    "job_id": "recursive-cycle-040-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-040-cap-004",
+    "job_id": "recursive-cycle-040-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-040-cap-005",
+    "job_id": "recursive-cycle-040-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-040-cap-006",
+    "job_id": "recursive-cycle-040-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-041-cap-001",
+    "job_id": "recursive-cycle-041-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-041-cap-002",
+    "job_id": "recursive-cycle-041-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-041-cap-003",
+    "job_id": "recursive-cycle-041-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-041-cap-004",
+    "job_id": "recursive-cycle-041-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-041-cap-005",
+    "job_id": "recursive-cycle-041-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-041-cap-006",
+    "job_id": "recursive-cycle-041-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-042-cap-001",
+    "job_id": "recursive-cycle-042-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-042-cap-002",
+    "job_id": "recursive-cycle-042-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-042-cap-003",
+    "job_id": "recursive-cycle-042-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-042-cap-004",
+    "job_id": "recursive-cycle-042-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-042-cap-005",
+    "job_id": "recursive-cycle-042-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-042-cap-006",
+    "job_id": "recursive-cycle-042-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-043-cap-001",
+    "job_id": "recursive-cycle-043-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-043-cap-002",
+    "job_id": "recursive-cycle-043-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-043-cap-003",
+    "job_id": "recursive-cycle-043-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-043-cap-004",
+    "job_id": "recursive-cycle-043-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-043-cap-005",
+    "job_id": "recursive-cycle-043-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-043-cap-006",
+    "job_id": "recursive-cycle-043-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-044-cap-001",
+    "job_id": "recursive-cycle-044-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-044-cap-002",
+    "job_id": "recursive-cycle-044-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-044-cap-003",
+    "job_id": "recursive-cycle-044-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-044-cap-004",
+    "job_id": "recursive-cycle-044-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-044-cap-005",
+    "job_id": "recursive-cycle-044-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-044-cap-006",
+    "job_id": "recursive-cycle-044-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-045-cap-001",
+    "job_id": "recursive-cycle-045-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-045-cap-002",
+    "job_id": "recursive-cycle-045-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-045-cap-003",
+    "job_id": "recursive-cycle-045-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-045-cap-004",
+    "job_id": "recursive-cycle-045-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-045-cap-005",
+    "job_id": "recursive-cycle-045-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-045-cap-006",
+    "job_id": "recursive-cycle-045-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-046-cap-001",
+    "job_id": "recursive-cycle-046-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-046-cap-002",
+    "job_id": "recursive-cycle-046-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-046-cap-003",
+    "job_id": "recursive-cycle-046-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-046-cap-004",
+    "job_id": "recursive-cycle-046-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-046-cap-005",
+    "job_id": "recursive-cycle-046-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-046-cap-006",
+    "job_id": "recursive-cycle-046-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-047-cap-001",
+    "job_id": "recursive-cycle-047-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-047-cap-002",
+    "job_id": "recursive-cycle-047-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-047-cap-003",
+    "job_id": "recursive-cycle-047-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-047-cap-004",
+    "job_id": "recursive-cycle-047-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-047-cap-005",
+    "job_id": "recursive-cycle-047-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-047-cap-006",
+    "job_id": "recursive-cycle-047-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-048-cap-001",
+    "job_id": "recursive-cycle-048-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-048-cap-002",
+    "job_id": "recursive-cycle-048-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-048-cap-003",
+    "job_id": "recursive-cycle-048-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-048-cap-004",
+    "job_id": "recursive-cycle-048-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-048-cap-005",
+    "job_id": "recursive-cycle-048-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-048-cap-006",
+    "job_id": "recursive-cycle-048-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-049-cap-001",
+    "job_id": "recursive-cycle-049-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-049-cap-002",
+    "job_id": "recursive-cycle-049-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-049-cap-003",
+    "job_id": "recursive-cycle-049-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-049-cap-004",
+    "job_id": "recursive-cycle-049-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-049-cap-005",
+    "job_id": "recursive-cycle-049-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-049-cap-006",
+    "job_id": "recursive-cycle-049-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-050-cap-001",
+    "job_id": "recursive-cycle-050-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-050-cap-002",
+    "job_id": "recursive-cycle-050-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-050-cap-003",
+    "job_id": "recursive-cycle-050-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-050-cap-004",
+    "job_id": "recursive-cycle-050-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-050-cap-005",
+    "job_id": "recursive-cycle-050-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-050-cap-006",
+    "job_id": "recursive-cycle-050-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-051-cap-001",
+    "job_id": "recursive-cycle-051-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-051-cap-002",
+    "job_id": "recursive-cycle-051-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-051-cap-003",
+    "job_id": "recursive-cycle-051-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-051-cap-004",
+    "job_id": "recursive-cycle-051-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-051-cap-005",
+    "job_id": "recursive-cycle-051-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-051-cap-006",
+    "job_id": "recursive-cycle-051-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-052-cap-001",
+    "job_id": "recursive-cycle-052-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-052-cap-002",
+    "job_id": "recursive-cycle-052-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-052-cap-003",
+    "job_id": "recursive-cycle-052-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-052-cap-004",
+    "job_id": "recursive-cycle-052-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-052-cap-005",
+    "job_id": "recursive-cycle-052-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-052-cap-006",
+    "job_id": "recursive-cycle-052-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-053-cap-001",
+    "job_id": "recursive-cycle-053-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-053-cap-002",
+    "job_id": "recursive-cycle-053-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-053-cap-003",
+    "job_id": "recursive-cycle-053-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-053-cap-004",
+    "job_id": "recursive-cycle-053-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-053-cap-005",
+    "job_id": "recursive-cycle-053-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-053-cap-006",
+    "job_id": "recursive-cycle-053-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-054-cap-001",
+    "job_id": "recursive-cycle-054-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-054-cap-002",
+    "job_id": "recursive-cycle-054-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-054-cap-003",
+    "job_id": "recursive-cycle-054-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-054-cap-004",
+    "job_id": "recursive-cycle-054-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-054-cap-005",
+    "job_id": "recursive-cycle-054-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-054-cap-006",
+    "job_id": "recursive-cycle-054-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-055-cap-001",
+    "job_id": "recursive-cycle-055-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-055-cap-002",
+    "job_id": "recursive-cycle-055-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-055-cap-003",
+    "job_id": "recursive-cycle-055-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-055-cap-004",
+    "job_id": "recursive-cycle-055-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-055-cap-005",
+    "job_id": "recursive-cycle-055-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-055-cap-006",
+    "job_id": "recursive-cycle-055-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-056-cap-001",
+    "job_id": "recursive-cycle-056-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-056-cap-002",
+    "job_id": "recursive-cycle-056-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-056-cap-003",
+    "job_id": "recursive-cycle-056-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-056-cap-004",
+    "job_id": "recursive-cycle-056-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-056-cap-005",
+    "job_id": "recursive-cycle-056-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-056-cap-006",
+    "job_id": "recursive-cycle-056-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-057-cap-001",
+    "job_id": "recursive-cycle-057-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-057-cap-002",
+    "job_id": "recursive-cycle-057-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-057-cap-003",
+    "job_id": "recursive-cycle-057-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-057-cap-004",
+    "job_id": "recursive-cycle-057-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-057-cap-005",
+    "job_id": "recursive-cycle-057-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-057-cap-006",
+    "job_id": "recursive-cycle-057-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-058-cap-001",
+    "job_id": "recursive-cycle-058-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-058-cap-002",
+    "job_id": "recursive-cycle-058-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-058-cap-003",
+    "job_id": "recursive-cycle-058-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-058-cap-004",
+    "job_id": "recursive-cycle-058-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-058-cap-005",
+    "job_id": "recursive-cycle-058-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-058-cap-006",
+    "job_id": "recursive-cycle-058-job-006",
+    "status": "archived"
   }
 ]

--- a/recursive_substrate_registry/cycles.json
+++ b/recursive_substrate_registry/cycles.json
@@ -1510,5 +1510,2273 @@
       "critical_safety_incidents": 0
     },
     "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-025",
+    "cycle_index": 24,
+    "generated_at": "2026-05-13T21:31:20.988709+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-026",
+    "cycle_index": 25,
+    "generated_at": "2026-05-13T21:31:21.210328+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-027",
+    "cycle_index": 26,
+    "generated_at": "2026-05-13T21:31:21.435396+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-028",
+    "cycle_index": 27,
+    "generated_at": "2026-05-13T21:31:21.672486+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-029",
+    "cycle_index": 28,
+    "generated_at": "2026-05-13T21:31:21.912486+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-030",
+    "cycle_index": 29,
+    "generated_at": "2026-05-13T21:31:22.138967+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-031",
+    "cycle_index": 30,
+    "generated_at": "2026-05-13T21:31:22.369861+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-032",
+    "cycle_index": 31,
+    "generated_at": "2026-05-13T21:31:22.600424+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-033",
+    "cycle_index": 32,
+    "generated_at": "2026-05-13T21:31:22.838678+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-034",
+    "cycle_index": 33,
+    "generated_at": "2026-05-13T21:31:23.175582+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-035",
+    "cycle_index": 34,
+    "generated_at": "2026-05-13T21:31:23.423806+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-036",
+    "cycle_index": 35,
+    "generated_at": "2026-05-13T21:32:16.297260+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-037",
+    "cycle_index": 36,
+    "generated_at": "2026-05-13T21:32:16.530377+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-038",
+    "cycle_index": 37,
+    "generated_at": "2026-05-13T21:32:16.760224+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-039",
+    "cycle_index": 38,
+    "generated_at": "2026-05-13T21:32:16.992166+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-040",
+    "cycle_index": 39,
+    "generated_at": "2026-05-13T21:32:17.231566+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-041",
+    "cycle_index": 40,
+    "generated_at": "2026-05-13T21:32:17.477131+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-042",
+    "cycle_index": 41,
+    "generated_at": "2026-05-13T21:32:17.725461+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-043",
+    "cycle_index": 42,
+    "generated_at": "2026-05-13T21:32:17.974820+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-044",
+    "cycle_index": 43,
+    "generated_at": "2026-05-13T21:32:18.217418+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-045",
+    "cycle_index": 44,
+    "generated_at": "2026-05-13T21:32:18.453612+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-046",
+    "cycle_index": 45,
+    "generated_at": "2026-05-13T21:32:18.688068+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-047",
+    "cycle_index": 46,
+    "generated_at": "2026-05-13T22:03:42.605857+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-048",
+    "cycle_index": 47,
+    "generated_at": "2026-05-13T22:03:48.813565+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-049",
+    "cycle_index": 48,
+    "generated_at": "2026-05-13T22:03:49.042563+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-050",
+    "cycle_index": 49,
+    "generated_at": "2026-05-13T22:03:49.278339+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-051",
+    "cycle_index": 50,
+    "generated_at": "2026-05-13T22:03:49.525852+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-052",
+    "cycle_index": 51,
+    "generated_at": "2026-05-13T22:03:49.770593+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-053",
+    "cycle_index": 52,
+    "generated_at": "2026-05-13T22:03:50.022510+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-054",
+    "cycle_index": 53,
+    "generated_at": "2026-05-13T22:03:50.283491+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-055",
+    "cycle_index": 54,
+    "generated_at": "2026-05-13T22:03:50.553728+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-056",
+    "cycle_index": 55,
+    "generated_at": "2026-05-13T22:03:50.810486+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-057",
+    "cycle_index": 56,
+    "generated_at": "2026-05-13T22:03:51.058376+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-058",
+    "cycle_index": 57,
+    "generated_at": "2026-05-13T22:03:51.320752+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-059",
+    "cycle_index": 58,
+    "generated_at": "2026-05-13T22:27:28.407220+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "0324c9aa027060f6d87e4ef1d2e56a467e56bc80",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-060",
+    "cycle_index": 59,
+    "generated_at": "2026-05-13T22:41:00.605061+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "3c98d36df3ba7b08523128cafee08df48f3acc90",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
   }
 ]

--- a/recursive_substrate_registry/evidence_dockets.json
+++ b/recursive_substrate_registry/evidence_dockets.json
@@ -142,5 +142,209 @@
     "status": "created",
     "claim_boundary": "local bounded recursive substrate evidence",
     "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
   }
 ]

--- a/recursive_substrate_registry/indexes/by_reference_family.json
+++ b/recursive_substrate_registry/indexes/by_reference_family.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "agialpha.recursive_index.v1",
+  "index": "by_reference_family",
+  "description": "Category-context reference families. Reference map only, not implementation claims.",
+  "entries": {},
+  "claim_boundary": "This index is local bounded recursive substrate evidence metadata and does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, or external validation."
+}

--- a/recursive_substrate_registry/insights.json
+++ b/recursive_substrate_registry/insights.json
@@ -118,5 +118,175 @@
     "insight_id": "insight-001",
     "summary": "Gap detection for recursive substrate",
     "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
   }
 ]

--- a/recursive_substrate_registry/jobs.json
+++ b/recursive_substrate_registry/jobs.json
@@ -862,5 +862,1229 @@
     "seed_id": "seed-006",
     "human_review_required": true,
     "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
   }
 ]

--- a/recursive_substrate_registry/latest.json
+++ b/recursive_substrate_registry/latest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "agialpha.recursive_cycle.v1",
-  "cycle_id": "recursive-cycle-024",
-  "cycle_index": 23,
-  "generated_at": "2026-05-13T17:03:26.752322+00:00",
+  "cycle_id": "recursive-cycle-060",
+  "cycle_index": 59,
+  "generated_at": "2026-05-13T22:41:00.605061+00:00",
   "repository": "MontrealAI/agialpha-first-real-loop",
-  "commit_sha": "348bcf1525399b88555da5e832e7f66bf8792147",
+  "commit_sha": "3c98d36df3ba7b08523128cafee08df48f3acc90",
   "status": "success",
   "substrate_layers": {
     "agents": true,

--- a/recursive_substrate_registry/nova_seeds.json
+++ b/recursive_substrate_registry/nova_seeds.json
@@ -2302,5 +2302,3269 @@
     "kind": "vnext",
     "status": "rejected",
     "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
   }
 ]

--- a/recursive_substrate_registry/proofbundles.json
+++ b/recursive_substrate_registry/proofbundles.json
@@ -118,5 +118,175 @@
     "proofbundle_id": "proofbundle-001",
     "status": "created",
     "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
   }
 ]

--- a/recursive_substrate_registry/validators.json
+++ b/recursive_substrate_registry/validators.json
@@ -718,5 +718,1025 @@
     "job_id": "job-006",
     "validator_id": "claim-boundary-validator",
     "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-025-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-026-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-027-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-028-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-029-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-030-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-031-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-032-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-033-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-034-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-035-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-036-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-037-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-038-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-039-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-040-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-041-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-042-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-043-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-044-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-045-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-046-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-047-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-048-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-049-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-050-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-051-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-052-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-053-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-054-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-055-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-056-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-057-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-058-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
   }
 ]

--- a/recursive_substrate_registry/vnext.json
+++ b/recursive_substrate_registry/vnext.json
@@ -719,5 +719,1030 @@
     "candidate_id": "recursive-cycle-024-vnext-006",
     "from_capability": "recursive-cycle-024-cap-006",
     "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "ai-improves-ai",
+    "status": "pending_human_review",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "candidate_id": "recursive-cycle-025-vnext-001",
+    "from_capability": "recursive-cycle-025-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-025-vnext-002",
+    "from_capability": "recursive-cycle-025-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-025-vnext-003",
+    "from_capability": "recursive-cycle-025-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-025-vnext-004",
+    "from_capability": "recursive-cycle-025-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-025-vnext-005",
+    "from_capability": "recursive-cycle-025-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-025-vnext-006",
+    "from_capability": "recursive-cycle-025-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-026-vnext-001",
+    "from_capability": "recursive-cycle-026-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-026-vnext-002",
+    "from_capability": "recursive-cycle-026-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-026-vnext-003",
+    "from_capability": "recursive-cycle-026-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-026-vnext-004",
+    "from_capability": "recursive-cycle-026-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-026-vnext-005",
+    "from_capability": "recursive-cycle-026-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-026-vnext-006",
+    "from_capability": "recursive-cycle-026-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-027-vnext-001",
+    "from_capability": "recursive-cycle-027-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-027-vnext-002",
+    "from_capability": "recursive-cycle-027-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-027-vnext-003",
+    "from_capability": "recursive-cycle-027-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-027-vnext-004",
+    "from_capability": "recursive-cycle-027-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-027-vnext-005",
+    "from_capability": "recursive-cycle-027-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-027-vnext-006",
+    "from_capability": "recursive-cycle-027-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-028-vnext-001",
+    "from_capability": "recursive-cycle-028-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-028-vnext-002",
+    "from_capability": "recursive-cycle-028-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-028-vnext-003",
+    "from_capability": "recursive-cycle-028-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-028-vnext-004",
+    "from_capability": "recursive-cycle-028-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-028-vnext-005",
+    "from_capability": "recursive-cycle-028-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-028-vnext-006",
+    "from_capability": "recursive-cycle-028-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-029-vnext-001",
+    "from_capability": "recursive-cycle-029-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-029-vnext-002",
+    "from_capability": "recursive-cycle-029-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-029-vnext-003",
+    "from_capability": "recursive-cycle-029-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-029-vnext-004",
+    "from_capability": "recursive-cycle-029-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-029-vnext-005",
+    "from_capability": "recursive-cycle-029-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-029-vnext-006",
+    "from_capability": "recursive-cycle-029-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-030-vnext-001",
+    "from_capability": "recursive-cycle-030-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-030-vnext-002",
+    "from_capability": "recursive-cycle-030-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-030-vnext-003",
+    "from_capability": "recursive-cycle-030-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-030-vnext-004",
+    "from_capability": "recursive-cycle-030-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-030-vnext-005",
+    "from_capability": "recursive-cycle-030-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-030-vnext-006",
+    "from_capability": "recursive-cycle-030-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-031-vnext-001",
+    "from_capability": "recursive-cycle-031-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-031-vnext-002",
+    "from_capability": "recursive-cycle-031-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-031-vnext-003",
+    "from_capability": "recursive-cycle-031-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-031-vnext-004",
+    "from_capability": "recursive-cycle-031-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-031-vnext-005",
+    "from_capability": "recursive-cycle-031-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-031-vnext-006",
+    "from_capability": "recursive-cycle-031-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-032-vnext-001",
+    "from_capability": "recursive-cycle-032-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-032-vnext-002",
+    "from_capability": "recursive-cycle-032-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-032-vnext-003",
+    "from_capability": "recursive-cycle-032-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-032-vnext-004",
+    "from_capability": "recursive-cycle-032-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-032-vnext-005",
+    "from_capability": "recursive-cycle-032-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-032-vnext-006",
+    "from_capability": "recursive-cycle-032-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-033-vnext-001",
+    "from_capability": "recursive-cycle-033-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-033-vnext-002",
+    "from_capability": "recursive-cycle-033-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-033-vnext-003",
+    "from_capability": "recursive-cycle-033-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-033-vnext-004",
+    "from_capability": "recursive-cycle-033-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-033-vnext-005",
+    "from_capability": "recursive-cycle-033-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-033-vnext-006",
+    "from_capability": "recursive-cycle-033-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-034-vnext-001",
+    "from_capability": "recursive-cycle-034-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-034-vnext-002",
+    "from_capability": "recursive-cycle-034-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-034-vnext-003",
+    "from_capability": "recursive-cycle-034-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-034-vnext-004",
+    "from_capability": "recursive-cycle-034-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-034-vnext-005",
+    "from_capability": "recursive-cycle-034-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-034-vnext-006",
+    "from_capability": "recursive-cycle-034-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-035-vnext-001",
+    "from_capability": "recursive-cycle-035-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-035-vnext-002",
+    "from_capability": "recursive-cycle-035-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-035-vnext-003",
+    "from_capability": "recursive-cycle-035-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-035-vnext-004",
+    "from_capability": "recursive-cycle-035-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-035-vnext-005",
+    "from_capability": "recursive-cycle-035-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-035-vnext-006",
+    "from_capability": "recursive-cycle-035-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-036-vnext-001",
+    "from_capability": "recursive-cycle-036-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-036-vnext-002",
+    "from_capability": "recursive-cycle-036-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-036-vnext-003",
+    "from_capability": "recursive-cycle-036-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-036-vnext-004",
+    "from_capability": "recursive-cycle-036-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-036-vnext-005",
+    "from_capability": "recursive-cycle-036-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-036-vnext-006",
+    "from_capability": "recursive-cycle-036-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-037-vnext-001",
+    "from_capability": "recursive-cycle-037-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-037-vnext-002",
+    "from_capability": "recursive-cycle-037-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-037-vnext-003",
+    "from_capability": "recursive-cycle-037-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-037-vnext-004",
+    "from_capability": "recursive-cycle-037-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-037-vnext-005",
+    "from_capability": "recursive-cycle-037-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-037-vnext-006",
+    "from_capability": "recursive-cycle-037-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-038-vnext-001",
+    "from_capability": "recursive-cycle-038-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-038-vnext-002",
+    "from_capability": "recursive-cycle-038-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-038-vnext-003",
+    "from_capability": "recursive-cycle-038-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-038-vnext-004",
+    "from_capability": "recursive-cycle-038-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-038-vnext-005",
+    "from_capability": "recursive-cycle-038-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-038-vnext-006",
+    "from_capability": "recursive-cycle-038-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-039-vnext-001",
+    "from_capability": "recursive-cycle-039-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-039-vnext-002",
+    "from_capability": "recursive-cycle-039-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-039-vnext-003",
+    "from_capability": "recursive-cycle-039-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-039-vnext-004",
+    "from_capability": "recursive-cycle-039-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-039-vnext-005",
+    "from_capability": "recursive-cycle-039-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-039-vnext-006",
+    "from_capability": "recursive-cycle-039-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-040-vnext-001",
+    "from_capability": "recursive-cycle-040-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-040-vnext-002",
+    "from_capability": "recursive-cycle-040-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-040-vnext-003",
+    "from_capability": "recursive-cycle-040-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-040-vnext-004",
+    "from_capability": "recursive-cycle-040-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-040-vnext-005",
+    "from_capability": "recursive-cycle-040-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-040-vnext-006",
+    "from_capability": "recursive-cycle-040-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-041-vnext-001",
+    "from_capability": "recursive-cycle-041-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-041-vnext-002",
+    "from_capability": "recursive-cycle-041-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-041-vnext-003",
+    "from_capability": "recursive-cycle-041-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-041-vnext-004",
+    "from_capability": "recursive-cycle-041-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-041-vnext-005",
+    "from_capability": "recursive-cycle-041-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-041-vnext-006",
+    "from_capability": "recursive-cycle-041-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-042-vnext-001",
+    "from_capability": "recursive-cycle-042-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-042-vnext-002",
+    "from_capability": "recursive-cycle-042-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-042-vnext-003",
+    "from_capability": "recursive-cycle-042-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-042-vnext-004",
+    "from_capability": "recursive-cycle-042-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-042-vnext-005",
+    "from_capability": "recursive-cycle-042-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-042-vnext-006",
+    "from_capability": "recursive-cycle-042-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-043-vnext-001",
+    "from_capability": "recursive-cycle-043-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-043-vnext-002",
+    "from_capability": "recursive-cycle-043-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-043-vnext-003",
+    "from_capability": "recursive-cycle-043-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-043-vnext-004",
+    "from_capability": "recursive-cycle-043-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-043-vnext-005",
+    "from_capability": "recursive-cycle-043-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-043-vnext-006",
+    "from_capability": "recursive-cycle-043-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-044-vnext-001",
+    "from_capability": "recursive-cycle-044-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-044-vnext-002",
+    "from_capability": "recursive-cycle-044-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-044-vnext-003",
+    "from_capability": "recursive-cycle-044-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-044-vnext-004",
+    "from_capability": "recursive-cycle-044-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-044-vnext-005",
+    "from_capability": "recursive-cycle-044-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-044-vnext-006",
+    "from_capability": "recursive-cycle-044-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-045-vnext-001",
+    "from_capability": "recursive-cycle-045-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-045-vnext-002",
+    "from_capability": "recursive-cycle-045-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-045-vnext-003",
+    "from_capability": "recursive-cycle-045-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-045-vnext-004",
+    "from_capability": "recursive-cycle-045-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-045-vnext-005",
+    "from_capability": "recursive-cycle-045-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-045-vnext-006",
+    "from_capability": "recursive-cycle-045-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-046-vnext-001",
+    "from_capability": "recursive-cycle-046-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-046-vnext-002",
+    "from_capability": "recursive-cycle-046-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-046-vnext-003",
+    "from_capability": "recursive-cycle-046-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-046-vnext-004",
+    "from_capability": "recursive-cycle-046-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-046-vnext-005",
+    "from_capability": "recursive-cycle-046-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-046-vnext-006",
+    "from_capability": "recursive-cycle-046-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-047-vnext-001",
+    "from_capability": "recursive-cycle-047-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-047-vnext-002",
+    "from_capability": "recursive-cycle-047-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-047-vnext-003",
+    "from_capability": "recursive-cycle-047-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-047-vnext-004",
+    "from_capability": "recursive-cycle-047-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-047-vnext-005",
+    "from_capability": "recursive-cycle-047-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-047-vnext-006",
+    "from_capability": "recursive-cycle-047-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-048-vnext-001",
+    "from_capability": "recursive-cycle-048-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-048-vnext-002",
+    "from_capability": "recursive-cycle-048-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-048-vnext-003",
+    "from_capability": "recursive-cycle-048-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-048-vnext-004",
+    "from_capability": "recursive-cycle-048-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-048-vnext-005",
+    "from_capability": "recursive-cycle-048-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-048-vnext-006",
+    "from_capability": "recursive-cycle-048-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-049-vnext-001",
+    "from_capability": "recursive-cycle-049-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-049-vnext-002",
+    "from_capability": "recursive-cycle-049-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-049-vnext-003",
+    "from_capability": "recursive-cycle-049-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-049-vnext-004",
+    "from_capability": "recursive-cycle-049-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-049-vnext-005",
+    "from_capability": "recursive-cycle-049-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-049-vnext-006",
+    "from_capability": "recursive-cycle-049-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-050-vnext-001",
+    "from_capability": "recursive-cycle-050-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-050-vnext-002",
+    "from_capability": "recursive-cycle-050-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-050-vnext-003",
+    "from_capability": "recursive-cycle-050-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-050-vnext-004",
+    "from_capability": "recursive-cycle-050-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-050-vnext-005",
+    "from_capability": "recursive-cycle-050-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-050-vnext-006",
+    "from_capability": "recursive-cycle-050-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-051-vnext-001",
+    "from_capability": "recursive-cycle-051-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-051-vnext-002",
+    "from_capability": "recursive-cycle-051-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-051-vnext-003",
+    "from_capability": "recursive-cycle-051-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-051-vnext-004",
+    "from_capability": "recursive-cycle-051-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-051-vnext-005",
+    "from_capability": "recursive-cycle-051-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-051-vnext-006",
+    "from_capability": "recursive-cycle-051-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-052-vnext-001",
+    "from_capability": "recursive-cycle-052-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-052-vnext-002",
+    "from_capability": "recursive-cycle-052-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-052-vnext-003",
+    "from_capability": "recursive-cycle-052-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-052-vnext-004",
+    "from_capability": "recursive-cycle-052-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-052-vnext-005",
+    "from_capability": "recursive-cycle-052-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-052-vnext-006",
+    "from_capability": "recursive-cycle-052-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-053-vnext-001",
+    "from_capability": "recursive-cycle-053-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-053-vnext-002",
+    "from_capability": "recursive-cycle-053-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-053-vnext-003",
+    "from_capability": "recursive-cycle-053-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-053-vnext-004",
+    "from_capability": "recursive-cycle-053-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-053-vnext-005",
+    "from_capability": "recursive-cycle-053-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-053-vnext-006",
+    "from_capability": "recursive-cycle-053-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-054-vnext-001",
+    "from_capability": "recursive-cycle-054-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-054-vnext-002",
+    "from_capability": "recursive-cycle-054-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-054-vnext-003",
+    "from_capability": "recursive-cycle-054-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-054-vnext-004",
+    "from_capability": "recursive-cycle-054-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-054-vnext-005",
+    "from_capability": "recursive-cycle-054-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-054-vnext-006",
+    "from_capability": "recursive-cycle-054-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-055-vnext-001",
+    "from_capability": "recursive-cycle-055-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-055-vnext-002",
+    "from_capability": "recursive-cycle-055-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-055-vnext-003",
+    "from_capability": "recursive-cycle-055-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-055-vnext-004",
+    "from_capability": "recursive-cycle-055-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-055-vnext-005",
+    "from_capability": "recursive-cycle-055-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-055-vnext-006",
+    "from_capability": "recursive-cycle-055-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-056-vnext-001",
+    "from_capability": "recursive-cycle-056-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-056-vnext-002",
+    "from_capability": "recursive-cycle-056-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-056-vnext-003",
+    "from_capability": "recursive-cycle-056-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-056-vnext-004",
+    "from_capability": "recursive-cycle-056-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-056-vnext-005",
+    "from_capability": "recursive-cycle-056-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-056-vnext-006",
+    "from_capability": "recursive-cycle-056-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-057-vnext-001",
+    "from_capability": "recursive-cycle-057-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-057-vnext-002",
+    "from_capability": "recursive-cycle-057-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-057-vnext-003",
+    "from_capability": "recursive-cycle-057-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-057-vnext-004",
+    "from_capability": "recursive-cycle-057-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-057-vnext-005",
+    "from_capability": "recursive-cycle-057-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-057-vnext-006",
+    "from_capability": "recursive-cycle-057-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-058-vnext-001",
+    "from_capability": "recursive-cycle-058-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-058-vnext-002",
+    "from_capability": "recursive-cycle-058-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-058-vnext-003",
+    "from_capability": "recursive-cycle-058-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-058-vnext-004",
+    "from_capability": "recursive-cycle-058-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-058-vnext-005",
+    "from_capability": "recursive-cycle-058-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-058-vnext-006",
+    "from_capability": "recursive-cycle-058-cap-006",
+    "status": "pending_human_review"
   }
 ]

--- a/schemas/agialpha_ai_improves_ai_experiment.schema.json
+++ b/schemas/agialpha_ai_improves_ai_experiment.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://montrealai.github.io/agialpha-first-real-loop/schemas/agialpha_ai_improves_ai_experiment.schema.json",
+  "title": "AGI ALPHA AI Improves AI Experiment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "candidate_lock",
+    "heldout_fixtures_generated_after_lock",
+    "persistence_status",
+    "human_review_required",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.ai_improves_ai_experiment.v1"},
+    "run_id": {"type": "string", "minLength": 1},
+    "candidate_lock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["locked"],
+      "properties": {
+        "locked": {"type": "boolean"},
+        "lock_hash": {"type": "string", "minLength": 1},
+        "locked_at": {"type": "string", "minLength": 1},
+        "candidate_hashes": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "claim_boundary": {"type": "string", "minLength": 1}
+      }
+    },
+    "heldout_fixtures_generated_after_lock": {"type": "boolean"},
+    "persistence_status": {
+      "type": "string",
+      "enum": ["not_persisted", "pending_human_review", "persisted_by_human_decision"]
+    },
+    "human_review_required": {"const": true},
+    "claim_boundary": {"type": "string", "minLength": 1}
+  }
+}

--- a/schemas/agialpha_recursive_category_context.schema.json
+++ b/schemas/agialpha_recursive_category_context.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://montrealai.github.io/agialpha-first-real-loop/schemas/agialpha_recursive_category_context.schema.json",
+  "title": "AGI ALPHA Recursive Category Context",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "category",
+    "external_context_summary",
+    "reference_families",
+    "agialpha_original_position",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {"const": "agialpha.recursive_category_context.v1"},
+    "category": {"type": "string", "minLength": 1},
+    "external_context_summary": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "minItems": 1
+    },
+    "reference_families": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "minItems": 1
+    },
+    "agialpha_original_position": {"type": "string", "minLength": 1},
+    "claim_boundary": {"type": "string", "minLength": 1}
+  }
+}

--- a/schemas/agialpha_recursive_reference_map.schema.json
+++ b/schemas/agialpha_recursive_reference_map.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://montrealai.github.io/agialpha-first-real-loop/schemas/agialpha_recursive_reference_map.schema.json",
+  "title": "AGI ALPHA Recursive Reference Map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "references",
+    "label",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "agialpha.recursive_reference_map.v1"
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "family",
+              "label",
+              "status"
+            ],
+            "properties": {
+              "family": {
+                "type": "string",
+                "minLength": 1
+              },
+              "label": {
+                "type": "string",
+                "minLength": 1
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "context_only",
+                  "implemented_with_evidence"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "usage_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "label": {
+      "type": "string",
+      "minLength": 1
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Register many newly generated recursive cycles, jobs, capabilities, validators, seeds, and related proof/evidence entries to keep the registry in sync with generated runs. 
- Add typed JSON schemas and an index for new recursive metadata types to formalize experiment and reference artifacts. 
- Prevent redundant candidate registrations when the `ai-improves-ai` helper is used to populate the registry.

### Description

- Update `agialpha_recursive_substrate/cli.py` to read `vnext.json` and only append the `ai-improves-ai` candidate if it does not already exist, preventing duplicate registry entries. 
- Add a new index file `recursive_substrate_registry/indexes/by_reference_family.json` to track reference families. 
- Add three new schema files under `schemas/`: `agialpha_ai_improves_ai_experiment.schema.json`, `agialpha_recursive_category_context.schema.json`, and `agialpha_recursive_reference_map.schema.json` to describe new artifact types. 
- Bulk-update registry data files (`capabilities.json`, `cycles.json`, `evidence_dockets.json`, `insights.json`, `jobs.json`, `nova_seeds.json`, `proofbundles.json`, `validators.json`, `vnext.json`, and `latest.json`) to include many new entries for cycles (025–060), associated jobs/capabilities/validators/seeds, and to set `latest.json` to `recursive-cycle-060` with updated `commit_sha` and timestamps.

### Testing

- Performed repository JSON validation of the modified registry files and new schema documents using `jsonschema` as a smoke-check and the registry files validated against their schemas. 
- Ran the repository linter and basic static checks; no issues were reported. 
- No functional unit tests were added or changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ed539cc08333ae0fbd6c8b36368d)