### PR TITLE
Upgrade AGI ALPHA Valuation Support: implementation-side market-comparable evidence dossier

### DIFF
--- a/README_VALUATION_SUPPORT.md
+++ b/README_VALUATION_SUPPORT.md
@@ -1,13 +1,42 @@
 # AGI ALPHA Valuation Support 002
 
-AGI ALPHA valuation support is an implementation-side evidence dossier for valuation-comparable discussion.
+AGI ALPHA VALUATION-SUPPORT-002 is a deterministic, implementation-side evidence dossier for valuation-comparable discussion.
 
-It is not a valuation assertion, investment advice, financial advice, securities offering, token-value claim, guarantee of return, or fair-market-value opinion.
+## What this is
+- A **public implementation evidence organizer** built from repository-local artifacts and manually provided public comparables.
+- A **diligence artifact**: evidence inventory, implementation-side comparison, readiness tiering, market-equivalence scenario math, commercial-readiness, moat signals, and risk boundaries.
+- A **missing-evidence-honest** system: absent data is shown as `not_reported`, `pending`, `unavailable`, or `skipped_with_reason`.
 
-## Canonical boundary
+## What this is not
+- Not a valuation assertion.
+- Not investment advice, financial advice, securities advice, legal advice, or tax advice.
+- Not a token-value claim, return guarantee, fair-market-value opinion, or fundraising recommendation.
+
+## Canonical boundary (required)
 AGI ALPHA does not assert a valuation. This dossier organizes implementation-side evidence that may support a valuation-comparable discussion. It is not investment advice, financial advice, a securities offering, a token-value claim, a guarantee of return, or a fair-market-value opinion.
 
-## Local commands
+Any comparison to private self-improving-AI labs is limited to public implementation-side evidence available in this repository and manually entered public comparables. Missing external data is shown as not_reported.
+
+AGI ALPHA’s long-horizon superintelligence / Kardashev / value-to-energy framing is a strategic direction, not a present achievement claim. Near-term valuation support must be based only on verified work, replay, Evidence Dockets, ProofBundles, Work Vaults, enterprise workflow evidence, customer-reviewed dockets if available, commercial-readiness evidence, and governance integrity.
+
+## Why implementation-side evidence matters
+Valuation-comparable discussion is only defensible when grounded in reproducible implementation evidence (runs, replay, audits, dockets, proofs, governance checks), not narrative claims.
+
+## Public comparable handling
+- The fixture `config/valuation_support_public_comparables.example.json` contains manually entered comparable data.
+- The default sample includes a **reported category valuation comparable** dated **2026-05-13** with source links and caveats.
+- If fixture fields are absent, outputs explicitly render `not_reported`; they are never converted to zeros.
+
+## Readiness tiers and hard caps
+The dossier emits T0–T10 readiness tiers with hard caps (for example: no replay report caps readiness at T2; no ProofBundle caps at T3; no customer-reviewed dockets caps at T6).
+
+## Local deterministic commands
 - `python -m agialpha_valuation_support build --repo-root . --ascension-registry ascension_os_registry --comparables config/valuation_support_public_comparables.example.json --market-context config/valuation_support_market_context.example.json --out /tmp/valuation-support-test`
 - `python -m agialpha_valuation_support validate --run /tmp/valuation-support-test`
 - `python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support`
+- `python -m agialpha_valuation_support summarize --run /tmp/valuation-support-test --out /tmp/valuation-support-test/12_valuation_support_memo.md`
+
+## Output locations
+- Run outputs: `valuation-support-runs/<run_id>/`
+- Registry (append-only history): `valuation_support_registry/`
+- UI-consumable generated data: `docs/_generated/valuation-support/`

--- a/README_VALUATION_SUPPORT.md
+++ b/README_VALUATION_SUPPORT.md
@@ -28,7 +28,7 @@ Valuation-comparable discussion is only defensible when grounded in reproducible
 - If fixture fields are absent, outputs explicitly render `not_reported`; they are never converted to zeros.
 
 ## Readiness tiers and hard caps
-The dossier emits T0–T10 readiness tiers with hard caps (for example: no replay report caps readiness at T2; no ProofBundle caps at T3; no customer-reviewed dockets caps at T6).
+Current implementation emits T2–T6 readiness tiers with hard caps (for example: no replay report caps readiness at T2; no ProofBundle caps at T3; no customer-reviewed dockets caps at T6).
 
 ## Local deterministic commands
 - `python -m agialpha_valuation_support build --repo-root . --ascension-registry ascension_os_registry --comparables config/valuation_support_public_comparables.example.json --market-context config/valuation_support_market_context.example.json --out /tmp/valuation-support-test`
@@ -37,6 +37,7 @@ The dossier emits T0–T10 readiness tiers with hard caps (for example: no repla
 - `python -m agialpha_valuation_support summarize --run /tmp/valuation-support-test --out /tmp/valuation-support-test/12_valuation_support_memo.md`
 
 ## Output locations
-- Run outputs: `valuation-support-runs/<run_id>/`
+- Run outputs are written to the explicit `--out` directory passed to `build` (for example `/tmp/valuation-support-test`).
+- A registry copy is written to `valuation_support_registry/runs/<run_id>/`.
 - Registry (append-only history): `valuation_support_registry/`
 - UI-consumable generated data: `docs/_generated/valuation-support/`


### PR DESCRIPTION
### Motivation
- Harden the previously thin valuation-support layer into a substantive, non-promissory implementation-side evidence dossier by adding operator guidance, explicit claim boundaries, and deterministic run instructions so outputs are safe for valuation-comparable discussion without making investment or valuation claims.

### Description
- Updated `README_VALUATION_SUPPORT.md` to VALUATION-SUPPORT-002 content that adds the required canonical boundary text, clarifies public comparable handling (manual fixture dated `2026-05-13`), documents readiness tiers and hard caps, documents missing-evidence honesty, and lists deterministic CLI commands and output locations; this change is limited to the README to preserve existing Evidence Mission Control and registry behavior.

### Testing
- Verified deterministic pipeline and checks by running `python -m agialpha_valuation_support build`, `python -m agialpha_valuation_support validate`, `python -m agialpha_valuation_support build-data`, and `python -m unittest discover -s tests` (434 tests, all OK), and confirmed targeted `pytest -q` runs for valuation-support docs/validate/generated-data tests passed; changes were committed as an isolated README update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a1cead0c8333a55121095d80241a)