### PR TITLE
Upgrade AGI ALPHA Valuation Support: implementation-side market-comparable evidence dossier

### DIFF
--- a/.github/workflows/agialpha-valuation-support-002.yml
+++ b/.github/workflows/agialpha-valuation-support-002.yml
@@ -1,11 +1,14 @@
 name: AGI ALPHA Valuation Support 002 / Implementation-Side Dossier
+
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * 1'
+
 permissions:
   contents: read
   actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,11 +17,25 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: python scripts/secure_rails_claim_boundary_check.py
-      - run: python -m agialpha_valuation_support build --repo-root . --ascension-registry ascension_os_registry --comparables config/valuation_support_public_comparables.example.json --market-context config/valuation_support_market_context.example.json --out valuation-support-runs/test
-      - run: python -m agialpha_valuation_support validate --run valuation-support-runs/test
-      - run: python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support
-      - uses: actions/upload-artifact@v4
+      - name: SecureRails checks
+        run: |
+          python scripts/secure_rails_claim_boundary_check.py
+          python scripts/secure_rails_human_review_check.py
+      - name: Ascension OS validation (if available)
+        run: |
+          if [ -f ascension_os_registry/latest.json ]; then
+            python -m agialpha_ascension_os validate --run "$(jq -r '.run_ref // empty' ascension_os_registry/latest.json)" || true
+          fi
+      - name: Build valuation support dossier
+        run: python -m agialpha_valuation_support build --repo-root . --ascension-registry ascension_os_registry --comparables config/valuation_support_public_comparables.example.json --market-context config/valuation_support_market_context.example.json --out valuation-support-runs/test
+      - name: Validate no investment/token/valuation overclaims
+        run: python -m agialpha_valuation_support validate --run valuation-support-runs/test
+      - name: Validate regulated-boundary firewall
+        run: python scripts/secure_rails_use_case_triage_check.py
+      - name: Build generated data
+        run: python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support
+      - name: Upload valuation-support dossier artifact
+        uses: actions/upload-artifact@v4
         with:
           name: valuation-support-dossier
           path: valuation-support-runs/test


### PR DESCRIPTION
### Motivation
- Harden the VALUATION-SUPPORT-002 workflow and align the repo with the Implementation-Side Dossier requirements so builds are deterministic, human-review guarded, and do not auto-deploy or auto-merge. 
- Provide an explicit CI job that runs SecureRails boundary checks, optional Ascension OS validation, the valuation-support build/validate/build-data pipeline, and uploads the dossier artifact.
- AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.
- Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.
- AGI ALPHA’s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim.

### Description
- Updated workflow `.github/workflows/agialpha-valuation-support-002.yml` to add a SecureRails check step (claim-boundary and human-review checks), conditional Ascension OS validation, explicit `agialpha_valuation_support` `build`/`validate`/`build-data` steps, a regulated-boundary triage check, and artifact upload, while keeping read-only permissions and no Pages or auto-merge behavior. 
- Ensured the Ascension OS validation runs only when `ascension_os_registry/latest.json` exists and will not fail the job (`|| true` / conditional invocation). 
- Left dossier generation and registry-copy behavior deterministic and CI-friendly by invoking the package CLI (`python -m agialpha_valuation_support ...`) rather than network calls or external lookups. 

### Testing
- Ran the dossier pipeline locally with `python -m agialpha_valuation_support build --repo-root . --ascension-registry ascension_os_registry --comparables config/valuation_support_public_comparables.example.json --market-context config/valuation_support_market_context.example.json --out /tmp/valuation-support-test` and it completed successfully. 
- Validated the run with `python -m agialpha_valuation_support validate --run /tmp/valuation-support-test` and generated site data with `python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support`, all successful. 
- Executed unit and workflow tests including `python -m unittest discover -s tests` and `pytest -q tests/test_valuation_support_workflow.py tests/test_valuation_support_validate.py tests/test_valuation_support_build.py`, and the invoked tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079f2dd200833385648f34289ee0e8)