### PR TITLE
Normalize regulated-boundary matching to avoid slash-fragment false positives

### DIFF
--- a/agialpha_ascension_os/regulated_boundary.py
+++ b/agialpha_ascension_os/regulated_boundary.py
@@ -1,8 +1,16 @@
 REGULATED_FLAGS=["financial advice","investment advice","payment/custody","wallet/trading","KYC/AML","legal advice","medical advice","HR/worker evaluation","credit/lending","insurance","critical-infrastructure control","energy/utility markets","biometric identification","emotion recognition","law enforcement","migration/border","education scoring","justice/democratic process","offensive cyber"]
 
+def _normalize(s:str)->str:
+    return ' '.join(
+        s.lower()
+        .replace('/', ' ')
+        .replace('-', ' ')
+        .split()
+    )
+
 def regulated_boundary_triage(workflow:dict)->dict:
-    t=(workflow.get('workflow_type','')+' '+workflow.get('description','')).lower()
-    hits=[f for f in REGULATED_FLAGS if f.lower().split('/')[0] in t]
+    t=_normalize(workflow.get('workflow_type','')+' '+workflow.get('description',''))
+    hits=[f for f in REGULATED_FLAGS if _normalize(f) in t]
     blocked=bool(hits)
     return {
         'regulated_flags_triggered':hits,

--- a/tests/test_ascension_os_boundaries.py
+++ b/tests/test_ascension_os_boundaries.py
@@ -7,3 +7,14 @@ def test_regulated_fixture_blocked():
 
 def test_missing_metrics_not_fake_zero():
     assert "not_reported" != 0
+
+def test_internal_scoring_not_regulated_by_substring():
+    triage=regulated_boundary_triage({
+        "workflow_type":"education access",
+        "description":"Uses an internal scoring rubric for project prioritization."
+    })
+    assert triage["regulated_boundary_blocked"] is False
+
+def test_slash_delimited_regulated_phrase_still_blocked():
+    triage=regulated_boundary_triage({"workflow_type":"payment custody controls"})
+    assert triage["regulated_boundary_blocked"] is True


### PR DESCRIPTION
### Motivation

- Prevent false positives where slash-delimited regulated flags (e.g., `education scoring` vs `education access/scoring`) caused fragment substring matches and over-blocked non-regulated workflows.
- Restore phrase-level matching behavior while tolerating punctuation/formatting variations like slashes and hyphens.

### Description

- Add a `_normalize` helper that lowercases input, replaces `/` and `-` with spaces, and collapses whitespace, and apply it to both workflow text and flag strings in `regulated_boundary_triage` in `agialpha_ascension_os/regulated_boundary.py`.
- Change matching to check whether the normalized flag phrase is contained in the normalized workflow text instead of matching slash fragments as independent substrings.
- Add regression tests in `tests/test_ascension_os_boundaries.py` to ensure internal scoring language is not blocked and that normalized slash-delimited regulated phrases (e.g., `payment/custody`) still trigger blocking.

### Testing

- Ran `python -m unittest discover -s tests`, which executed the full test suite and completed successfully with all tests passing (428 tests ran, OK). 
- The newly added tests `test_internal_scoring_not_regulated_by_substring` and `test_slash_delimited_regulated_phrase_still_blocked` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069aad04bc8333b9060225639a6638)