### PR TITLE
Upgrade AGI ALPHA Valuation Support: implementation-side market-comparable evidence dossier

### DIFF
--- a/tests/test_valuation_support_risk_boundary.py
+++ b/tests/test_valuation_support_risk_boundary.py
@@ -1,0 +1,46 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+MAJOR_OUTPUTS = [
+    "00_manifest.json",
+    "01_category_valuation_signal.json",
+    "02_public_comparables.json",
+    "03_agialpha_evidence_inventory.json",
+    "04_implementation_side_comparison.json",
+    "05_implementation_equivalence_score.json",
+    "06_market_equivalence_sensitivity.json",
+    "07_commercial_readiness.json",
+    "08_moat_assessment.json",
+    "09_risk_boundary.json",
+    "10_missing_evidence.json",
+]
+
+
+def test_risk_boundary_present_in_major_outputs():
+    out = tempfile.mkdtemp()
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "agialpha_valuation_support",
+            "build",
+            "--repo-root",
+            ".",
+            "--ascension-registry",
+            "ascension_os_registry",
+            "--comparables",
+            "config/valuation_support_public_comparables.example.json",
+            "--market-context",
+            "config/valuation_support_market_context.example.json",
+            "--out",
+            out,
+        ]
+    )
+    for rel_path in MAJOR_OUTPUTS:
+        payload = json.load(open(os.path.join(out, rel_path), "r", encoding="utf-8"))
+        assert payload.get("claim_boundary")
+        assert payload.get("not_an_investment_claim") is True


### PR DESCRIPTION
### Motivation
- Improve explicit boundary coverage for VALUATION-SUPPORT-002 artifacts by asserting that every major generated dossier JSON includes a `claim_boundary` and `not_an_investment_claim: true` field. 

### Description
- Add `tests/test_valuation_support_risk_boundary.py`, a deterministic coverage test that runs the dossier build and asserts `claim_boundary` and `not_an_investment_claim` are present in each major output JSON. 

### Testing
- Ran `python -m agialpha_valuation_support build ... --out /tmp/valuation-support-test`, `python -m agialpha_valuation_support validate --run /tmp/valuation-support-test`, `python -m agialpha_valuation_support build-data --registry valuation_support_registry --out docs/_generated/valuation-support`, `pytest -q tests/test_valuation_support_risk_boundary.py`, and `python -m unittest discover -s tests`, and all executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c2fda07883338d5ecea118986232)