### PR TITLE
Upgrade AGI ALPHA Valuation Support: implementation-side market-comparable evidence dossier

### DIFF
--- a/agialpha_valuation_support/cli.py
+++ b/agialpha_valuation_support/cli.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import argparse
 from .core import build, validate, build_data
+from .render import render_summary
 
 def main():
  p=argparse.ArgumentParser(); sp=p.add_subparsers(dest='cmd', required=True)
@@ -8,5 +9,5 @@ def main():
  b.set_defaults(func=lambda a: build(Path(a.repo_root),Path(a.ascension_registry),Path(a.comparables),Path(a.market_context),Path(a.out)))
  v=sp.add_parser('validate'); v.add_argument('--run',required=True); v.set_defaults(func=lambda a: validate(Path(a.run)))
  d=sp.add_parser('build-data'); d.add_argument('--registry',required=True); d.add_argument('--out',required=True); d.set_defaults(func=lambda a: build_data(Path(a.registry),Path(a.out)))
- s=sp.add_parser('summarize'); s.add_argument('--run',required=True); s.add_argument('--out',required=True); s.set_defaults(func=lambda a: Path(a.out).write_text('Valuation support memo\n', encoding='utf-8'))
+ s=sp.add_parser('summarize'); s.add_argument('--run',required=True); s.add_argument('--out',required=True); s.set_defaults(func=lambda a: Path(a.out).write_text(render_summary(Path(a.run)), encoding='utf-8'))
  a=p.parse_args(); a.func(a)

--- a/agialpha_valuation_support/core.py
+++ b/agialpha_valuation_support/core.py
@@ -3,6 +3,7 @@ import json, hashlib, shutil
 from pathlib import Path
 from .boundaries import boundary_fields, REQUIRED_BOUNDARY_TEXT
 from .implementation_axes import AXES
+from .validate import scan_forbidden_language
 
 FORBIDDEN = ["agi alpha is worth", "fair market value", "guaranteed valuation", "guaranteed return", "token appreciation", "securities offering", "profit rights", "ownership rights", "achieved agi", "achieved asi", "achieved superintelligence", "empirical sota", "eu ai act exempt", "legally approved worldwide", "recursive beaten"]
 
@@ -68,6 +69,9 @@ def validate(run: Path):
     miss = [n for n in needed if not (Path(run) / n).exists()]
     if miss:
         raise SystemExit("missing artifacts: " + ",".join(miss))
+    violations = scan_forbidden_language(Path(run))
+    if violations:
+        raise SystemExit("forbidden language detected: " + " | ".join(violations))
 
 def build_data(registry: Path, out: Path):
     registry = Path(registry)

--- a/agialpha_valuation_support/render.py
+++ b/agialpha_valuation_support/render.py
@@ -1,2 +1,29 @@
-def render_summary():
-    return "valuation-support summary"
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .boundaries import REQUIRED_BOUNDARY_TEXT
+
+
+def render_summary(run_dir: Path) -> str:
+    run_dir = Path(run_dir)
+    score = json.loads((run_dir / "05_implementation_equivalence_score.json").read_text(encoding="utf-8"))
+    missing = json.loads((run_dir / "10_missing_evidence.json").read_text(encoding="utf-8"))
+    tier = score.get("readiness_tier", "not_reported")
+    eq = score.get("implementation_equivalence_score", "not_reported")
+    missing_items = missing.get("missing_evidence", [])
+    lines = [
+        "# AGI ALPHA Valuation Support Memo",
+        "",
+        REQUIRED_BOUNDARY_TEXT,
+        "",
+        "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
+        "",
+        f"- Implementation equivalence score: `{eq}`",
+        f"- Readiness tier: `{tier}`",
+        "- Missing-evidence honesty:",
+    ]
+    for item in missing_items:
+        lines.append(f"  - {item}")
+    return "\n".join(lines) + "\n"

--- a/agialpha_valuation_support/validate.py
+++ b/agialpha_valuation_support/validate.py
@@ -1,1 +1,37 @@
-from .boundaries import boundary_fields
+from __future__ import annotations
+
+from pathlib import Path
+
+FORBIDDEN_PHRASES = [
+    "agi alpha is worth",
+    "fair market value",
+    "guaranteed valuation",
+    "guaranteed return",
+    "token appreciation",
+    "buy",
+    "sell",
+    "hold",
+    "profit rights",
+    "ownership rights",
+    "achieved agi",
+    "achieved asi",
+    "achieved superintelligence",
+    "empirical sota",
+    "certified",
+    "eu ai act exempt",
+    "legally approved worldwide",
+    "recursive beaten",
+]
+
+
+def scan_forbidden_language(run_dir: Path) -> list[str]:
+    violations: list[str] = []
+    run_dir = Path(run_dir)
+    for path in sorted(run_dir.iterdir()):
+        if path.suffix not in {".json", ".md"}:
+            continue
+        text = path.read_text(encoding="utf-8").lower()
+        for phrase in FORBIDDEN_PHRASES:
+            if phrase in text:
+                violations.append(f"{path.name}: {phrase}")
+    return violations

--- a/docs/_generated/valuation-support/public_comparables.json
+++ b/docs/_generated/valuation-support/public_comparables.json
@@ -12,6 +12,7 @@
       "public_recursive_eval_available": "not_reported",
       "public_replay_available": "not_reported",
       "public_technical_results_available": "not_reported",
+      "reported_category_valuation_comparable": "not_reported",
       "reported_raise_usd": 650000000,
       "reported_thesis": "AI systems that conduct experiments to safely improve themselves, identify limitations, write benchmarks, and rewrite their own codebase.",
       "reported_valuation_date": "2026-05-13",

--- a/valuation_support_registry/latest.json
+++ b/valuation_support_registry/latest.json
@@ -5,7 +5,7 @@
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "run_id": "72889195f6e9",
-  "run_ref": "runs/72889195f6e9",
+  "run_id": "4f38948dd141",
+  "run_ref": "runs/4f38948dd141",
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity."
 }

--- a/valuation_support_registry/registry.json
+++ b/valuation_support_registry/registry.json
@@ -7,7 +7,7 @@
   "not_an_investment_claim": true,
   "records": [
     {
-      "run_id": "72889195f6e9"
+      "run_id": "4f38948dd141"
     }
   ],
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity."


### PR DESCRIPTION
### Motivation
- Replace placeholder summarization and weak validation with deterministic, non‑promissory dossier outputs that surface implementation-side evidence and enforce claim boundaries.
- Ensure generated registry and Evidence Mission Control artifacts include canonical boundary text and are validated for forbidden valuation/investment language.

### Description
- Implemented deterministic memo rendering via `agialpha_valuation_support/render.py` and wired it into the CLI `summarize` action so `python -m agialpha_valuation_support summarize --run <run> --out <file>` produces a real memo including the implementation equivalence score, readiness tier, and missing-evidence list. 
- Added forbidden-language scanning in `agialpha_valuation_support/validate.py` and integrated the check into the core `validate` flow in `agialpha_valuation_support/core.py`, causing validation to fail when outputs contain disallowed valuation/investment/token/AGI overclaim phrases.
- Updated CLI wiring in `agialpha_valuation_support/cli.py` to call the new `render_summary` function for `summarize`.
- Build now emits deterministic dossier artifacts and updates the `valuation_support_registry` run pointers, and a generated `public_comparables.json` was refreshed to include the required boundary fields.

### Testing
- Ran `python -m agialpha_valuation_support build` and confirmed run artifacts were produced and copied into `valuation_support_registry` successfully (build completed). (success)
- Ran `python -m agialpha_valuation_support validate --run /tmp/valuation-support-test` and confirmed validation passed when outputs complied and rejected runs containing forbidden phrases (validation exercised and enforced). (success)
- Ran `python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support` and verified generated data files were written. (success)
- Ran the full test suite with `python -m unittest discover -s tests` and all tests passed. (434 tests, OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077c8ec7c88333b18ef96360659245)