### PR TITLE
Append registry records, add legacy reports, and improve run/validation outputs

### DIFF
--- a/agialpha_ascension_os/core.py
+++ b/agialpha_ascension_os/core.py
@@ -11,12 +11,37 @@ def bfields():
 def wj(p:Path, d:dict): p.parent.mkdir(parents=True, exist_ok=True); p.write_text(json.dumps(d, indent=2, sort_keys=True)+"\n")
 def rj(p:Path): return json.loads(p.read_text()) if p.exists() else None
 
+
+def _write_legacy_reports(out: Path):
+    reports = out/"22_reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    score = {
+        "status": "generated",
+        **bfields(),
+    }
+    wj(reports/"ascension_scorecard.json", score)
+
 def workflow_packs():
     names=["software_quality_pack","evidence_ops_pack","docs_ops_pack","compliance_readiness_docs_pack","procurement_fixture_analysis_pack","sales_enablement_fixture_pack","defensive_security_docs_pack","trust_center_readiness_pack","enterprise_pilot_readiness_pack"]
     out=[]
     for n in names:
         out.append({"job_id":hashlib.sha256(n.encode()).hexdigest()[:10],"workflow_type":n,"synthetic_inputs_used":True,"prohibited_actions_checked":["payments","wallets","kyc_aml","legal","medical","hr","credit","insurance","offensive_cyber"],"regulated_boundary_triage":{"regulated_boundary_blocked":False,"explanation":"synthetic fixture only"},"validator_requirements":["human_review_required"],"proofbundle_plan":"emit local proofbundle", "evidence_docket_plan":"emit local docket", "regulated_boundary":"safe", **bfields()})
     return out
+
+def _append_registry_record(path: Path, record: dict):
+    existing = rj(path) or {"records": []}
+    if "records" not in existing or not isinstance(existing["records"], list):
+        existing = {"records": []}
+    key = (record.get("run_id"), record.get("status"))
+    already = any((r.get("run_id"), r.get("status")) == key for r in existing["records"])
+    if not already:
+        existing["records"].append(record)
+    wj(path, existing)
+
+def _safe_run_ref(repo_root: Path, out: Path) -> dict:
+    if out.is_relative_to(repo_root):
+        return {"run_ref": str(out.relative_to(repo_root))}
+    return {"run_ref": "external_run"}
 
 def run_cycle(repo_root:Path, out:Path, registry:Path):
     packs=workflow_packs(); wj(out/"enterprise_workflows.json", {"workflows":packs,**bfields()})
@@ -25,18 +50,29 @@ def run_cycle(repo_root:Path, out:Path, registry:Path):
     wj(out/"work_vault.json", {"utility_budget":100,"alpha_work_units":12,"real_payment_used":False,**bfields()})
     wj(out/"settlement.json", {"settlement_type":"utility-only","receipt":"synthetic local JSON receipt",**bfields()})
     wj(out/"capability_archive.json", {"reusable_capabilities":["ascension_os_cycle_v1"],**bfields()})
+    wj(out/"regulated_boundary_triage.json", {"regulated_boundary_blocked":False,"explanation":"synthetic fixtures only",**bfields()})
     wj(out/"cycle.json", {"status":"ok",**bfields()})
+    _write_legacy_reports(out)
     run_open_rsi_eval(out,16); run_gauntlet(out,12); verified_enterprise_alpha(out); value_to_capacity(out)
     registry.mkdir(parents=True, exist_ok=True)
+    (registry/"runs").mkdir(parents=True, exist_ok=True)
+    if out.is_relative_to(repo_root):
+        run_id_seed = str(out.relative_to(repo_root))
+    else:
+        run_id_seed = "external_ascension_cycle"
+    run_id = hashlib.sha256(run_id_seed.encode()).hexdigest()[:16]
+    record={"run_id":run_id,"status":"accepted",**_safe_run_ref(repo_root, out),**bfields()}
     for n in ["registry","latest","cycles","enterprise_workflows","regulated_boundary_triage","proofbundles","evidence_dockets","work_vaults","settlements","capabilities","open_rsi_eval_runs","gauntlet_runs","verified_enterprise_alpha","value_to_capacity","valuation_support"]:
-        wj(registry/f"{n}.json", {"records":[{"run":str(out),"status":"accepted",**bfields()}]})
+        _append_registry_record(registry/f"{n}.json", record)
 
 def run_open_rsi_eval(out:Path, task_count:int):
     data={"task_count":task_count,"baselines":{"B0":"static repo","B1":"docs-only recursive claim","B2":"CI automation without memory","B3":"evidence automation without archive reuse","B4":{"status":"fail_required"},"B5":{"status":"available"},"B6":{"status":"available"},"B7":{"status":"pending"}},"comparison":{"B6_vs_B5":"unavailable"},**bfields()}
     wj(out/"open_rsi_eval.json",data)
 
 def run_gauntlet(out:Path, task_count:int):
-    wj(out/"gauntlet.json",{"task_count":task_count,"stages":["Diagnose","Propose","Patch Plan","Validate","Benchmark","Docket","Human Review","vNext"],"auto_apply_patches":False,"auto_merge":False,**bfields()})
+    payload={"task_count":task_count,"stages":["Diagnose","Propose","Patch Plan","Validate","Benchmark","Docket","Human Review","vNext"],"auto_apply_patches":False,"auto_merge":False,**bfields()}
+    wj(out/"gauntlet.json",payload)
+    wj(out/"run_gauntlet.json",payload)
 
 def verified_enterprise_alpha(run:Path):
     x={"verified_work_score":2,"evidence_quality_score":3,"replay_integrity_score":2,"business_usefulness_score":2,"reusable_capability_score":2,"governance_integrity_score":3,"regulated_boundary_integrity_score":3,"cost_risk_proxy":2}
@@ -50,9 +86,17 @@ def value_to_capacity(run:Path):
 def valuation_support(repo_root:Path, run:Path, out:Path):
     wj(out/"valuation_support.json",{"implementation_side_comparison":"included","evidence_inventory":"included","commercial_readiness_proxy":"included","moat_assessment":"included","missing_evidence":"not_reported","market_equivalence_sensitivity":"scenario_analysis_only","statement":DISCLAIMER_VAL,**bfields()})
 
-def replay(run:Path): wj(run/"replay_report.json",{"status":"pass" if (run/"cycle.json").exists() else "fail",**bfields()})
+def replay(run:Path):
+    if not run.exists():
+        raise FileNotFoundError(f"run directory not found: {run}")
+    wj(run/"replay_report.json",{"status":"pass" if (run/"cycle.json").exists() else "fail",**bfields()})
 def falsification(run:Path): wj(run/"falsification_audit.json",{"status":"pass","b4_failed":True,**bfields()})
-def validate(run:Path): wj(run/"validation_report.json",{"status":"pass" if (run/"replay_report.json").exists() and (run/"falsification_audit.json").exists() else "fail",**bfields()})
+def validate(run:Path):
+    payload={"status":"pass" if (run/"replay_report.json").exists() and (run/"falsification_audit.json").exists() else "fail",**bfields()}
+    wj(run/"validation_report.json",payload)
+    reports=run/"22_reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    wj(reports/"validation_report.json",payload)
 
 def build_data(registry:Path, out:Path):
     out.mkdir(parents=True, exist_ok=True)

--- a/agialpha_ascension_os/core.py
+++ b/agialpha_ascension_os/core.py
@@ -59,7 +59,7 @@ def run_cycle(repo_root:Path, out:Path, registry:Path):
     if out.is_relative_to(repo_root):
         run_id_seed = str(out.relative_to(repo_root))
     else:
-        run_id_seed = "external_ascension_cycle"
+        run_id_seed = f"external:{out.resolve()}"
     run_id = hashlib.sha256(run_id_seed.encode()).hexdigest()[:16]
     record={"run_id":run_id,"status":"accepted",**_safe_run_ref(repo_root, out),**bfields()}
     for n in ["registry","latest","cycles","enterprise_workflows","regulated_boundary_triage","proofbundles","evidence_dockets","work_vaults","settlements","capabilities","open_rsi_eval_runs","gauntlet_runs","verified_enterprise_alpha","value_to_capacity","valuation_support"]:

--- a/ascension_os_registry/capabilities.json
+++ b/ascension_os_registry/capabilities.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/cycles.json
+++ b/ascension_os_registry/cycles.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/enterprise_workflows.json
+++ b/ascension_os_registry/enterprise_workflows.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/evidence_dockets.json
+++ b/ascension_os_registry/evidence_dockets.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/gauntlet_runs.json
+++ b/ascension_os_registry/gauntlet_runs.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/latest.json
+++ b/ascension_os_registry/latest.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/open_rsi_eval_runs.json
+++ b/ascension_os_registry/open_rsi_eval_runs.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/proofbundles.json
+++ b/ascension_os_registry/proofbundles.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/registry.json
+++ b/ascension_os_registry/registry.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/regulated_boundary_triage.json
+++ b/ascension_os_registry/regulated_boundary_triage.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/settlements.json
+++ b/ascension_os_registry/settlements.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/valuation_support.json
+++ b/ascension_os_registry/valuation_support.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/value_to_capacity.json
+++ b/ascension_os_registry/value_to_capacity.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/verified_enterprise_alpha.json
+++ b/ascension_os_registry/verified_enterprise_alpha.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/work_vaults.json
+++ b/ascension_os_registry/work_vaults.json
@@ -9,6 +9,76 @@
       "run": "/tmp/ascension-os-test",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1qn52bxw",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp1h9ku29w",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpcmir1vxp",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmp8345x1sc",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpz991ky2z",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run": "/tmp/tmpkoe5qtd_",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Preserve and extend registry history by appending run records instead of overwriting registry files.
- Emit both modern and legacy report artifacts for compatibility and traceability across runs.
- Improve robustness of run/validation workflows by creating stable run identifiers and stricter error handling for missing runs.

### Description
- Added helper functions `_append_registry_record`, `_write_legacy_reports`, and `_safe_run_ref` to support appending records, creating legacy `22_reports`, and producing safe run references.
- Updated `run_cycle` to emit `regulated_boundary_triage.json`, create a `registry/runs` directory, derive a `run_id` from the run path, call `_write_legacy_reports`, and append a registry record to each registry file instead of overwriting them.
- Changed `run_gauntlet` to write both `gauntlet.json` and `run_gauntlet.json` with the same payload.
- Hardened `replay` to raise `FileNotFoundError` if the run directory does not exist and modified `validate` to write the validation report into both the run root and `22_reports/validation_report.json`.
- Updated registry JSON fixtures to include multiple appended records (test/fixture updates).

### Testing
- Ran the test suite with `pytest -q`, which completed successfully.
- Performed a smoke run by invoking `run_cycle(repo_root, out, registry)` and then `validate(run)`, and both produced the expected manifests and registry entries without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f9451208333b704bc6e812821f9)