### PR TITLE
Add enterprise pilot compliance tests for docs, workflow, and generated artifacts

### DIFF
--- a/tests/test_enterprise_pilot_docs.py
+++ b/tests/test_enterprise_pilot_docs.py
@@ -1,2 +1,14 @@
-def test_placeholder():
-    assert True
+from pathlib import Path
+
+
+def test_enterprise_pilot_docs_exist_and_state_boundaries():
+    required = [
+        "README_ENTERPRISE_PILOT.md",
+        "docs/enterprise-pilot/README.md",
+        "docs/enterprise-pilot/regulated-boundary.md",
+        "docs/enterprise-pilot/not-an-investment-claim.md",
+    ]
+    for path in required:
+        assert Path(path).exists(), path
+    text = Path("README_ENTERPRISE_PILOT.md").read_text().lower()
+    assert "not regulated decisioning" in text

--- a/tests/test_enterprise_pilot_no_investment_claims.py
+++ b/tests/test_enterprise_pilot_no_investment_claims.py
@@ -1,2 +1,42 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _build_run() -> Path:
+    run_dir = Path(tempfile.mkdtemp())
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "agialpha_enterprise_pilot",
+        "build",
+        "--repo-root",
+        ".",
+        "--out",
+        str(run_dir),
+        "--workflow-family",
+        "software_quality_pack",
+        "--customer-mode",
+        "synthetic_only",
+    ])
+    return run_dir
+
+
+def test_settlement_receipt_has_required_utility_only_wording():
+    run_dir = _build_run()
+    data = json.loads((run_dir / "09_utility_settlement_receipt.json").read_text())
+    text = data["statement"]
+    assert "utility-only local accounting receipt" in text
+    assert "not payment processing" in text
+    assert "not_an_investment_claim" in data and data["not_an_investment_claim"] is True
+
+
+def test_valuation_support_link_disclaims_valuation_and_roi():
+    run_dir = _build_run()
+    data = json.loads((run_dir / "14_valuation_support_link.json").read_text())
+    text = data["statement"].lower()
+    assert "does not assert valuation" in text
+    assert "roi" in text
+    assert "fair market value" in text

--- a/tests/test_enterprise_pilot_no_regulated_decisioning.py
+++ b/tests/test_enterprise_pilot_no_regulated_decisioning.py
@@ -1,2 +1,25 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def test_regulated_domain_signal_is_blocked_and_human_review_required():
+    run_dir = Path(tempfile.mkdtemp())
+    subprocess.check_call([
+        sys.executable, "-m", "agialpha_enterprise_pilot", "build",
+        "--repo-root", ".", "--out", str(run_dir),
+        "--workflow-family", "software_quality_pack", "--customer-mode", "synthetic_only",
+    ])
+    triage = json.loads((run_dir / "02_regulated_boundary_triage.json").read_text())
+    assert triage["regulated_boundary_result"] == "passed"
+    assert triage["human_review_required"] is True
+
+    # Directly test regulated boundary triage behavior with a regulated-domain input.
+    from agialpha_enterprise_pilot.regulated_boundary import triage
+    blocked = triage("credit underwriting decision for applicants")
+    assert blocked["regulated_boundary_result"] == "blocked"
+    assert blocked["regulated_boundary_blocked"] is True
+    assert blocked["documentation_only"] is True
+    assert blocked["human_review_required"] is True

--- a/tests/test_enterprise_pilot_no_token_value_claims.py
+++ b/tests/test_enterprise_pilot_no_token_value_claims.py
@@ -1,2 +1,25 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def test_no_token_value_or_appreciation_claims_in_core_artifacts():
+    run_dir = Path(tempfile.mkdtemp())
+    subprocess.check_call([
+        sys.executable, "-m", "agialpha_enterprise_pilot", "build",
+        "--repo-root", ".", "--out", str(run_dir),
+        "--workflow-family", "software_quality_pack", "--customer-mode", "synthetic_only",
+    ])
+    files = [
+        "01_pilot_intake.json",
+        "09_utility_settlement_receipt.json",
+        "14_valuation_support_link.json",
+    ]
+    for name in files:
+        payload = json.loads((run_dir / name).read_text())
+        text = json.dumps(payload).lower()
+        assert "token appreciation" not in text
+        assert "securities value" not in text
+        assert "guaranteed appreciation" not in text

--- a/tests/test_enterprise_pilot_workflow.py
+++ b/tests/test_enterprise_pilot_workflow.py
@@ -8,4 +8,5 @@ def test_enterprise_pilot_workflow_exists_and_disables_pages_automerge():
     assert "schedule:" in wf
     assert "actions/upload-artifact" in wf
     assert "deploy pages" not in wf
+    assert "actions/deploy-pages" not in wf
     assert "automerge" not in wf

--- a/tests/test_enterprise_pilot_workflow.py
+++ b/tests/test_enterprise_pilot_workflow.py
@@ -1,2 +1,11 @@
-def test_placeholder():
-    assert True
+from pathlib import Path
+
+
+def test_enterprise_pilot_workflow_exists_and_disables_pages_automerge():
+    wf = Path('.github/workflows/agialpha-enterprise-pilot-001.yml').read_text().lower()
+    assert "agi alpha enterprise pilot 001 / evidence factory" in wf
+    assert "workflow_dispatch:" in wf
+    assert "schedule:" in wf
+    assert "actions/upload-artifact" in wf
+    assert "deploy pages" not in wf
+    assert "automerge" not in wf


### PR DESCRIPTION
### Motivation

- Replace placeholder tests with concrete checks to validate enterprise pilot documentation, CI workflow configuration, regulated-boundary behavior, and generated artifact content.
- Ensure the repository enforces wording and safety boundaries (no regulated decisioning, no investment/token value claims) for the enterprise pilot workflow outputs.

### Description

- Added `tests/test_enterprise_pilot_docs.py` to assert presence of required docs and that `README_ENTERPRISE_PILOT.md` contains the phrase `not regulated decisioning`.
- Added `tests/test_enterprise_pilot_workflow.py` to validate the GitHub Actions workflow file contains the expected schedule/dispatch/upload steps and that pages automerge/deploy are disabled.
- Added `tests/test_enterprise_pilot_no_regulated_decisioning.py` which invokes the CLI build and asserts triage results in generated JSON and also directly exercises `agialpha_enterprise_pilot.regulated_boundary.triage` to confirm blocking and human review behavior for regulated-domain inputs.
- Added `tests/test_enterprise_pilot_no_investment_claims.py` and `tests/test_enterprise_pilot_no_token_value_claims.py` which run the CLI build, inspect generated JSON artifacts, and assert required disclaimers are present and investment/token-appreciation claims are absent.

### Testing

- Ran the new test files with `pytest tests/test_enterprise_pilot_*.py tests/test_enterprise_pilot_docs.py tests/test_enterprise_pilot_workflow.py`.
- All added tests executed against the local build artifacts and the modified test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0881569d1c833399f152e6a0eecc5b)