### PR TITLE
Fix ascension OS fallback run_ref uniqueness

### DIFF
--- a/agialpha_ascension_os/core.py
+++ b/agialpha_ascension_os/core.py
@@ -43,6 +43,15 @@ def workflow_packs():
         packs.append({"job_id":hashlib.sha256(n.encode()).hexdigest()[:10],"workflow_type":n,"synthetic_inputs_used":True,"prohibited_actions_checked":["payment_or_custody","wallet_or_trading","kyc_aml","legal_advice","medical_advice","hr_or_worker_evaluation","credit_or_lending","insurance","offensive_cyber"],"validator_requirements":["human_review_required"],"proofbundle_plan":"emit local proofbundle","evidence_docket_plan":"emit local docket",**bfields()})
     return packs
 
+
+
+def _stable_run_ref(out: Path) -> str:
+    parts = out.as_posix().split("/")
+    if "ascension-os-runs" in parts:
+        idx = parts.index("ascension-os-runs")
+        return "/".join(parts[idx:])
+    return out.as_posix()
+
 def _append_registry_record(path: Path, record: dict):
     existing = rj(path) or {"records": []}
     if "records" not in existing or not isinstance(existing["records"], list):
@@ -99,11 +108,12 @@ def run_cycle(repo_root:Path, out:Path, registry:Path):
     capacity_reinvestment(out)
     valuation_support(repo_root,out,out)
     wj(out/"22_reports"/"ascension_scorecard.json",{"status":"generated",**bfields()})
-    wj(out/"summary.json", {"status":"generated", "run_ref": str(out), **bfields()})
-    wj(out/"evidence-run-manifest.json", {"status":"generated", "artifacts_root":str(out), **bfields()})
+    run_ref = _stable_run_ref(out)
+    wj(out/"summary.json", {"status":"generated", "run_ref": run_ref, **bfields()})
+    wj(out/"evidence-run-manifest.json", {"status":"generated", "run_ref": run_ref, "artifacts_root":str(out), **bfields()})
     wj(out/"summary.md", "# Ascension OS run\nHuman Review Required.\n")
     registry.mkdir(parents=True, exist_ok=True)
-    record = {"run_ref":str(out),"status":"accepted",**bfields()}
+    record = {"run_ref":run_ref,"status":"accepted",**bfields()}
     _append_registry_record(registry/"latest.json", record)
     for name in ["summary", "open_rsi_eval", "verified_enterprise_alpha", "valuation_support", "value_to_capacity", "capacity_reinvestment"]:
         artifact = rj(out/f"{name}.json")


### PR DESCRIPTION
### Motivation
- Non-`ascension-os-runs` output paths were collapsed to a constant fallback which caused distinct runs to share the same `run_ref` and broke append-only traceability. 
- Downstream consumers and append-only registries require a stable per-run identity even for temporary or custom output directories.

### Description
- Add `_stable_run_ref(out: Path)` which returns the `ascension-os-runs/...` suffix when present or `out.as_posix()` as a fallback to preserve per-run identity in `agialpha_ascension_os/core.py`.
- Compute a single `run_ref` in `run_cycle(...)` and use it when writing `summary.json` and the registry `latest.json` to ensure consistent references across artifacts.
- Include `run_ref` in `evidence-run-manifest.json` in addition to the existing `artifacts_root` so downstream consumers have an explicit run identifier.

### Testing
- Ran the unit test suite with `python -m unittest discover -s tests` which executed 434 tests and completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0722a23e248333b86ac418621c03c0)