### PR TITLE
Harden regulated-boundary triage matching in agialpha_ascension_os

### DIFF
--- a/agialpha_ascension_os/regulated_boundary.py
+++ b/agialpha_ascension_os/regulated_boundary.py
@@ -1,12 +1,46 @@
-REGULATED_FLAGS=["financial advice","investment advice","payment/custody","wallet/trading","KYC/AML","legal advice","medical advice","HR/worker evaluation","credit/lending","insurance","critical-infrastructure control","energy/utility markets","biometric identification","emotion recognition","law enforcement","migration/border","education scoring","justice/democratic process","offensive cyber"]
+"""Regulated-boundary triage for Ascension OS enterprise workflows."""
 
-def regulated_boundary_triage(workflow:dict)->dict:
-    t=(workflow.get('workflow_type','')+' '+workflow.get('description','')).lower()
-    hits=[f for f in REGULATED_FLAGS if f.lower().split('/')[0] in t]
-    blocked=bool(hits)
+from __future__ import annotations
+
+REGULATED_FLAGS = [
+    "financial advice",
+    "investment advice",
+    "payment/custody",
+    "wallet/trading",
+    "KYC/AML",
+    "legal advice",
+    "medical advice",
+    "HR/worker evaluation",
+    "credit/lending",
+    "insurance",
+    "critical-infrastructure control",
+    "energy/utility markets",
+    "biometric identification",
+    "emotion recognition",
+    "law enforcement",
+    "migration/border",
+    "education access/scoring",
+    "justice/democratic process",
+    "offensive cyber",
+]
+
+
+def _keywords(flag: str) -> list[str]:
+    return [part.strip().lower() for part in flag.split("/") if part.strip()]
+
+
+def regulated_boundary_triage(workflow: dict) -> dict:
+    text = f"{workflow.get('workflow_type', '')} {workflow.get('description', '')}".lower()
+    hits = [flag for flag in REGULATED_FLAGS if any(term in text for term in _keywords(flag))]
+    blocked = bool(hits)
     return {
-        'regulated_flags_triggered':hits,
-        'regulated_boundary_blocked':blocked,
-        'status':'blocked_human_review_required' if blocked else 'documentation_only',
-        'safe_explanation':'No automated execution for regulated domains.' if blocked else 'Synthetic non-regulated workflow.'
+        "regulated_flags_triggered": hits,
+        "regulated_boundary_blocked": blocked,
+        "status": "blocked_human_review_required" if blocked else "documentation_only",
+        "safe_explanation": (
+            "No automated execution for regulated domains; documentation-only handoff required."
+            if blocked
+            else "Synthetic non-regulated workflow."
+        ),
+        "human_review_required": True,
     }


### PR DESCRIPTION
### Motivation
- Reduce false-negative matches for regulated-domain detection in Ascension OS triage and ensure triage records explicitly require human review to prevent autonomous persistence.

### Description
- Replace simple substring split-matching with tokenized keyword matching in `agialpha_ascension_os/regulated_boundary.py`, add `_keywords()` helper, and include `human_review_required: True` plus clearer `safe_explanation` in the triage output.

### Testing
- Ran the full test suite with `python -m unittest discover -s tests` which completed successfully (all tests passed).
- Ran focused tests with `pytest -q tests/test_ascension_os_regulated_boundary.py tests/test_ascension_os_cycle.py` which also passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0698e752048333b9e018eb3b05e6fc)