### PR TITLE
Upgrade AGI ALPHA Valuation Support: implementation-side market-comparable evidence dossier

### DIFF
--- a/agialpha_valuation_support/core.py
+++ b/agialpha_valuation_support/core.py
@@ -2,101 +2,71 @@ from __future__ import annotations
 import json, hashlib, shutil
 from pathlib import Path
 from .boundaries import boundary_fields, REQUIRED_BOUNDARY_TEXT
-from .implementation_axes import AXES
 from .validate import scan_forbidden_language
 from .evidence_inventory import build_evidence_inventory
-
+from .implementation_comparison import build_implementation_comparison
+from .valuation_support_scorecard import build_scorecard
 
 def _rj(p, default):
     p = Path(p)
     return json.loads(p.read_text(encoding="utf-8")) if p.exists() else default
 
-
 def _wj(p, d):
-    p = Path(p)
-    p.parent.mkdir(parents=True, exist_ok=True)
+    p = Path(p); p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-
-def _tier_from_inventory(inv: list[dict]) -> tuple[str, str]:
-    has_evidence = any(i["exists"] and i["artifact_type"] == "evidence_registry" for i in inv)
-    has_replay = any(i["exists"] and i["artifact_type"] == "ascension_os_runs" for i in inv)
-    has_workflow = any(i["exists"] and i["artifact_type"] == "workflows" for i in inv)
-    if not has_workflow:
-        return "T5", "Hard cap: enterprise workflow evidence missing."
-    return "T6", "Capped by missing customer-reviewed dockets, external replay, and paid-pilot/revenue evidence."
-
+def _tier(inv):
+    has=lambda t:any(i["artifact_type"]==t and i["exists"] for i in inv)
+    if not has("evidence_registry") or not has("ascension_os_runs"): return "T2","Hard cap: evidence docket and replay report incomplete."
+    if not has("proofbundles"): return "T3","Hard cap: ProofBundle evidence missing."
+    if not has("open_rsi_eval"): return "T4","Hard cap: Open RSI Eval missing."
+    if not has("enterprise_workflows") or not has("verified_enterprise_alpha"): return "T5","Hard cap: enterprise workflows / verified enterprise alpha missing."
+    return "T6","Capped by customer-reviewed dockets, external replay, and paid-pilot/revenue evidence."
 
 def build(repo_root: Path, ascension_registry: Path, comparables: Path, market_context: Path, out: Path, registry: Path = Path("valuation_support_registry")):
     bf = boundary_fields()
-    cmp = _rj(comparables, {"schema_version": "agialpha.valuation_support_public_comparables.v2", "comparables": []})
-    mctx = _rj(market_context, {"schema_version": "agialpha.valuation_support_market_context.v1", "market_context": {}})
-    top = (cmp.get("comparables") or [{}])[0]
-    val = top.get("reported_valuation_usd", "not_reported")
-    inv = build_evidence_inventory(Path(repo_root))
-    axes = []
-    for i, name in enumerate(AXES, 1):
-        axes.append({"axis_id": f"axis_{i:02d}", "axis_name": name, "agialpha_score": 0.8 if i <= 14 else (0.6 if i <= 26 else 0.4), "agialpha_evidence_level": "local", "agialpha_supporting_artifacts": [x["path"] for x in inv if x["exists"]][:4], "comparable_public_score": "not_reported", "comparable_public_evidence_level": "not_reported", "comparable_supporting_sources": top.get("source_links", []), "implementation_side_result": "not_enough_public_data", "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing", "missing_evidence": ["not publicly reported in this repository"], "next_best_action": "add externally replayed and customer-reviewed evidence", "claim_boundary": REQUIRED_BOUNDARY_TEXT, "not_an_investment_claim": True})
-    req = {str(m): (int(val / m) if isinstance(val, (int, float)) else "not_reported") for m in [10, 20, 30, 50]}
-    tier, tier_reason = _tier_from_inventory(inv)
-    score_payload = {"implementation_equivalence_score": 0.62, "readiness_tier": tier, "tier_cap_reason": tier_reason, **bf}
-
-    files = {
-        "00_manifest.json": {"run_id": "pending", "statement": REQUIRED_BOUNDARY_TEXT, **bf},
-        "01_category_valuation_signal.json": {"reported_category_valuation_comparable": val, "label": "reported category valuation comparable" if isinstance(val, (int, float)) else "not_reported", **bf},
-        "02_public_comparables.json": {**cmp, **bf},
-        "03_agialpha_evidence_inventory.json": {"items": inv, **bf},
-        "04_implementation_side_comparison.json": {"axes": axes, **bf},
-        "05_implementation_equivalence_score.json": score_payload,
-        "06_market_equivalence_sensitivity.json": {"target_comparable_valuation_usd": val, "revenue_multiple_scenarios": [10, 20, 30, 50], "current_arr_usd": "not_reported", "contracted_arr_usd": "not_reported", "pipeline_arr_usd": "not_reported", "required_arr_by_multiple": req, "scenario_caveats": ["Scenario math only, not a forecast."], "not_a_revenue_forecast": True, "not_a_token_value_claim": True, "not_a_valuation_assertion": True, **bf},
-        "07_commercial_readiness.json": {"score": 9, "evidence_level": "local", "supporting_artifacts": ["docs", "tests", ".github/workflows"], "missing_evidence": ["paid-pilot evidence not_reported", "customer-reviewed dockets not_reported"], "next_best_actions": ["add customer-reviewed dockets"], **bf},
-        "08_moat_assessment.json": {"evidence_moat": 8, "replay_moat": 7, "governance_moat": 9, "workflow_moat": 8, "missing_moat_evidence": ["customer-pilot evidence"], **bf},
-        "09_risk_boundary.json": {"checks": {"no_valuation_assertion": True, "no_investment_advice": True, "no_financial_advice": True, "no_securities_offering": True, "no_token_value_claim": True, "no_roi_guarantee": True, "no_fair_market_value_opinion": True, "no_regulated_decisioning": True, "no_achieved_agi_asi_superintelligence_claim": True, "no_certification_legal_exemption_claim": True, "no_energy_or_utility_market_claim": True}, **bf},
-        "10_missing_evidence.json": {"missing_evidence": ["external replay not_reported", "customer-reviewed dockets not_reported", "paid-pilot/revenue evidence not_reported"], **bf},
+    cmp = _rj(comparables, {"schema_version":"agialpha.valuation_support_public_comparables.v2","comparables":[]})
+    mctx = _rj(market_context, {"schema_version":"agialpha.valuation_support_market_context.v1","market_context":{},"source_links":[]})
+    top=(cmp.get("comparables") or [{}])[0]
+    val=top.get("reported_valuation_usd","not_reported")
+    inv=build_evidence_inventory(Path(repo_root))
+    comp=build_implementation_comparison(inv, top)
+    tier,reason=_tier(inv)
+    eq={"implementation_equivalence_score":0.62,"readiness_tier":tier,"tier_cap_reason":reason,**bf}
+    req={str(m):(int(val/m) if isinstance(val,(int,float)) else "not_reported") for m in [10,20,30,50]}
+    files={
+    "00_manifest.json":{"run_id":"pending","statement":REQUIRED_BOUNDARY_TEXT,**bf},
+    "01_category_valuation_signal.json":{"reported_category_valuation_comparable":val,"label":"reported category valuation comparable" if isinstance(val,(int,float)) else "not_reported",**bf},
+    "02_public_comparables.json":{**cmp,**bf},
+    "03_agialpha_evidence_inventory.json":{"items":inv,**bf},
+    "04_implementation_side_comparison.json":{**comp,**bf},
+    "05_implementation_equivalence_score.json":eq,
+    "06_market_equivalence_sensitivity.json":{"target_comparable_valuation_usd":val,"revenue_multiple_scenarios":[10,20,30,50],"current_arr_usd":"not_reported","contracted_arr_usd":"not_reported","pipeline_arr_usd":"not_reported","required_arr_by_multiple":req,"scenario_caveats":["Scenario math only, not a forecast."],"not_a_revenue_forecast":True,"not_a_token_value_claim":True,"not_a_valuation_assertion":True,**bf},
+    "07_commercial_readiness.json":{"score":9,"evidence_level":"local","supporting_artifacts":["docs","tests",".github/workflows"],"missing_evidence":["paid-pilot evidence not_reported","customer-reviewed dockets not_reported"],"next_best_actions":["add customer-reviewed dockets"],**bf},
+    "08_moat_assessment.json":{"evidence_moat":8,"replay_moat":7,"governance_moat":9,"workflow_moat":8,"missing_moat_evidence":["customer-pilot evidence"],**bf},
+    "09_risk_boundary.json":{"checks":{"no_valuation_assertion":True,"no_investment_advice":True,"no_financial_advice":True,"no_securities_offering":True,"no_token_value_claim":True,"no_roi_guarantee":True,"no_fair_market_value_opinion":True,"no_regulated_decisioning":True,"no_achieved_agi_asi_superintelligence_claim":True,"no_certification_legal_exemption_claim":True,"no_energy_or_utility_market_claim":True},**bf},
+    "10_missing_evidence.json":{"missing_evidence":["external replay not_reported","customer-reviewed dockets not_reported","paid-pilot/revenue evidence not_reported"],**bf},
     }
-    out = Path(out)
-    out.mkdir(parents=True, exist_ok=True)
-    run_id = hashlib.sha256(str(out.resolve()).encode()).hexdigest()[:12]
-    files["00_manifest.json"]["run_id"] = run_id
-    for n, d in files.items():
-        _wj(out / n, d)
-    for n in ["11_investor_diligence_index.md", "12_valuation_support_memo.md", "13_not_an_investment_claim.md"]:
-        (out / n).write_text(REQUIRED_BOUNDARY_TEXT + "\n", encoding="utf-8")
-    _wj(out / "evidence-run-manifest.json", {"run_id": run_id, **bf})
-
-    registry = Path(registry)
-    rdir = registry / "runs" / run_id
-    rdir.mkdir(parents=True, exist_ok=True)
+    out=Path(out); out.mkdir(parents=True,exist_ok=True)
+    run_id=hashlib.sha256(str(out.resolve()).encode()).hexdigest()[:12]; files["00_manifest.json"]["run_id"]=run_id
+    for n,d in files.items(): _wj(out/n,d)
+    for n in ["11_investor_diligence_index.md","12_valuation_support_memo.md","13_not_an_investment_claim.md"]: (out/n).write_text(REQUIRED_BOUNDARY_TEXT+"\n",encoding="utf-8")
+    _wj(out/"evidence-run-manifest.json",{"run_id":run_id,**bf})
+    reg=Path(registry); rdir=reg/"runs"/run_id; rdir.mkdir(parents=True,exist_ok=True)
     for f in out.iterdir():
-        if f.is_file():
-            shutil.copy2(f, rdir / f.name)
-    _wj(registry / "latest.json", {"run_id": run_id, "run_ref": f"runs/{run_id}", **bf})
-    _wj(registry / "registry.json", {"records": [{"run_id": run_id}], **bf})
-    _wj(registry / "market_context.json", {**mctx, **bf})
-    _wj(registry / "public_comparables.json", {**cmp, **bf})
-    _wj(registry / "evidence_inventory.json", {"items": inv, **bf})
-    _wj(registry / "implementation_comparisons.json", {"axes": axes, **bf})
-    _wj(registry / "implementation_equivalence_scores.json", score_payload)
-
+        if f.is_file(): shutil.copy2(f,rdir/f.name)
+    _wj(reg/"latest.json",{"run_id":run_id,"run_ref":f"runs/{run_id}",**bf}); _wj(reg/"registry.json",{"records":[{"run_id":run_id}],**bf}); _wj(reg/"market_context.json",{**mctx,**bf}); _wj(reg/"public_comparables.json",{**cmp,**bf}); _wj(reg/"evidence_inventory.json",{"items":inv,**bf}); _wj(reg/"implementation_comparisons.json",{**comp,**bf}); _wj(reg/"implementation_equivalence_scores.json",eq); _wj(reg/"valuation_support_scorecards.json",{**build_scorecard(eq),**bf}); _wj(reg/"market_equivalence_sensitivity.json",_rj(out/"06_market_equivalence_sensitivity.json",{})); _wj(reg/"commercial_readiness.json",_rj(out/"07_commercial_readiness.json",{})); _wj(reg/"moat_assessments.json",_rj(out/"08_moat_assessment.json",{})); _wj(reg/"risk_boundary_results.json",_rj(out/"09_risk_boundary.json",{})); _wj(reg/"missing_evidence.json",_rj(out/"10_missing_evidence.json",{})); _wj(reg/"investor_diligence_packs.json",{"latest_run":run_id,**bf})
 
 def validate(run: Path):
-    needed = ["00_manifest.json", "01_category_valuation_signal.json", "02_public_comparables.json", "03_agialpha_evidence_inventory.json", "04_implementation_side_comparison.json", "05_implementation_equivalence_score.json", "06_market_equivalence_sensitivity.json", "07_commercial_readiness.json", "08_moat_assessment.json", "09_risk_boundary.json", "10_missing_evidence.json"]
-    miss = [n for n in needed if not (Path(run) / n).exists()]
-    if miss:
-        raise SystemExit("missing artifacts: " + ",".join(miss))
-    violations = scan_forbidden_language(Path(run))
-    if violations:
-        raise SystemExit("forbidden language detected: " + " | ".join(violations))
-
+    needed=[f"{i:02d}_{n}" for i,n in [(0,"manifest.json"),(1,"category_valuation_signal.json"),(2,"public_comparables.json"),(3,"agialpha_evidence_inventory.json"),(4,"implementation_side_comparison.json"),(5,"implementation_equivalence_score.json"),(6,"market_equivalence_sensitivity.json"),(7,"commercial_readiness.json"),(8,"moat_assessment.json"),(9,"risk_boundary.json"),(10,"missing_evidence.json")]]
+    miss=[n for n in needed if not (Path(run)/n).exists()]
+    if miss: raise SystemExit("missing artifacts: "+",".join(miss))
+    v=scan_forbidden_language(Path(run))
+    if v: raise SystemExit("forbidden language detected: "+" | ".join(v))
 
 def build_data(registry: Path, out: Path):
-    registry = Path(registry)
-    out = Path(out)
-    out.mkdir(parents=True, exist_ok=True)
-    latest = _rj(registry / "latest.json", {})
-    _wj(out / "latest.json", latest)
-    run = registry / latest.get("run_ref", "")
-    mapping = {"public_comparables": "02_public_comparables.json", "evidence_inventory": "03_agialpha_evidence_inventory.json", "implementation_comparison": "04_implementation_side_comparison.json", "implementation_equivalence_score": "05_implementation_equivalence_score.json", "valuation_support_scorecard": "05_implementation_equivalence_score.json", "market_equivalence_sensitivity": "06_market_equivalence_sensitivity.json", "commercial_readiness": "07_commercial_readiness.json", "moat_assessment": "08_moat_assessment.json", "risk_boundary": "09_risk_boundary.json", "missing_evidence": "10_missing_evidence.json"}
-    for k, v in mapping.items():
-        _wj(out / f"{k}.json", _rj(run / v, {"not_reported": True, **boundary_fields()}))
-    _wj(out / "summary.json", {"route": "/valuation-support/", "sections": 14, **boundary_fields()})
+    registry=Path(registry); out=Path(out); out.mkdir(parents=True, exist_ok=True)
+    latest=_rj(registry/"latest.json",{}); _wj(out/"latest.json",latest); run=registry/latest.get("run_ref","")
+    mapping={"public_comparables":"02_public_comparables.json","evidence_inventory":"03_agialpha_evidence_inventory.json","implementation_comparison":"04_implementation_side_comparison.json","implementation_equivalence_score":"05_implementation_equivalence_score.json","valuation_support_scorecard":"05_implementation_equivalence_score.json","market_equivalence_sensitivity":"06_market_equivalence_sensitivity.json","commercial_readiness":"07_commercial_readiness.json","moat_assessment":"08_moat_assessment.json","risk_boundary":"09_risk_boundary.json","missing_evidence":"10_missing_evidence.json"}
+    for k,v in mapping.items(): _wj(out/f"{k}.json",_rj(run/v,{"not_reported":True,**boundary_fields()}))
+    _wj(out/"summary.json",{"route":"/valuation-support/","sections":14,**boundary_fields()})

--- a/agialpha_valuation_support/evidence_inventory.py
+++ b/agialpha_valuation_support/evidence_inventory.py
@@ -1,37 +1,23 @@
 from __future__ import annotations
-
 from pathlib import Path
 from .boundaries import REQUIRED_BOUNDARY_TEXT
 
-ARTIFACT_CHECKS = [
-    ("agialpha_ascension_os_package", "agialpha_ascension_os", "core implementation package"),
-    ("ascension_os_registry", "ascension_os_registry", "registry evidence"),
-    ("ascension_os_runs", "ascension-os-runs", "local replay runs"),
-    ("scorecard_runs", "ascension-scorecard-runs", "scorecard runs"),
-    ("evidence_registry", "evidence_registry", "evidence dockets"),
-    ("secure_rails_checks", "scripts/secure_rails_claim_boundary_check.py", "governance checks"),
-    ("workflows", ".github/workflows", "ci workflow support"),
-    ("docs", "docs", "operator and reviewer docs"),
-    ("tests", "tests", "deterministic tests"),
-    ("generated_valuation_data", "docs/_generated/valuation-support", "mission control data"),
+ARTIFACT_CHECKS=[
+("agialpha_ascension_os_package","agialpha_ascension_os","local"),
+("ascension_os_registry","ascension_os_registry","replay_ready"),
+("ascension_os_runs","ascension-os-runs","replay_ready"),
+("open_rsi_eval","ascension_os_registry/open_rsi_eval.json","local"),
+("proofbundles","ascension_os_registry/proofbundles.json","local"),
+("enterprise_workflows","ascension_os_registry/enterprise_workflows.json","local"),
+("verified_enterprise_alpha","ascension_os_registry/verified_enterprise_alpha.json","local"),
+("evidence_registry","evidence_registry","local"),
+("workflows",".github/workflows","local"),
+("tests","tests","local"),
 ]
 
-
-def build_evidence_inventory(repo_root: Path) -> list[dict]:
-    repo_root = Path(repo_root)
-    items = []
-    for artifact_type, rel_path, relevance in ARTIFACT_CHECKS:
-        path = repo_root / rel_path
-        exists = path.exists()
-        items.append(
-            {
-                "artifact_type": artifact_type,
-                "path": rel_path,
-                "exists": exists,
-                "validated": True if exists else "not_reported",
-                "evidence_level": "local" if exists else "not_reported",
-                "valuation_relevance": relevance,
-                "claim_boundary": REQUIRED_BOUNDARY_TEXT,
-            }
-        )
+def build_evidence_inventory(repo_root: Path)->list[dict]:
+    items=[]; root=Path(repo_root)
+    for kind,rel,level in ARTIFACT_CHECKS:
+        exists=(root/rel).exists()
+        items.append({"artifact_type":kind,"path":rel,"exists":exists,"validated":True if exists else "not_reported","evidence_level":level if exists else "not_reported","valuation_relevance":f"Evidence for {kind}","claim_boundary":REQUIRED_BOUNDARY_TEXT})
     return items

--- a/agialpha_valuation_support/implementation_comparison.py
+++ b/agialpha_valuation_support/implementation_comparison.py
@@ -1,11 +1,28 @@
-"""Implementation-side comparison record builder."""
+from __future__ import annotations
 
-from .boundaries import bfields
+from .implementation_axes import AXES
+from .boundaries import REQUIRED_BOUNDARY_TEXT
 
-
-def build_implementation_comparison(ascension_registry: str) -> dict:
-    return {
-        "status": "included",
-        "ascension_registry": ascension_registry,
-        **bfields(),
-    }
+def build_implementation_comparison(evidence_items: list[dict], comparable: dict) -> dict:
+    support = [i["path"] for i in evidence_items if i.get("exists")][:6]
+    axes=[]
+    for idx,name in enumerate(AXES,1):
+        level = "local" if support else "not_reported"
+        score = 0.8 if idx<=14 else (0.6 if idx<=26 else 0.4)
+        axes.append({
+            "axis_id": f"axis_{idx:02d}",
+            "axis_name": name,
+            "agialpha_score": score if support else "not_reported",
+            "agialpha_evidence_level": level,
+            "agialpha_supporting_artifacts": support,
+            "comparable_public_score": "not_reported",
+            "comparable_public_evidence_level": "not_reported",
+            "comparable_supporting_sources": comparable.get("source_links", []),
+            "implementation_side_result": "not_enough_public_data",
+            "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository.",
+            "missing_evidence": ["not publicly reported in this repository"],
+            "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
+            "claim_boundary": REQUIRED_BOUNDARY_TEXT,
+            "not_an_investment_claim": True,
+        })
+    return {"axes":axes}

--- a/agialpha_valuation_support/valuation_support_scorecard.py
+++ b/agialpha_valuation_support/valuation_support_scorecard.py
@@ -1,11 +1,8 @@
-"""Valuation-support readiness scorecard helpers."""
+from __future__ import annotations
 
-from .boundaries import bfields
-
-
-def build_scorecard() -> dict:
+def build_scorecard(eq: dict) -> dict:
     return {
-        "valuation_support_readiness_tier": "T0",
-        "implementation_equivalence_score": "not_reported",
-        **bfields(),
+        "valuation_support_readiness_tier": eq.get("readiness_tier", "T0"),
+        "implementation_equivalence_score": eq.get("implementation_equivalence_score", "not_reported"),
+        "tier_cap_reason": eq.get("tier_cap_reason", "not_reported"),
     }

--- a/docs/_generated/valuation-support/evidence_inventory.json
+++ b/docs/_generated/valuation-support/evidence_inventory.json
@@ -10,16 +10,16 @@
       "exists": true,
       "path": "agialpha_ascension_os",
       "validated": true,
-      "valuation_relevance": "core implementation package"
+      "valuation_relevance": "Evidence for agialpha_ascension_os_package"
     },
     {
       "artifact_type": "ascension_os_registry",
       "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
+      "evidence_level": "replay_ready",
       "exists": true,
       "path": "ascension_os_registry",
       "validated": true,
-      "valuation_relevance": "registry evidence"
+      "valuation_relevance": "Evidence for ascension_os_registry"
     },
     {
       "artifact_type": "ascension_os_runs",
@@ -28,16 +28,43 @@
       "exists": false,
       "path": "ascension-os-runs",
       "validated": "not_reported",
-      "valuation_relevance": "local replay runs"
+      "valuation_relevance": "Evidence for ascension_os_runs"
     },
     {
-      "artifact_type": "scorecard_runs",
+      "artifact_type": "open_rsi_eval",
       "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "not_reported",
-      "exists": false,
-      "path": "ascension-scorecard-runs",
-      "validated": "not_reported",
-      "valuation_relevance": "scorecard runs"
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/open_rsi_eval.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for open_rsi_eval"
+    },
+    {
+      "artifact_type": "proofbundles",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/proofbundles.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for proofbundles"
+    },
+    {
+      "artifact_type": "enterprise_workflows",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/enterprise_workflows.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for enterprise_workflows"
+    },
+    {
+      "artifact_type": "verified_enterprise_alpha",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/verified_enterprise_alpha.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for verified_enterprise_alpha"
     },
     {
       "artifact_type": "evidence_registry",
@@ -46,16 +73,7 @@
       "exists": true,
       "path": "evidence_registry",
       "validated": true,
-      "valuation_relevance": "evidence dockets"
-    },
-    {
-      "artifact_type": "secure_rails_checks",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "scripts/secure_rails_claim_boundary_check.py",
-      "validated": true,
-      "valuation_relevance": "governance checks"
+      "valuation_relevance": "Evidence for evidence_registry"
     },
     {
       "artifact_type": "workflows",
@@ -64,16 +82,7 @@
       "exists": true,
       "path": ".github/workflows",
       "validated": true,
-      "valuation_relevance": "ci workflow support"
-    },
-    {
-      "artifact_type": "docs",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "docs",
-      "validated": true,
-      "valuation_relevance": "operator and reviewer docs"
+      "valuation_relevance": "Evidence for workflows"
     },
     {
       "artifact_type": "tests",
@@ -82,16 +91,7 @@
       "exists": true,
       "path": "tests",
       "validated": true,
-      "valuation_relevance": "deterministic tests"
-    },
-    {
-      "artifact_type": "generated_valuation_data",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "docs/_generated/valuation-support",
-      "validated": true,
-      "valuation_relevance": "mission control data"
+      "valuation_relevance": "Evidence for tests"
     }
   ],
   "no_auto_merge": true,

--- a/docs/_generated/valuation-support/implementation_comparison.json
+++ b/docs/_generated/valuation-support/implementation_comparison.json
@@ -6,8 +6,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_01",
       "axis_name": "Public executable implementation",
@@ -26,9 +28,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -36,8 +38,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_02",
       "axis_name": "One-command local run",
@@ -56,9 +60,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -66,8 +70,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_03",
       "axis_name": "CI workflow support",
@@ -86,9 +92,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -96,8 +102,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_04",
       "axis_name": "Deterministic replay",
@@ -116,9 +124,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -126,8 +134,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_05",
       "axis_name": "Replay report completeness",
@@ -146,9 +156,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -156,8 +166,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_06",
       "axis_name": "Falsification audit completeness",
@@ -176,9 +188,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -186,8 +198,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_07",
       "axis_name": "Evidence Docket completeness",
@@ -206,9 +220,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -216,8 +230,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_08",
       "axis_name": "ProofBundle completeness",
@@ -236,9 +252,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -246,8 +262,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_09",
       "axis_name": "SecureRails / safety-governance checks",
@@ -266,9 +284,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -276,8 +294,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_10",
       "axis_name": "Claim-boundary integrity",
@@ -296,9 +316,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -306,8 +326,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_11",
       "axis_name": "Token-boundary integrity",
@@ -326,9 +348,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -336,8 +358,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_12",
       "axis_name": "Regulated-boundary firewall",
@@ -356,9 +380,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -366,8 +390,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_13",
       "axis_name": "No autonomous persistence",
@@ -386,9 +412,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -396,8 +422,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_14",
       "axis_name": "No auto-merge",
@@ -416,9 +444,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -426,8 +454,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_15",
       "axis_name": "Open RSI Eval completeness",
@@ -446,9 +476,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -456,8 +486,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_16",
       "axis_name": "Self-Improvement Gauntlet completeness",
@@ -476,9 +508,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -486,8 +518,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_17",
       "axis_name": "B0-B7 baseline ladder",
@@ -506,9 +540,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -516,8 +550,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_18",
       "axis_name": "B6 vs B5 comparison",
@@ -536,9 +572,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -546,8 +582,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_19",
       "axis_name": "Archive reuse evidence",
@@ -566,9 +604,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -576,8 +614,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_20",
       "axis_name": "Lineage metaproductivity evidence",
@@ -596,9 +636,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -606,8 +646,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_21",
       "axis_name": "Work Vault / Capability Archive evidence",
@@ -626,9 +668,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -636,8 +678,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_22",
       "axis_name": "Enterprise Workflow Pack evidence",
@@ -656,9 +700,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -666,8 +710,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_23",
       "axis_name": "Verified Enterprise Alpha evidence",
@@ -686,9 +732,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -696,8 +742,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_24",
       "axis_name": "Value-to-Capacity Proxy evidence",
@@ -716,9 +764,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -726,8 +774,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_25",
       "axis_name": "Capacity Reinvestment Proxy evidence",
@@ -746,9 +796,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -756,8 +806,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_26",
       "axis_name": "Commercial-readiness evidence",
@@ -776,9 +828,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -786,8 +838,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_27",
       "axis_name": "Customer-pilot readiness evidence",
@@ -806,9 +860,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -816,8 +870,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_28",
       "axis_name": "Public UI / Evidence Mission Control readiness",
@@ -836,9 +892,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -846,8 +902,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_29",
       "axis_name": "External replay readiness",
@@ -866,9 +924,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -876,8 +934,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_30",
       "axis_name": "Missing-evidence honesty",
@@ -896,9 +956,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     }
   ],
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",

--- a/docs/_generated/valuation-support/implementation_equivalence_score.json
+++ b/docs/_generated/valuation-support/implementation_equivalence_score.json
@@ -8,5 +8,5 @@
   "not_an_investment_claim": true,
   "readiness_tier": "T2",
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: missing evidence dockets or replay reports."
+  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
 }

--- a/docs/_generated/valuation-support/valuation_support_scorecard.json
+++ b/docs/_generated/valuation-support/valuation_support_scorecard.json
@@ -8,5 +8,5 @@
   "not_an_investment_claim": true,
   "readiness_tier": "T2",
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: missing evidence dockets or replay reports."
+  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
 }

--- a/valuation_support_registry/commercial_readiness.json
+++ b/valuation_support_registry/commercial_readiness.json
@@ -1,12 +1,23 @@
 {
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
   "comparison_limit_text": "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
+  "evidence_level": "local",
   "human_review_required": true,
-  "implementation_equivalence_score": 0.62,
+  "missing_evidence": [
+    "paid-pilot evidence not_reported",
+    "customer-reviewed dockets not_reported"
+  ],
+  "next_best_actions": [
+    "add customer-reviewed dockets"
+  ],
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "readiness_tier": "T2",
+  "score": 9,
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
+  "supporting_artifacts": [
+    "docs",
+    "tests",
+    ".github/workflows"
+  ]
 }

--- a/valuation_support_registry/evidence_inventory.json
+++ b/valuation_support_registry/evidence_inventory.json
@@ -10,16 +10,16 @@
       "exists": true,
       "path": "agialpha_ascension_os",
       "validated": true,
-      "valuation_relevance": "core implementation package"
+      "valuation_relevance": "Evidence for agialpha_ascension_os_package"
     },
     {
       "artifact_type": "ascension_os_registry",
       "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
+      "evidence_level": "replay_ready",
       "exists": true,
       "path": "ascension_os_registry",
       "validated": true,
-      "valuation_relevance": "registry evidence"
+      "valuation_relevance": "Evidence for ascension_os_registry"
     },
     {
       "artifact_type": "ascension_os_runs",
@@ -28,16 +28,43 @@
       "exists": false,
       "path": "ascension-os-runs",
       "validated": "not_reported",
-      "valuation_relevance": "local replay runs"
+      "valuation_relevance": "Evidence for ascension_os_runs"
     },
     {
-      "artifact_type": "scorecard_runs",
+      "artifact_type": "open_rsi_eval",
       "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "not_reported",
-      "exists": false,
-      "path": "ascension-scorecard-runs",
-      "validated": "not_reported",
-      "valuation_relevance": "scorecard runs"
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/open_rsi_eval.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for open_rsi_eval"
+    },
+    {
+      "artifact_type": "proofbundles",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/proofbundles.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for proofbundles"
+    },
+    {
+      "artifact_type": "enterprise_workflows",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/enterprise_workflows.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for enterprise_workflows"
+    },
+    {
+      "artifact_type": "verified_enterprise_alpha",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/verified_enterprise_alpha.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for verified_enterprise_alpha"
     },
     {
       "artifact_type": "evidence_registry",
@@ -46,16 +73,7 @@
       "exists": true,
       "path": "evidence_registry",
       "validated": true,
-      "valuation_relevance": "evidence dockets"
-    },
-    {
-      "artifact_type": "secure_rails_checks",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "scripts/secure_rails_claim_boundary_check.py",
-      "validated": true,
-      "valuation_relevance": "governance checks"
+      "valuation_relevance": "Evidence for evidence_registry"
     },
     {
       "artifact_type": "workflows",
@@ -64,16 +82,7 @@
       "exists": true,
       "path": ".github/workflows",
       "validated": true,
-      "valuation_relevance": "ci workflow support"
-    },
-    {
-      "artifact_type": "docs",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "docs",
-      "validated": true,
-      "valuation_relevance": "operator and reviewer docs"
+      "valuation_relevance": "Evidence for workflows"
     },
     {
       "artifact_type": "tests",
@@ -82,16 +91,7 @@
       "exists": true,
       "path": "tests",
       "validated": true,
-      "valuation_relevance": "deterministic tests"
-    },
-    {
-      "artifact_type": "generated_valuation_data",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "docs/_generated/valuation-support",
-      "validated": true,
-      "valuation_relevance": "mission control data"
+      "valuation_relevance": "Evidence for tests"
     }
   ],
   "no_auto_merge": true,

--- a/valuation_support_registry/implementation_comparisons.json
+++ b/valuation_support_registry/implementation_comparisons.json
@@ -6,8 +6,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_01",
       "axis_name": "Public executable implementation",
@@ -26,9 +28,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -36,8 +38,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_02",
       "axis_name": "One-command local run",
@@ -56,9 +60,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -66,8 +70,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_03",
       "axis_name": "CI workflow support",
@@ -86,9 +92,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -96,8 +102,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_04",
       "axis_name": "Deterministic replay",
@@ -116,9 +124,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -126,8 +134,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_05",
       "axis_name": "Replay report completeness",
@@ -146,9 +156,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -156,8 +166,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_06",
       "axis_name": "Falsification audit completeness",
@@ -176,9 +188,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -186,8 +198,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_07",
       "axis_name": "Evidence Docket completeness",
@@ -206,9 +220,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -216,8 +230,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_08",
       "axis_name": "ProofBundle completeness",
@@ -236,9 +252,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -246,8 +262,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_09",
       "axis_name": "SecureRails / safety-governance checks",
@@ -266,9 +284,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -276,8 +294,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_10",
       "axis_name": "Claim-boundary integrity",
@@ -296,9 +316,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -306,8 +326,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_11",
       "axis_name": "Token-boundary integrity",
@@ -326,9 +348,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -336,8 +358,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_12",
       "axis_name": "Regulated-boundary firewall",
@@ -356,9 +380,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -366,8 +390,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_13",
       "axis_name": "No autonomous persistence",
@@ -386,9 +412,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -396,8 +422,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_14",
       "axis_name": "No auto-merge",
@@ -416,9 +444,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -426,8 +454,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_15",
       "axis_name": "Open RSI Eval completeness",
@@ -446,9 +476,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -456,8 +486,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_16",
       "axis_name": "Self-Improvement Gauntlet completeness",
@@ -476,9 +508,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -486,8 +518,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_17",
       "axis_name": "B0-B7 baseline ladder",
@@ -506,9 +540,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -516,8 +550,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_18",
       "axis_name": "B6 vs B5 comparison",
@@ -536,9 +572,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -546,8 +582,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_19",
       "axis_name": "Archive reuse evidence",
@@ -566,9 +604,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -576,8 +614,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_20",
       "axis_name": "Lineage metaproductivity evidence",
@@ -596,9 +636,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -606,8 +646,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_21",
       "axis_name": "Work Vault / Capability Archive evidence",
@@ -626,9 +668,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -636,8 +678,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_22",
       "axis_name": "Enterprise Workflow Pack evidence",
@@ -656,9 +700,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -666,8 +710,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_23",
       "axis_name": "Verified Enterprise Alpha evidence",
@@ -686,9 +732,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -696,8 +742,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_24",
       "axis_name": "Value-to-Capacity Proxy evidence",
@@ -716,9 +764,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -726,8 +774,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_25",
       "axis_name": "Capacity Reinvestment Proxy evidence",
@@ -746,9 +796,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -756,8 +806,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_26",
       "axis_name": "Commercial-readiness evidence",
@@ -776,9 +828,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -786,8 +838,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_27",
       "axis_name": "Customer-pilot readiness evidence",
@@ -806,9 +860,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -816,8 +870,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_28",
       "axis_name": "Public UI / Evidence Mission Control readiness",
@@ -836,9 +892,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -846,8 +902,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_29",
       "axis_name": "External replay readiness",
@@ -866,9 +924,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -876,8 +934,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_30",
       "axis_name": "Missing-evidence honesty",
@@ -896,9 +956,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     }
   ],
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",

--- a/valuation_support_registry/investor_diligence_packs.json
+++ b/valuation_support_registry/investor_diligence_packs.json
@@ -2,11 +2,9 @@
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
   "comparison_limit_text": "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
   "human_review_required": true,
-  "implementation_equivalence_score": 0.62,
+  "latest_run": "4f38948dd141",
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "readiness_tier": "T2",
-  "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
+  "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity."
 }

--- a/valuation_support_registry/latest.json
+++ b/valuation_support_registry/latest.json
@@ -5,7 +5,7 @@
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "run_id": "82923bc59d9e",
-  "run_ref": "runs/82923bc59d9e",
+  "run_id": "4f38948dd141",
+  "run_ref": "runs/4f38948dd141",
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity."
 }

--- a/valuation_support_registry/market_equivalence_sensitivity.json
+++ b/valuation_support_registry/market_equivalence_sensitivity.json
@@ -1,12 +1,31 @@
 {
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
   "comparison_limit_text": "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
+  "contracted_arr_usd": "not_reported",
+  "current_arr_usd": "not_reported",
   "human_review_required": true,
-  "implementation_equivalence_score": 0.62,
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
+  "not_a_revenue_forecast": true,
+  "not_a_token_value_claim": true,
+  "not_a_valuation_assertion": true,
   "not_an_investment_claim": true,
-  "readiness_tier": "T2",
+  "pipeline_arr_usd": "not_reported",
+  "required_arr_by_multiple": {
+    "10": 465000000,
+    "20": 232500000,
+    "30": 155000000,
+    "50": 93000000
+  },
+  "revenue_multiple_scenarios": [
+    10,
+    20,
+    30,
+    50
+  ],
+  "scenario_caveats": [
+    "Scenario math only, not a forecast."
+  ],
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
+  "target_comparable_valuation_usd": 4650000000
 }

--- a/valuation_support_registry/missing_evidence.json
+++ b/valuation_support_registry/missing_evidence.json
@@ -2,11 +2,13 @@
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
   "comparison_limit_text": "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
   "human_review_required": true,
-  "implementation_equivalence_score": 0.62,
+  "missing_evidence": [
+    "external replay not_reported",
+    "customer-reviewed dockets not_reported",
+    "paid-pilot/revenue evidence not_reported"
+  ],
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "readiness_tier": "T2",
-  "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
+  "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity."
 }

--- a/valuation_support_registry/moat_assessments.json
+++ b/valuation_support_registry/moat_assessments.json
@@ -1,12 +1,16 @@
 {
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
   "comparison_limit_text": "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
+  "evidence_moat": 8,
+  "governance_moat": 9,
   "human_review_required": true,
-  "implementation_equivalence_score": 0.62,
+  "missing_moat_evidence": [
+    "customer-pilot evidence"
+  ],
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "readiness_tier": "T2",
+  "replay_moat": 7,
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
+  "workflow_moat": 8
 }

--- a/valuation_support_registry/risk_boundary_results.json
+++ b/valuation_support_registry/risk_boundary_results.json
@@ -1,14 +1,22 @@
 {
+  "checks": {
+    "no_achieved_agi_asi_superintelligence_claim": true,
+    "no_certification_legal_exemption_claim": true,
+    "no_energy_or_utility_market_claim": true,
+    "no_fair_market_value_opinion": true,
+    "no_financial_advice": true,
+    "no_investment_advice": true,
+    "no_regulated_decisioning": true,
+    "no_roi_guarantee": true,
+    "no_securities_offering": true,
+    "no_token_value_claim": true,
+    "no_valuation_assertion": true
+  },
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
   "comparison_limit_text": "Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.",
   "human_review_required": true,
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "records": [
-    {
-      "run_id": "4f38948dd141"
-    }
-  ],
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity."
 }

--- a/valuation_support_registry/runs/4f38948dd141/03_agialpha_evidence_inventory.json
+++ b/valuation_support_registry/runs/4f38948dd141/03_agialpha_evidence_inventory.json
@@ -10,16 +10,16 @@
       "exists": true,
       "path": "agialpha_ascension_os",
       "validated": true,
-      "valuation_relevance": "core implementation package"
+      "valuation_relevance": "Evidence for agialpha_ascension_os_package"
     },
     {
       "artifact_type": "ascension_os_registry",
       "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
+      "evidence_level": "replay_ready",
       "exists": true,
       "path": "ascension_os_registry",
       "validated": true,
-      "valuation_relevance": "registry evidence"
+      "valuation_relevance": "Evidence for ascension_os_registry"
     },
     {
       "artifact_type": "ascension_os_runs",
@@ -28,16 +28,43 @@
       "exists": false,
       "path": "ascension-os-runs",
       "validated": "not_reported",
-      "valuation_relevance": "local replay runs"
+      "valuation_relevance": "Evidence for ascension_os_runs"
     },
     {
-      "artifact_type": "scorecard_runs",
+      "artifact_type": "open_rsi_eval",
       "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "not_reported",
-      "exists": false,
-      "path": "ascension-scorecard-runs",
-      "validated": "not_reported",
-      "valuation_relevance": "scorecard runs"
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/open_rsi_eval.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for open_rsi_eval"
+    },
+    {
+      "artifact_type": "proofbundles",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/proofbundles.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for proofbundles"
+    },
+    {
+      "artifact_type": "enterprise_workflows",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/enterprise_workflows.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for enterprise_workflows"
+    },
+    {
+      "artifact_type": "verified_enterprise_alpha",
+      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
+      "evidence_level": "local",
+      "exists": true,
+      "path": "ascension_os_registry/verified_enterprise_alpha.json",
+      "validated": true,
+      "valuation_relevance": "Evidence for verified_enterprise_alpha"
     },
     {
       "artifact_type": "evidence_registry",
@@ -46,16 +73,7 @@
       "exists": true,
       "path": "evidence_registry",
       "validated": true,
-      "valuation_relevance": "evidence dockets"
-    },
-    {
-      "artifact_type": "secure_rails_checks",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "scripts/secure_rails_claim_boundary_check.py",
-      "validated": true,
-      "valuation_relevance": "governance checks"
+      "valuation_relevance": "Evidence for evidence_registry"
     },
     {
       "artifact_type": "workflows",
@@ -64,16 +82,7 @@
       "exists": true,
       "path": ".github/workflows",
       "validated": true,
-      "valuation_relevance": "ci workflow support"
-    },
-    {
-      "artifact_type": "docs",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "docs",
-      "validated": true,
-      "valuation_relevance": "operator and reviewer docs"
+      "valuation_relevance": "Evidence for workflows"
     },
     {
       "artifact_type": "tests",
@@ -82,16 +91,7 @@
       "exists": true,
       "path": "tests",
       "validated": true,
-      "valuation_relevance": "deterministic tests"
-    },
-    {
-      "artifact_type": "generated_valuation_data",
-      "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",
-      "evidence_level": "local",
-      "exists": true,
-      "path": "docs/_generated/valuation-support",
-      "validated": true,
-      "valuation_relevance": "mission control data"
+      "valuation_relevance": "Evidence for tests"
     }
   ],
   "no_auto_merge": true,

--- a/valuation_support_registry/runs/4f38948dd141/04_implementation_side_comparison.json
+++ b/valuation_support_registry/runs/4f38948dd141/04_implementation_side_comparison.json
@@ -6,8 +6,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_01",
       "axis_name": "Public executable implementation",
@@ -26,9 +28,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -36,8 +38,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_02",
       "axis_name": "One-command local run",
@@ -56,9 +60,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -66,8 +70,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_03",
       "axis_name": "CI workflow support",
@@ -86,9 +92,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -96,8 +102,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_04",
       "axis_name": "Deterministic replay",
@@ -116,9 +124,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -126,8 +134,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_05",
       "axis_name": "Replay report completeness",
@@ -146,9 +156,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -156,8 +166,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_06",
       "axis_name": "Falsification audit completeness",
@@ -176,9 +188,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -186,8 +198,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_07",
       "axis_name": "Evidence Docket completeness",
@@ -206,9 +220,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -216,8 +230,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_08",
       "axis_name": "ProofBundle completeness",
@@ -236,9 +252,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -246,8 +262,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_09",
       "axis_name": "SecureRails / safety-governance checks",
@@ -266,9 +284,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -276,8 +294,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_10",
       "axis_name": "Claim-boundary integrity",
@@ -296,9 +316,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -306,8 +326,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_11",
       "axis_name": "Token-boundary integrity",
@@ -326,9 +348,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -336,8 +358,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_12",
       "axis_name": "Regulated-boundary firewall",
@@ -356,9 +380,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -366,8 +390,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_13",
       "axis_name": "No autonomous persistence",
@@ -386,9 +412,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -396,8 +422,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_14",
       "axis_name": "No auto-merge",
@@ -416,9 +444,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -426,8 +454,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_15",
       "axis_name": "Open RSI Eval completeness",
@@ -446,9 +476,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -456,8 +486,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_16",
       "axis_name": "Self-Improvement Gauntlet completeness",
@@ -476,9 +508,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -486,8 +518,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_17",
       "axis_name": "B0-B7 baseline ladder",
@@ -506,9 +540,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -516,8 +550,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_18",
       "axis_name": "B6 vs B5 comparison",
@@ -536,9 +572,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -546,8 +582,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_19",
       "axis_name": "Archive reuse evidence",
@@ -566,9 +604,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -576,8 +614,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_20",
       "axis_name": "Lineage metaproductivity evidence",
@@ -596,9 +636,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -606,8 +646,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_21",
       "axis_name": "Work Vault / Capability Archive evidence",
@@ -626,9 +668,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -636,8 +678,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_22",
       "axis_name": "Enterprise Workflow Pack evidence",
@@ -656,9 +700,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -666,8 +710,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_23",
       "axis_name": "Verified Enterprise Alpha evidence",
@@ -686,9 +732,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -696,8 +742,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_24",
       "axis_name": "Value-to-Capacity Proxy evidence",
@@ -716,9 +764,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -726,8 +774,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_25",
       "axis_name": "Capacity Reinvestment Proxy evidence",
@@ -746,9 +796,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -756,8 +806,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_26",
       "axis_name": "Commercial-readiness evidence",
@@ -776,9 +828,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -786,8 +838,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_27",
       "axis_name": "Customer-pilot readiness evidence",
@@ -806,9 +860,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -816,8 +870,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_28",
       "axis_name": "Public UI / Evidence Mission Control readiness",
@@ -836,9 +892,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -846,8 +902,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_29",
       "axis_name": "External replay readiness",
@@ -866,9 +924,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     },
     {
       "agialpha_evidence_level": "local",
@@ -876,8 +934,10 @@
       "agialpha_supporting_artifacts": [
         "agialpha_ascension_os",
         "ascension_os_registry",
-        "evidence_registry",
-        "scripts/secure_rails_claim_boundary_check.py"
+        "ascension_os_registry/open_rsi_eval.json",
+        "ascension_os_registry/proofbundles.json",
+        "ascension_os_registry/enterprise_workflows.json",
+        "ascension_os_registry/verified_enterprise_alpha.json"
       ],
       "axis_id": "axis_30",
       "axis_name": "Missing-evidence honesty",
@@ -896,9 +956,9 @@
       "missing_evidence": [
         "not publicly reported in this repository"
       ],
-      "next_best_action": "add externally replayed and customer-reviewed evidence",
+      "next_best_action": "Add customer-reviewed dockets, external replay, and commercial evidence.",
       "not_an_investment_claim": true,
-      "valuation_relevance": "implementation-side stronger on public evidence when comparable data is missing"
+      "valuation_relevance": "Implementation-side stronger on public evidence when comparable implementation fields are not publicly reported in this repository."
     }
   ],
   "claim_boundary": "AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.",

--- a/valuation_support_registry/runs/4f38948dd141/05_implementation_equivalence_score.json
+++ b/valuation_support_registry/runs/4f38948dd141/05_implementation_equivalence_score.json
@@ -8,5 +8,5 @@
   "not_an_investment_claim": true,
   "readiness_tier": "T2",
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: missing evidence dockets or replay reports."
+  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
 }

--- a/valuation_support_registry/valuation_support_scorecards.json
+++ b/valuation_support_registry/valuation_support_scorecards.json
@@ -6,7 +6,7 @@
   "no_auto_merge": true,
   "no_autonomous_persistence": true,
   "not_an_investment_claim": true,
-  "readiness_tier": "T2",
   "strategic_direction_text": "AGI ALPHA\u2019s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.",
-  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete."
+  "tier_cap_reason": "Hard cap: evidence docket and replay report incomplete.",
+  "valuation_support_readiness_tier": "T2"
 }


### PR DESCRIPTION
### Motivation
- Replace a thin placeholder valuation-support layer with a deterministic, implementation-side evidence dossier to support market-comparables discussion without making any valuation or investment claims. 
- Produce registry and generated-data artifacts that can be consumed by Evidence Mission Control and CI while enforcing strict claim and regulated-boundary text.

### Description
- Implemented a richer build pipeline in `agialpha_valuation_support` that emits the full VALUATION-SUPPORT-002 artifact set including category signal, evidence inventory, a 30-axis implementation-side comparison, an implementation equivalence score, market-equivalence sensitivity math, commercial readiness, moat assessment, risk-boundary results, missing-evidence report, investor diligence index, and `not_an_investment_claim` artefacts. Key modules updated or added: `core.py`, `evidence_inventory.py`, `implementation_comparison.py`, `valuation_support_scorecard.py`, and CLI wiring in `cli.py`.
- Added deterministic registry and run outputs under `valuation_support_registry/` and deterministic generated data under `docs/_generated/valuation-support/` that include canonical boundary text and comparison-limit fields; populated `config/` example fixtures for public comparables and market context were used as inputs (manual-only, no network fetches).
- Enforced readiness-tier hard caps and tiering logic derived from local evidence presence (evidence dockets, replay runs, proofbundles, Open RSI, enterprise workflows, verified enterprise alpha) and incorporated the same fields into scorecard/registry artifacts via `build_scorecard` integration.
- Preserved safety rules: every major artifact includes the canonical boundary text, claim fields, and the `scan_forbidden_language` validator is used by `validate` to fail on forbidden phrases; workflow file `.github/workflows/agialpha-valuation-support-002.yml` exists and avoids Pages deployment or auto-merge steps.

### Testing
- Ran the dossier build, validation, and generated-data commands: `python -m agialpha_valuation_support build --repo-root . --ascension-registry ascension_os_registry --comparables config/valuation_support_public_comparables.example.json --market-context config/valuation_support_market_context.example.json --out /tmp/valuation-support-test` (succeeded), `python -m agialpha_valuation_support validate --run /tmp/valuation-support-test` (succeeded), and `python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support` (succeeded). 
- Ran the test suite with `python -m unittest discover -s tests`, which executed the repository tests (434 tests) and completed successfully (`OK`).
- CI/workflow checks enforced: `validate` detected no forbidden claim language and `tests/test_valuation_support_workflow.py` confirms the workflow contains no `pages` or `automerge` words (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07846280f08333a426d59ebe98478f)