### PR TITLE
Use stable run references and expand generated registries for new cycles

### DIFF
--- a/agialpha_ascension_os/core.py
+++ b/agialpha_ascension_os/core.py
@@ -22,6 +22,13 @@ def wj(p: Path, d: dict):
 def rj(p: Path):
     return json.loads(p.read_text()) if p.exists() else None
 
+def _stable_run_ref(run_path: Path) -> str:
+    parts = run_path.parts
+    if "ascension-os-runs" in parts:
+        idx = parts.index("ascension-os-runs")
+        return "/".join(parts[idx:])
+    return "external_run"
+
 def _regulated_triage(workflow_name:str, flags:dict):
     blocked = any(flags.values())
     return {
@@ -99,11 +106,12 @@ def run_cycle(repo_root:Path, out:Path, registry:Path):
     capacity_reinvestment(out)
     valuation_support(repo_root,out,out)
     wj(out/"22_reports"/"ascension_scorecard.json",{"status":"generated",**bfields()})
-    wj(out/"summary.json", {"status":"generated", "run_ref": str(out), **bfields()})
-    wj(out/"evidence-run-manifest.json", {"status":"generated", "artifacts_root":str(out), **bfields()})
+    stable_run_ref = _stable_run_ref(out)
+    wj(out/"summary.json", {"status":"generated", "run_ref": stable_run_ref, **bfields()})
+    wj(out/"evidence-run-manifest.json", {"status":"generated", "artifacts_root":stable_run_ref, **bfields()})
     wj(out/"summary.md", "# Ascension OS run\nHuman Review Required.\n")
     registry.mkdir(parents=True, exist_ok=True)
-    record = {"run_ref":str(out),"status":"accepted",**bfields()}
+    record = {"run_ref":stable_run_ref,"status":"accepted",**bfields()}
     _append_registry_record(registry/"latest.json", record)
     for name in ["summary", "open_rsi_eval", "verified_enterprise_alpha", "valuation_support", "value_to_capacity", "capacity_reinvestment"]:
         artifact = rj(out/f"{name}.json")

--- a/ascension_os_registry/capacity_reinvestment.json
+++ b/ascension_os_registry/capacity_reinvestment.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/enterprise_intakes.json
+++ b/ascension_os_registry/enterprise_intakes.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/insights.json
+++ b/ascension_os_registry/insights.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/jobs.json
+++ b/ascension_os_registry/jobs.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/latest.json
+++ b/ascension_os_registry/latest.json
@@ -311,6 +311,26 @@
       "run_ref": "external_run",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/nova_seeds.json
+++ b/ascension_os_registry/nova_seeds.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/open_rsi_eval.json
+++ b/ascension_os_registry/open_rsi_eval.json
@@ -278,6 +278,68 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "task_count": 16,
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "baselines": {
+        "B0": "static repository",
+        "B1": "docs-only recursive claim",
+        "B2": "CI automation without memory",
+        "B3": "evidence automation without archive reuse",
+        "B4": {
+          "reason": "ungated self-modification lacks human review",
+          "status": "fail"
+        },
+        "B5": {
+          "status": "available"
+        },
+        "B6": {
+          "status": "available"
+        },
+        "B7": {
+          "status": "pending_human_review"
+        }
+      },
+      "claim_boundary": "local bounded public evidence",
+      "comparison": {
+        "B6_vs_B5": "unavailable_honest_missing_inputs"
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "task_count": 16,
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "baselines": {
+        "B0": "static repository",
+        "B1": "docs-only recursive claim",
+        "B2": "CI automation without memory",
+        "B3": "evidence automation without archive reuse",
+        "B4": {
+          "reason": "ungated self-modification lacks human review",
+          "status": "fail"
+        },
+        "B5": {
+          "status": "available"
+        },
+        "B6": {
+          "status": "available"
+        },
+        "B7": {
+          "status": "pending_human_review"
+        }
+      },
+      "claim_boundary": "local bounded public evidence",
+      "comparison": {
+        "B6_vs_B5": "unavailable_honest_missing_inputs"
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "task_count": 16,
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/self_improvement_gauntlet_runs.json
+++ b/ascension_os_registry/self_improvement_gauntlet_runs.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/summary.json
+++ b/ascension_os_registry/summary.json
@@ -89,6 +89,26 @@
       "run_ref": "external_run",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/validators.json
+++ b/ascension_os_registry/validators.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/valuation_support.json
+++ b/ascension_os_registry/valuation_support.json
@@ -391,6 +391,46 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "statement": "AGI ALPHA does not assert a valuation in this document. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "comparables": {
+        "comparables": [
+          {
+            "name": "Example Comparable A",
+            "reported_category_valuation_comparable": "not_reported",
+            "revenue_proxy": 1,
+            "source": "not_reported"
+          }
+        ]
+      },
+      "human_review_required": true,
+      "missing_metrics": "not_reported",
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "AGI ALPHA does not assert a valuation in this document. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "comparables": {
+        "comparables": [
+          {
+            "name": "Example Comparable A",
+            "reported_category_valuation_comparable": "not_reported",
+            "revenue_proxy": 1,
+            "source": "not_reported"
+          }
+        ]
+      },
+      "human_review_required": true,
+      "missing_metrics": "not_reported",
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "AGI ALPHA does not assert a valuation in this document. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/ascension_os_registry/value_to_capacity.json
+++ b/ascension_os_registry/value_to_capacity.json
@@ -283,6 +283,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "token_boundary": "utility-only $AGIALPHA settlement record",
       "value_to_capacity_proxy": 1
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "value_to_capacity_proxy": 1
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "value_to_capacity_proxy": 1
     }
   ]
 }

--- a/ascension_os_registry/verified_enterprise_alpha.json
+++ b/ascension_os_registry/verified_enterprise_alpha.json
@@ -391,6 +391,46 @@
       "statement": "This is a directional operational usefulness proxy, not a financial projection, ROI claim, investment claim, token-value claim, legal conclusion, or guaranteed economic result.",
       "token_boundary": "utility-only $AGIALPHA settlement record",
       "verified_enterprise_alpha": 216
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "formula": {
+        "business_usefulness_score": 2,
+        "cost_risk_proxy": 2,
+        "evidence_quality_score": 3,
+        "governance_integrity_score": 3,
+        "regulated_boundary_integrity_score": 3,
+        "replay_integrity_score": 2,
+        "reusable_capability_score": 2,
+        "verified_work_score": 2
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "This is a directional operational usefulness proxy, not a financial projection, ROI claim, investment claim, token-value claim, legal conclusion, or guaranteed economic result.",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "verified_enterprise_alpha": 216
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "formula": {
+        "business_usefulness_score": 2,
+        "cost_risk_proxy": 2,
+        "evidence_quality_score": 3,
+        "governance_integrity_score": 3,
+        "regulated_boundary_integrity_score": 3,
+        "replay_integrity_score": 2,
+        "reusable_capability_score": 2,
+        "verified_work_score": 2
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "This is a directional operational usefulness proxy, not a financial projection, ROI claim, investment claim, token-value claim, legal conclusion, or guaranteed economic result.",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "verified_enterprise_alpha": 216
     }
   ]
 }

--- a/docs/_generated/ascension-os/archive_reuse.json
+++ b/docs/_generated/ascension-os/archive_reuse.json
@@ -89,6 +89,26 @@
       "run_ref": "external_run",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/capacity_reinvestment.json
+++ b/docs/_generated/ascension-os/capacity_reinvestment.json
@@ -71,6 +71,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/latest.json
+++ b/docs/_generated/ascension-os/latest.json
@@ -311,6 +311,26 @@
       "run_ref": "external_run",
       "status": "accepted",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "accepted",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/open_rsi_eval.json
+++ b/docs/_generated/ascension-os/open_rsi_eval.json
@@ -278,6 +278,68 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "task_count": 16,
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "baselines": {
+        "B0": "static repository",
+        "B1": "docs-only recursive claim",
+        "B2": "CI automation without memory",
+        "B3": "evidence automation without archive reuse",
+        "B4": {
+          "reason": "ungated self-modification lacks human review",
+          "status": "fail"
+        },
+        "B5": {
+          "status": "available"
+        },
+        "B6": {
+          "status": "available"
+        },
+        "B7": {
+          "status": "pending_human_review"
+        }
+      },
+      "claim_boundary": "local bounded public evidence",
+      "comparison": {
+        "B6_vs_B5": "unavailable_honest_missing_inputs"
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "task_count": 16,
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "baselines": {
+        "B0": "static repository",
+        "B1": "docs-only recursive claim",
+        "B2": "CI automation without memory",
+        "B3": "evidence automation without archive reuse",
+        "B4": {
+          "reason": "ungated self-modification lacks human review",
+          "status": "fail"
+        },
+        "B5": {
+          "status": "available"
+        },
+        "B6": {
+          "status": "available"
+        },
+        "B7": {
+          "status": "pending_human_review"
+        }
+      },
+      "claim_boundary": "local bounded public evidence",
+      "comparison": {
+        "B6_vs_B5": "unavailable_honest_missing_inputs"
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "task_count": 16,
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/open_rsi_eval_runs.json
+++ b/docs/_generated/ascension-os/open_rsi_eval_runs.json
@@ -278,6 +278,68 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "task_count": 16,
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "baselines": {
+        "B0": "static repository",
+        "B1": "docs-only recursive claim",
+        "B2": "CI automation without memory",
+        "B3": "evidence automation without archive reuse",
+        "B4": {
+          "reason": "ungated self-modification lacks human review",
+          "status": "fail"
+        },
+        "B5": {
+          "status": "available"
+        },
+        "B6": {
+          "status": "available"
+        },
+        "B7": {
+          "status": "pending_human_review"
+        }
+      },
+      "claim_boundary": "local bounded public evidence",
+      "comparison": {
+        "B6_vs_B5": "unavailable_honest_missing_inputs"
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "task_count": 16,
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "baselines": {
+        "B0": "static repository",
+        "B1": "docs-only recursive claim",
+        "B2": "CI automation without memory",
+        "B3": "evidence automation without archive reuse",
+        "B4": {
+          "reason": "ungated self-modification lacks human review",
+          "status": "fail"
+        },
+        "B5": {
+          "status": "available"
+        },
+        "B6": {
+          "status": "available"
+        },
+        "B7": {
+          "status": "pending_human_review"
+        }
+      },
+      "claim_boundary": "local bounded public evidence",
+      "comparison": {
+        "B6_vs_B5": "unavailable_honest_missing_inputs"
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "task_count": 16,
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/scorecards.json
+++ b/docs/_generated/ascension-os/scorecards.json
@@ -89,6 +89,26 @@
       "run_ref": "external_run",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/self_improvement_gauntlet_runs.json
+++ b/docs/_generated/ascension-os/self_improvement_gauntlet_runs.json
@@ -89,6 +89,26 @@
       "run_ref": "external_run",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/summary.json
+++ b/docs/_generated/ascension-os/summary.json
@@ -89,6 +89,26 @@
       "run_ref": "external_run",
       "status": "generated",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "/tmp/ascension-os-test",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "run_ref": "external_run",
+      "status": "generated",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/valuation_support.json
+++ b/docs/_generated/ascension-os/valuation_support.json
@@ -391,6 +391,46 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "statement": "AGI ALPHA does not assert a valuation in this document. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
       "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "comparables": {
+        "comparables": [
+          {
+            "name": "Example Comparable A",
+            "reported_category_valuation_comparable": "not_reported",
+            "revenue_proxy": 1,
+            "source": "not_reported"
+          }
+        ]
+      },
+      "human_review_required": true,
+      "missing_metrics": "not_reported",
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "AGI ALPHA does not assert a valuation in this document. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "comparables": {
+        "comparables": [
+          {
+            "name": "Example Comparable A",
+            "reported_category_valuation_comparable": "not_reported",
+            "revenue_proxy": 1,
+            "source": "not_reported"
+          }
+        ]
+      },
+      "human_review_required": true,
+      "missing_metrics": "not_reported",
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "AGI ALPHA does not assert a valuation in this document. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "token_boundary": "utility-only $AGIALPHA settlement record"
     }
   ]
 }

--- a/docs/_generated/ascension-os/value_to_capacity.json
+++ b/docs/_generated/ascension-os/value_to_capacity.json
@@ -283,6 +283,24 @@
       "regulated_boundary": "regulated-boundary-safe documentation-only automation",
       "token_boundary": "utility-only $AGIALPHA settlement record",
       "value_to_capacity_proxy": 1
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "value_to_capacity_proxy": 1
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "value_to_capacity_proxy": 1
     }
   ]
 }

--- a/docs/_generated/ascension-os/verified_enterprise_alpha.json
+++ b/docs/_generated/ascension-os/verified_enterprise_alpha.json
@@ -391,6 +391,46 @@
       "statement": "This is a directional operational usefulness proxy, not a financial projection, ROI claim, investment claim, token-value claim, legal conclusion, or guaranteed economic result.",
       "token_boundary": "utility-only $AGIALPHA settlement record",
       "verified_enterprise_alpha": 216
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "formula": {
+        "business_usefulness_score": 2,
+        "cost_risk_proxy": 2,
+        "evidence_quality_score": 3,
+        "governance_integrity_score": 3,
+        "regulated_boundary_integrity_score": 3,
+        "replay_integrity_score": 2,
+        "reusable_capability_score": 2,
+        "verified_work_score": 2
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "This is a directional operational usefulness proxy, not a financial projection, ROI claim, investment claim, token-value claim, legal conclusion, or guaranteed economic result.",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "verified_enterprise_alpha": 216
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence",
+      "formula": {
+        "business_usefulness_score": 2,
+        "cost_risk_proxy": 2,
+        "evidence_quality_score": 3,
+        "governance_integrity_score": 3,
+        "regulated_boundary_integrity_score": 3,
+        "replay_integrity_score": 2,
+        "reusable_capability_score": 2,
+        "verified_work_score": 2
+      },
+      "human_review_required": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-boundary-safe documentation-only automation",
+      "statement": "This is a directional operational usefulness proxy, not a financial projection, ROI claim, investment claim, token-value claim, legal conclusion, or guaranteed economic result.",
+      "token_boundary": "utility-only $AGIALPHA settlement record",
+      "verified_enterprise_alpha": 216
     }
   ]
 }

--- a/recursive_substrate_registry/capabilities.json
+++ b/recursive_substrate_registry/capabilities.json
@@ -5458,5 +5458,665 @@
     "capability_id": "recursive-cycle-184-cap-006",
     "job_id": "recursive-cycle-184-job-006",
     "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-185-cap-001",
+    "job_id": "recursive-cycle-185-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-185-cap-002",
+    "job_id": "recursive-cycle-185-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-185-cap-003",
+    "job_id": "recursive-cycle-185-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-185-cap-004",
+    "job_id": "recursive-cycle-185-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-185-cap-005",
+    "job_id": "recursive-cycle-185-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-185-cap-006",
+    "job_id": "recursive-cycle-185-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-186-cap-001",
+    "job_id": "recursive-cycle-186-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-186-cap-002",
+    "job_id": "recursive-cycle-186-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-186-cap-003",
+    "job_id": "recursive-cycle-186-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-186-cap-004",
+    "job_id": "recursive-cycle-186-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-186-cap-005",
+    "job_id": "recursive-cycle-186-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-186-cap-006",
+    "job_id": "recursive-cycle-186-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-187-cap-001",
+    "job_id": "recursive-cycle-187-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-187-cap-002",
+    "job_id": "recursive-cycle-187-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-187-cap-003",
+    "job_id": "recursive-cycle-187-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-187-cap-004",
+    "job_id": "recursive-cycle-187-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-187-cap-005",
+    "job_id": "recursive-cycle-187-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-187-cap-006",
+    "job_id": "recursive-cycle-187-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-188-cap-001",
+    "job_id": "recursive-cycle-188-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-188-cap-002",
+    "job_id": "recursive-cycle-188-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-188-cap-003",
+    "job_id": "recursive-cycle-188-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-188-cap-004",
+    "job_id": "recursive-cycle-188-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-188-cap-005",
+    "job_id": "recursive-cycle-188-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-188-cap-006",
+    "job_id": "recursive-cycle-188-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-189-cap-001",
+    "job_id": "recursive-cycle-189-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-189-cap-002",
+    "job_id": "recursive-cycle-189-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-189-cap-003",
+    "job_id": "recursive-cycle-189-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-189-cap-004",
+    "job_id": "recursive-cycle-189-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-189-cap-005",
+    "job_id": "recursive-cycle-189-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-189-cap-006",
+    "job_id": "recursive-cycle-189-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-190-cap-001",
+    "job_id": "recursive-cycle-190-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-190-cap-002",
+    "job_id": "recursive-cycle-190-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-190-cap-003",
+    "job_id": "recursive-cycle-190-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-190-cap-004",
+    "job_id": "recursive-cycle-190-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-190-cap-005",
+    "job_id": "recursive-cycle-190-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-190-cap-006",
+    "job_id": "recursive-cycle-190-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-191-cap-001",
+    "job_id": "recursive-cycle-191-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-191-cap-002",
+    "job_id": "recursive-cycle-191-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-191-cap-003",
+    "job_id": "recursive-cycle-191-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-191-cap-004",
+    "job_id": "recursive-cycle-191-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-191-cap-005",
+    "job_id": "recursive-cycle-191-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-191-cap-006",
+    "job_id": "recursive-cycle-191-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-192-cap-001",
+    "job_id": "recursive-cycle-192-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-192-cap-002",
+    "job_id": "recursive-cycle-192-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-192-cap-003",
+    "job_id": "recursive-cycle-192-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-192-cap-004",
+    "job_id": "recursive-cycle-192-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-192-cap-005",
+    "job_id": "recursive-cycle-192-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-192-cap-006",
+    "job_id": "recursive-cycle-192-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-193-cap-001",
+    "job_id": "recursive-cycle-193-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-193-cap-002",
+    "job_id": "recursive-cycle-193-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-193-cap-003",
+    "job_id": "recursive-cycle-193-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-193-cap-004",
+    "job_id": "recursive-cycle-193-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-193-cap-005",
+    "job_id": "recursive-cycle-193-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-193-cap-006",
+    "job_id": "recursive-cycle-193-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-194-cap-001",
+    "job_id": "recursive-cycle-194-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-194-cap-002",
+    "job_id": "recursive-cycle-194-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-194-cap-003",
+    "job_id": "recursive-cycle-194-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-194-cap-004",
+    "job_id": "recursive-cycle-194-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-194-cap-005",
+    "job_id": "recursive-cycle-194-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-194-cap-006",
+    "job_id": "recursive-cycle-194-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-195-cap-001",
+    "job_id": "recursive-cycle-195-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-195-cap-002",
+    "job_id": "recursive-cycle-195-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-195-cap-003",
+    "job_id": "recursive-cycle-195-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-195-cap-004",
+    "job_id": "recursive-cycle-195-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-195-cap-005",
+    "job_id": "recursive-cycle-195-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-195-cap-006",
+    "job_id": "recursive-cycle-195-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-196-cap-001",
+    "job_id": "recursive-cycle-196-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-196-cap-002",
+    "job_id": "recursive-cycle-196-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-196-cap-003",
+    "job_id": "recursive-cycle-196-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-196-cap-004",
+    "job_id": "recursive-cycle-196-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-196-cap-005",
+    "job_id": "recursive-cycle-196-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-196-cap-006",
+    "job_id": "recursive-cycle-196-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-197-cap-001",
+    "job_id": "recursive-cycle-197-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-197-cap-002",
+    "job_id": "recursive-cycle-197-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-197-cap-003",
+    "job_id": "recursive-cycle-197-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-197-cap-004",
+    "job_id": "recursive-cycle-197-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-197-cap-005",
+    "job_id": "recursive-cycle-197-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-197-cap-006",
+    "job_id": "recursive-cycle-197-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-198-cap-001",
+    "job_id": "recursive-cycle-198-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-198-cap-002",
+    "job_id": "recursive-cycle-198-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-198-cap-003",
+    "job_id": "recursive-cycle-198-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-198-cap-004",
+    "job_id": "recursive-cycle-198-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-198-cap-005",
+    "job_id": "recursive-cycle-198-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-198-cap-006",
+    "job_id": "recursive-cycle-198-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-199-cap-001",
+    "job_id": "recursive-cycle-199-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-199-cap-002",
+    "job_id": "recursive-cycle-199-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-199-cap-003",
+    "job_id": "recursive-cycle-199-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-199-cap-004",
+    "job_id": "recursive-cycle-199-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-199-cap-005",
+    "job_id": "recursive-cycle-199-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-199-cap-006",
+    "job_id": "recursive-cycle-199-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-200-cap-001",
+    "job_id": "recursive-cycle-200-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-200-cap-002",
+    "job_id": "recursive-cycle-200-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-200-cap-003",
+    "job_id": "recursive-cycle-200-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-200-cap-004",
+    "job_id": "recursive-cycle-200-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-200-cap-005",
+    "job_id": "recursive-cycle-200-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-200-cap-006",
+    "job_id": "recursive-cycle-200-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-201-cap-001",
+    "job_id": "recursive-cycle-201-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-201-cap-002",
+    "job_id": "recursive-cycle-201-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-201-cap-003",
+    "job_id": "recursive-cycle-201-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-201-cap-004",
+    "job_id": "recursive-cycle-201-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-201-cap-005",
+    "job_id": "recursive-cycle-201-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-201-cap-006",
+    "job_id": "recursive-cycle-201-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-202-cap-001",
+    "job_id": "recursive-cycle-202-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-202-cap-002",
+    "job_id": "recursive-cycle-202-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-202-cap-003",
+    "job_id": "recursive-cycle-202-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-202-cap-004",
+    "job_id": "recursive-cycle-202-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-202-cap-005",
+    "job_id": "recursive-cycle-202-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-202-cap-006",
+    "job_id": "recursive-cycle-202-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-203-cap-001",
+    "job_id": "recursive-cycle-203-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-203-cap-002",
+    "job_id": "recursive-cycle-203-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-203-cap-003",
+    "job_id": "recursive-cycle-203-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-203-cap-004",
+    "job_id": "recursive-cycle-203-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-203-cap-005",
+    "job_id": "recursive-cycle-203-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-203-cap-006",
+    "job_id": "recursive-cycle-203-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-204-cap-001",
+    "job_id": "recursive-cycle-204-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-204-cap-002",
+    "job_id": "recursive-cycle-204-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-204-cap-003",
+    "job_id": "recursive-cycle-204-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-204-cap-004",
+    "job_id": "recursive-cycle-204-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-204-cap-005",
+    "job_id": "recursive-cycle-204-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-204-cap-006",
+    "job_id": "recursive-cycle-204-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-205-cap-001",
+    "job_id": "recursive-cycle-205-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-205-cap-002",
+    "job_id": "recursive-cycle-205-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-205-cap-003",
+    "job_id": "recursive-cycle-205-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-205-cap-004",
+    "job_id": "recursive-cycle-205-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-205-cap-005",
+    "job_id": "recursive-cycle-205-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-205-cap-006",
+    "job_id": "recursive-cycle-205-job-006",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-206-cap-001",
+    "job_id": "recursive-cycle-206-job-001",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-206-cap-002",
+    "job_id": "recursive-cycle-206-job-002",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-206-cap-003",
+    "job_id": "recursive-cycle-206-job-003",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-206-cap-004",
+    "job_id": "recursive-cycle-206-job-004",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-206-cap-005",
+    "job_id": "recursive-cycle-206-job-005",
+    "status": "archived"
+  },
+  {
+    "capability_id": "recursive-cycle-206-cap-006",
+    "job_id": "recursive-cycle-206-job-006",
+    "status": "archived"
   }
 ]

--- a/recursive_substrate_registry/cycles.json
+++ b/recursive_substrate_registry/cycles.json
@@ -11590,5 +11590,1391 @@
       "critical_safety_incidents": 0
     },
     "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-185",
+    "cycle_index": 184,
+    "generated_at": "2026-05-15T05:30:40.536497+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-186",
+    "cycle_index": 185,
+    "generated_at": "2026-05-15T05:30:40.988644+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-187",
+    "cycle_index": 186,
+    "generated_at": "2026-05-15T05:30:41.428394+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-188",
+    "cycle_index": 187,
+    "generated_at": "2026-05-15T05:30:41.878423+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-189",
+    "cycle_index": 188,
+    "generated_at": "2026-05-15T05:30:42.354030+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-190",
+    "cycle_index": 189,
+    "generated_at": "2026-05-15T05:30:42.829991+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-191",
+    "cycle_index": 190,
+    "generated_at": "2026-05-15T05:30:43.304607+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-192",
+    "cycle_index": 191,
+    "generated_at": "2026-05-15T05:30:43.776988+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-193",
+    "cycle_index": 192,
+    "generated_at": "2026-05-15T05:30:44.295168+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-194",
+    "cycle_index": 193,
+    "generated_at": "2026-05-15T05:30:44.825372+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-195",
+    "cycle_index": 194,
+    "generated_at": "2026-05-15T05:30:45.310878+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "72fde455962553e1712a580c24c57289dbac3c33",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-196",
+    "cycle_index": 195,
+    "generated_at": "2026-05-15T05:40:19.977098+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-197",
+    "cycle_index": 196,
+    "generated_at": "2026-05-15T05:40:20.438058+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-198",
+    "cycle_index": 197,
+    "generated_at": "2026-05-15T05:40:20.896804+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-199",
+    "cycle_index": 198,
+    "generated_at": "2026-05-15T05:40:21.370023+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-200",
+    "cycle_index": 199,
+    "generated_at": "2026-05-15T05:40:21.861947+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-201",
+    "cycle_index": 200,
+    "generated_at": "2026-05-15T05:40:22.327182+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-202",
+    "cycle_index": 201,
+    "generated_at": "2026-05-15T05:40:22.782814+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-203",
+    "cycle_index": 202,
+    "generated_at": "2026-05-15T05:40:23.243834+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-204",
+    "cycle_index": 203,
+    "generated_at": "2026-05-15T05:40:23.778313+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-205",
+    "cycle_index": 204,
+    "generated_at": "2026-05-15T05:40:24.309692+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
+  },
+  {
+    "schema_version": "agialpha.recursive_cycle.v1",
+    "cycle_id": "recursive-cycle-206",
+    "cycle_index": 205,
+    "generated_at": "2026-05-15T05:40:24.801523+00:00",
+    "repository": "MontrealAI/agialpha-first-real-loop",
+    "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
+    "status": "success",
+    "substrate_layers": {
+      "agents": true,
+      "jobs": true,
+      "validators": true,
+      "memory": true,
+      "governance": true,
+      "settlement": true,
+      "recursive_improvement": true,
+      "human_governed_promotion": true
+    },
+    "open_ended_loop": {
+      "insights_generated": 1,
+      "nova_seeds_generated": 16,
+      "jobs_generated": 6,
+      "validators_generated": 6,
+      "capabilities_archived": 6,
+      "vnext_candidates_generated": 6
+    },
+    "proof_loop": {
+      "proofbundles_created": 1,
+      "evidence_dockets_created": 1,
+      "replay_reports_created": "pending",
+      "falsification_reports_created": "pending"
+    },
+    "governance_loop": {
+      "policy_decisions_created": "pending",
+      "human_review_records_created": "pending",
+      "promotion_gates_passed": 0,
+      "promotion_gates_failed": 1
+    },
+    "settlement_loop": {
+      "work_vaults_created": "pending",
+      "mark_allocations_created": 16,
+      "sovereign_assignments_created": 16,
+      "utility_settlement_records_created": 6
+    },
+    "metrics": {
+      "recursive_substrate_readiness_score": "pending",
+      "open_ended_discovery_score": "pending",
+      "proof_density_score": "pending",
+      "memory_reuse_score": "pending",
+      "vnext_compounding_score": "pending",
+      "human_governance_integrity": "pending"
+    },
+    "hard_safety_counters": {
+      "raw_secret_leak_count": 0,
+      "external_target_scan_count": 0,
+      "exploit_execution_count": 0,
+      "malware_generation_count": 0,
+      "social_engineering_content_count": 0,
+      "unsafe_automerge_count": 0,
+      "critical_safety_incidents": 0
+    },
+    "claim_boundary": "This recursive substrate cycle is local, bounded evidence of governance and machine-labor infrastructure. It does not claim achieved AGI, ASI, superintelligence, empirical SOTA, safe autonomy, official benchmark victory, or external validation."
   }
 ]

--- a/recursive_substrate_registry/evidence_dockets.json
+++ b/recursive_substrate_registry/evidence_dockets.json
@@ -1090,5 +1090,137 @@
     "status": "created",
     "claim_boundary": "local bounded recursive substrate evidence",
     "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
+  },
+  {
+    "docket_id": "docket-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence",
+    "human_review_required": true
   }
 ]

--- a/recursive_substrate_registry/insights.json
+++ b/recursive_substrate_registry/insights.json
@@ -908,5 +908,115 @@
     "insight_id": "insight-001",
     "summary": "Gap detection for recursive substrate",
     "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "insight_id": "insight-001",
+    "summary": "Gap detection for recursive substrate",
+    "claim_boundary": "local bounded recursive substrate evidence"
   }
 ]

--- a/recursive_substrate_registry/jobs.json
+++ b/recursive_substrate_registry/jobs.json
@@ -6550,5 +6550,797 @@
     "seed_id": "seed-006",
     "human_review_required": true,
     "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-001",
+    "seed_id": "seed-001",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-002",
+    "seed_id": "seed-002",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-003",
+    "seed_id": "seed-003",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-004",
+    "seed_id": "seed-004",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-005",
+    "seed_id": "seed-005",
+    "human_review_required": true,
+    "status": "completed"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-006",
+    "seed_id": "seed-006",
+    "human_review_required": true,
+    "status": "completed"
   }
 ]

--- a/recursive_substrate_registry/latest.json
+++ b/recursive_substrate_registry/latest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "agialpha.recursive_cycle.v1",
-  "cycle_id": "recursive-cycle-184",
-  "cycle_index": 183,
-  "generated_at": "2026-05-15T04:39:37.370994+00:00",
+  "cycle_id": "recursive-cycle-206",
+  "cycle_index": 205,
+  "generated_at": "2026-05-15T05:40:24.801523+00:00",
   "repository": "MontrealAI/agialpha-first-real-loop",
-  "commit_sha": "55567000098dc80c819b5cc80215b8d00c58aed7",
+  "commit_sha": "30251bd37d6904f25f946c67db57c45bebaddc98",
   "status": "success",
   "substrate_layers": {
     "agents": true,

--- a/recursive_substrate_registry/nova_seeds.json
+++ b/recursive_substrate_registry/nova_seeds.json
@@ -17470,5 +17470,2117 @@
     "kind": "vnext",
     "status": "rejected",
     "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-001",
+    "kind": "task",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-002",
+    "kind": "validator",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-003",
+    "kind": "doc",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-004",
+    "kind": "workflow",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-005",
+    "kind": "policy",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-006",
+    "kind": "evidence",
+    "status": "accepted",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-007",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-008",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-009",
+    "kind": "task",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-010",
+    "kind": "validator",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-011",
+    "kind": "doc",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-012",
+    "kind": "workflow",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-013",
+    "kind": "policy",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-014",
+    "kind": "evidence",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-015",
+    "kind": "replay",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "seed_id": "seed-016",
+    "kind": "vnext",
+    "status": "rejected",
+    "claim_boundary": "local bounded recursive substrate evidence"
   }
 ]

--- a/recursive_substrate_registry/proofbundles.json
+++ b/recursive_substrate_registry/proofbundles.json
@@ -908,5 +908,115 @@
     "proofbundle_id": "proofbundle-001",
     "status": "created",
     "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
+  },
+  {
+    "proofbundle_id": "proofbundle-001",
+    "status": "created",
+    "claim_boundary": "local bounded recursive substrate evidence"
   }
 ]

--- a/recursive_substrate_registry/validators.json
+++ b/recursive_substrate_registry/validators.json
@@ -5458,5 +5458,665 @@
     "job_id": "recursive-cycle-184-job-006",
     "validator_id": "claim-boundary-validator",
     "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-185-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-186-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-187-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-188-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-189-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-190-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-191-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-192-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-193-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-194-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-195-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-196-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-197-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-198-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-199-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-200-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-201-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-202-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-203-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-204-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-205-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-001",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-002",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-003",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-004",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-005",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
+  },
+  {
+    "job_id": "recursive-cycle-206-job-006",
+    "validator_id": "claim-boundary-validator",
+    "status": "pass"
   }
 ]

--- a/recursive_substrate_registry/vnext.json
+++ b/recursive_substrate_registry/vnext.json
@@ -5464,5 +5464,665 @@
     "candidate_id": "recursive-cycle-184-vnext-006",
     "from_capability": "recursive-cycle-184-cap-006",
     "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-185-vnext-001",
+    "from_capability": "recursive-cycle-185-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-185-vnext-002",
+    "from_capability": "recursive-cycle-185-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-185-vnext-003",
+    "from_capability": "recursive-cycle-185-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-185-vnext-004",
+    "from_capability": "recursive-cycle-185-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-185-vnext-005",
+    "from_capability": "recursive-cycle-185-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-185-vnext-006",
+    "from_capability": "recursive-cycle-185-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-186-vnext-001",
+    "from_capability": "recursive-cycle-186-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-186-vnext-002",
+    "from_capability": "recursive-cycle-186-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-186-vnext-003",
+    "from_capability": "recursive-cycle-186-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-186-vnext-004",
+    "from_capability": "recursive-cycle-186-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-186-vnext-005",
+    "from_capability": "recursive-cycle-186-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-186-vnext-006",
+    "from_capability": "recursive-cycle-186-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-187-vnext-001",
+    "from_capability": "recursive-cycle-187-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-187-vnext-002",
+    "from_capability": "recursive-cycle-187-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-187-vnext-003",
+    "from_capability": "recursive-cycle-187-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-187-vnext-004",
+    "from_capability": "recursive-cycle-187-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-187-vnext-005",
+    "from_capability": "recursive-cycle-187-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-187-vnext-006",
+    "from_capability": "recursive-cycle-187-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-188-vnext-001",
+    "from_capability": "recursive-cycle-188-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-188-vnext-002",
+    "from_capability": "recursive-cycle-188-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-188-vnext-003",
+    "from_capability": "recursive-cycle-188-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-188-vnext-004",
+    "from_capability": "recursive-cycle-188-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-188-vnext-005",
+    "from_capability": "recursive-cycle-188-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-188-vnext-006",
+    "from_capability": "recursive-cycle-188-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-189-vnext-001",
+    "from_capability": "recursive-cycle-189-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-189-vnext-002",
+    "from_capability": "recursive-cycle-189-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-189-vnext-003",
+    "from_capability": "recursive-cycle-189-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-189-vnext-004",
+    "from_capability": "recursive-cycle-189-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-189-vnext-005",
+    "from_capability": "recursive-cycle-189-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-189-vnext-006",
+    "from_capability": "recursive-cycle-189-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-190-vnext-001",
+    "from_capability": "recursive-cycle-190-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-190-vnext-002",
+    "from_capability": "recursive-cycle-190-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-190-vnext-003",
+    "from_capability": "recursive-cycle-190-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-190-vnext-004",
+    "from_capability": "recursive-cycle-190-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-190-vnext-005",
+    "from_capability": "recursive-cycle-190-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-190-vnext-006",
+    "from_capability": "recursive-cycle-190-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-191-vnext-001",
+    "from_capability": "recursive-cycle-191-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-191-vnext-002",
+    "from_capability": "recursive-cycle-191-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-191-vnext-003",
+    "from_capability": "recursive-cycle-191-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-191-vnext-004",
+    "from_capability": "recursive-cycle-191-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-191-vnext-005",
+    "from_capability": "recursive-cycle-191-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-191-vnext-006",
+    "from_capability": "recursive-cycle-191-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-192-vnext-001",
+    "from_capability": "recursive-cycle-192-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-192-vnext-002",
+    "from_capability": "recursive-cycle-192-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-192-vnext-003",
+    "from_capability": "recursive-cycle-192-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-192-vnext-004",
+    "from_capability": "recursive-cycle-192-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-192-vnext-005",
+    "from_capability": "recursive-cycle-192-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-192-vnext-006",
+    "from_capability": "recursive-cycle-192-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-193-vnext-001",
+    "from_capability": "recursive-cycle-193-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-193-vnext-002",
+    "from_capability": "recursive-cycle-193-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-193-vnext-003",
+    "from_capability": "recursive-cycle-193-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-193-vnext-004",
+    "from_capability": "recursive-cycle-193-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-193-vnext-005",
+    "from_capability": "recursive-cycle-193-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-193-vnext-006",
+    "from_capability": "recursive-cycle-193-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-194-vnext-001",
+    "from_capability": "recursive-cycle-194-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-194-vnext-002",
+    "from_capability": "recursive-cycle-194-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-194-vnext-003",
+    "from_capability": "recursive-cycle-194-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-194-vnext-004",
+    "from_capability": "recursive-cycle-194-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-194-vnext-005",
+    "from_capability": "recursive-cycle-194-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-194-vnext-006",
+    "from_capability": "recursive-cycle-194-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-195-vnext-001",
+    "from_capability": "recursive-cycle-195-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-195-vnext-002",
+    "from_capability": "recursive-cycle-195-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-195-vnext-003",
+    "from_capability": "recursive-cycle-195-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-195-vnext-004",
+    "from_capability": "recursive-cycle-195-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-195-vnext-005",
+    "from_capability": "recursive-cycle-195-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-195-vnext-006",
+    "from_capability": "recursive-cycle-195-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-196-vnext-001",
+    "from_capability": "recursive-cycle-196-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-196-vnext-002",
+    "from_capability": "recursive-cycle-196-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-196-vnext-003",
+    "from_capability": "recursive-cycle-196-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-196-vnext-004",
+    "from_capability": "recursive-cycle-196-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-196-vnext-005",
+    "from_capability": "recursive-cycle-196-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-196-vnext-006",
+    "from_capability": "recursive-cycle-196-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-197-vnext-001",
+    "from_capability": "recursive-cycle-197-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-197-vnext-002",
+    "from_capability": "recursive-cycle-197-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-197-vnext-003",
+    "from_capability": "recursive-cycle-197-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-197-vnext-004",
+    "from_capability": "recursive-cycle-197-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-197-vnext-005",
+    "from_capability": "recursive-cycle-197-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-197-vnext-006",
+    "from_capability": "recursive-cycle-197-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-198-vnext-001",
+    "from_capability": "recursive-cycle-198-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-198-vnext-002",
+    "from_capability": "recursive-cycle-198-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-198-vnext-003",
+    "from_capability": "recursive-cycle-198-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-198-vnext-004",
+    "from_capability": "recursive-cycle-198-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-198-vnext-005",
+    "from_capability": "recursive-cycle-198-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-198-vnext-006",
+    "from_capability": "recursive-cycle-198-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-199-vnext-001",
+    "from_capability": "recursive-cycle-199-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-199-vnext-002",
+    "from_capability": "recursive-cycle-199-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-199-vnext-003",
+    "from_capability": "recursive-cycle-199-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-199-vnext-004",
+    "from_capability": "recursive-cycle-199-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-199-vnext-005",
+    "from_capability": "recursive-cycle-199-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-199-vnext-006",
+    "from_capability": "recursive-cycle-199-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-200-vnext-001",
+    "from_capability": "recursive-cycle-200-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-200-vnext-002",
+    "from_capability": "recursive-cycle-200-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-200-vnext-003",
+    "from_capability": "recursive-cycle-200-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-200-vnext-004",
+    "from_capability": "recursive-cycle-200-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-200-vnext-005",
+    "from_capability": "recursive-cycle-200-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-200-vnext-006",
+    "from_capability": "recursive-cycle-200-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-201-vnext-001",
+    "from_capability": "recursive-cycle-201-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-201-vnext-002",
+    "from_capability": "recursive-cycle-201-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-201-vnext-003",
+    "from_capability": "recursive-cycle-201-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-201-vnext-004",
+    "from_capability": "recursive-cycle-201-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-201-vnext-005",
+    "from_capability": "recursive-cycle-201-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-201-vnext-006",
+    "from_capability": "recursive-cycle-201-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-202-vnext-001",
+    "from_capability": "recursive-cycle-202-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-202-vnext-002",
+    "from_capability": "recursive-cycle-202-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-202-vnext-003",
+    "from_capability": "recursive-cycle-202-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-202-vnext-004",
+    "from_capability": "recursive-cycle-202-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-202-vnext-005",
+    "from_capability": "recursive-cycle-202-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-202-vnext-006",
+    "from_capability": "recursive-cycle-202-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-203-vnext-001",
+    "from_capability": "recursive-cycle-203-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-203-vnext-002",
+    "from_capability": "recursive-cycle-203-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-203-vnext-003",
+    "from_capability": "recursive-cycle-203-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-203-vnext-004",
+    "from_capability": "recursive-cycle-203-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-203-vnext-005",
+    "from_capability": "recursive-cycle-203-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-203-vnext-006",
+    "from_capability": "recursive-cycle-203-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-204-vnext-001",
+    "from_capability": "recursive-cycle-204-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-204-vnext-002",
+    "from_capability": "recursive-cycle-204-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-204-vnext-003",
+    "from_capability": "recursive-cycle-204-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-204-vnext-004",
+    "from_capability": "recursive-cycle-204-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-204-vnext-005",
+    "from_capability": "recursive-cycle-204-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-204-vnext-006",
+    "from_capability": "recursive-cycle-204-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-205-vnext-001",
+    "from_capability": "recursive-cycle-205-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-205-vnext-002",
+    "from_capability": "recursive-cycle-205-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-205-vnext-003",
+    "from_capability": "recursive-cycle-205-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-205-vnext-004",
+    "from_capability": "recursive-cycle-205-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-205-vnext-005",
+    "from_capability": "recursive-cycle-205-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-205-vnext-006",
+    "from_capability": "recursive-cycle-205-cap-006",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-206-vnext-001",
+    "from_capability": "recursive-cycle-206-cap-001",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-206-vnext-002",
+    "from_capability": "recursive-cycle-206-cap-002",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-206-vnext-003",
+    "from_capability": "recursive-cycle-206-cap-003",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-206-vnext-004",
+    "from_capability": "recursive-cycle-206-cap-004",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-206-vnext-005",
+    "from_capability": "recursive-cycle-206-cap-005",
+    "status": "pending_human_review"
+  },
+  {
+    "candidate_id": "recursive-cycle-206-vnext-006",
+    "from_capability": "recursive-cycle-206-cap-006",
+    "status": "pending_human_review"
   }
 ]


### PR DESCRIPTION
### Motivation
- Use a portable, stable identifier for run references and artifact roots instead of absolute `Path` strings so registry entries and manifests are reproducible across environments.
- Reflect newly generated cycles and associated artifacts in the registries and generated docs so the dataset includes recent runs, capabilities, jobs, validators, and vnext candidates.

### Description
- Added `_stable_run_ref(run_path: Path) -> str` to `agialpha_ascension_os/core.py` and switched manifest and registry writes to use `stable_run_ref` for `summary.json`, `evidence-run-manifest.json`, and the `latest.json` registry record instead of `str(out)`.
- Updated many registry files under `ascension_os_registry/` and corresponding generated docs under `docs/_generated/ascension-os/` to include additional entries (runs, summaries, open_rsi_eval items, valuation_support, verified_enterprise_alpha, value_to_capacity, capacity_reinvestment, etc.).
- Expanded `recursive_substrate_registry/` data (added cycles, capabilities, jobs, validators, vnext candidates, proofbundles, nova_seeds, insights and updated `latest.json`) to reflect a sequence of new recursive cycles and artifacts.
- Preserved existing metadata fields (via `bfields()`), triage behavior, and append-only registry patterns while applying the stable run ref change.

### Testing
- Ran the repository test suite with `pytest` and verified the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06af033b78833389f5df8289563d09)