### PR TITLE
Add enterprise pilot compliance tests for docs, workflow, and artifact content

### DIFF
--- a/tests/test_enterprise_pilot_docs.py
+++ b/tests/test_enterprise_pilot_docs.py
@@ -1,2 +1,14 @@
-def test_placeholder():
-    assert True
+from pathlib import Path
+
+
+def test_enterprise_pilot_docs_exist_and_state_boundaries():
+    required = [
+        "README_ENTERPRISE_PILOT.md",
+        "docs/enterprise-pilot/README.md",
+        "docs/enterprise-pilot/regulated-boundary.md",
+        "docs/enterprise-pilot/not-an-investment-claim.md",
+    ]
+    for path in required:
+        assert Path(path).exists(), path
+    text = Path("README_ENTERPRISE_PILOT.md").read_text().lower()
+    assert "not regulated decisioning" in text

--- a/tests/test_enterprise_pilot_no_investment_claims.py
+++ b/tests/test_enterprise_pilot_no_investment_claims.py
@@ -1,2 +1,42 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _build_run() -> Path:
+    run_dir = Path(tempfile.mkdtemp())
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "agialpha_enterprise_pilot",
+        "build",
+        "--repo-root",
+        ".",
+        "--out",
+        str(run_dir),
+        "--workflow-family",
+        "software_quality_pack",
+        "--customer-mode",
+        "synthetic_only",
+    ])
+    return run_dir
+
+
+def test_settlement_receipt_has_required_utility_only_wording():
+    run_dir = _build_run()
+    data = json.loads((run_dir / "09_utility_settlement_receipt.json").read_text())
+    text = data["statement"]
+    assert "utility-only local accounting receipt" in text
+    assert "not payment processing" in text
+    assert "not_an_investment_claim" in data and data["not_an_investment_claim"] is True
+
+
+def test_valuation_support_link_disclaims_valuation_and_roi():
+    run_dir = _build_run()
+    data = json.loads((run_dir / "14_valuation_support_link.json").read_text())
+    text = data["statement"].lower()
+    assert "does not assert valuation" in text
+    assert "roi" in text
+    assert "fair market value" in text

--- a/tests/test_enterprise_pilot_no_regulated_decisioning.py
+++ b/tests/test_enterprise_pilot_no_regulated_decisioning.py
@@ -1,2 +1,25 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def test_regulated_domain_signal_is_blocked_and_human_review_required():
+    run_dir = Path(tempfile.mkdtemp())
+    subprocess.check_call([
+        sys.executable, "-m", "agialpha_enterprise_pilot", "build",
+        "--repo-root", ".", "--out", str(run_dir),
+        "--workflow-family", "software_quality_pack", "--customer-mode", "synthetic_only",
+    ])
+    triage = json.loads((run_dir / "02_regulated_boundary_triage.json").read_text())
+    assert triage["regulated_boundary_result"] == "passed"
+    assert triage["human_review_required"] is True
+
+    # Directly test regulated boundary triage behavior with a regulated-domain input.
+    from agialpha_enterprise_pilot.regulated_boundary import triage
+    blocked = triage("credit underwriting decision for applicants")
+    assert blocked["regulated_boundary_result"] == "blocked"
+    assert blocked["regulated_boundary_blocked"] is True
+    assert blocked["documentation_only"] is True
+    assert blocked["human_review_required"] is True

--- a/tests/test_enterprise_pilot_no_token_value_claims.py
+++ b/tests/test_enterprise_pilot_no_token_value_claims.py
@@ -1,2 +1,25 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def test_no_token_value_or_appreciation_claims_in_core_artifacts():
+    run_dir = Path(tempfile.mkdtemp())
+    subprocess.check_call([
+        sys.executable, "-m", "agialpha_enterprise_pilot", "build",
+        "--repo-root", ".", "--out", str(run_dir),
+        "--workflow-family", "software_quality_pack", "--customer-mode", "synthetic_only",
+    ])
+    files = [
+        "01_pilot_intake.json",
+        "09_utility_settlement_receipt.json",
+        "14_valuation_support_link.json",
+    ]
+    for name in files:
+        payload = json.loads((run_dir / name).read_text())
+        text = json.dumps(payload).lower()
+        assert "token appreciation" not in text
+        assert "securities value" not in text
+        assert "guaranteed appreciation" not in text

--- a/tests/test_enterprise_pilot_workflow.py
+++ b/tests/test_enterprise_pilot_workflow.py
@@ -1,2 +1,12 @@
-def test_placeholder():
-    assert True
+from pathlib import Path
+
+
+def test_enterprise_pilot_workflow_exists_and_disables_pages_automerge():
+    wf = Path('.github/workflows/agialpha-enterprise-pilot-001.yml').read_text().lower()
+    assert "agi alpha enterprise pilot 001 / evidence factory" in wf
+    assert "workflow_dispatch:" in wf
+    assert "schedule:" in wf
+    assert "actions/upload-artifact" in wf
+    assert "deploy pages" not in wf
+    assert "actions/deploy-pages" not in wf
+    assert "automerge" not in wf


### PR DESCRIPTION
### Motivation
- Replace placeholder tests with concrete checks to validate enterprise pilot documentation, workflow configuration, and generated artifact content constraints.
- Ensure the project does not claim regulated decisioning, investment/token value claims, or expose pages automerge in the pilot workflow.
- Provide automated coverage for the triage behavior in `agialpha_enterprise_pilot.regulated_boundary` to guard regulated-domain blocking and human review requirements.

### Description
- Added `tests/test_enterprise_pilot_docs.py` to assert required docs exist and that `README_ENTERPRISE_PILOT.md` contains the phrase `not regulated decisioning`.
- Added `tests/test_enterprise_pilot_workflow.py` to validate the Enterprise Pilot GitHub Actions workflow file contains expected triggers and explicitly does not deploy pages or enable automerge.
- Added `tests/test_enterprise_pilot_no_investment_claims.py`, `tests/test_enterprise_pilot_no_token_value_claims.py`, and `tests/test_enterprise_pilot_no_regulated_decisioning.py` which run `agialpha_enterprise_pilot build` via `sys.executable -m agialpha_enterprise_pilot build` to produce artifacts and assert content constraints on generated JSON outputs.
- Directly tests the `triage` function in `agialpha_enterprise_pilot.regulated_boundary` to confirm blocked/regulatory behavior and `human_review_required` semantics.

### Testing
- Ran the updated test suite with `pytest` which executed the new tests under `tests/` and they passed.
- The build-invoking tests run `agialpha_enterprise_pilot build` into temporary directories and successfully read and validated the produced JSON artifacts.
- The direct unit test of `agialpha_enterprise_pilot.regulated_boundary.triage` executed and returned the expected blocked and human review flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0881569d1c833399f152e6a0eecc5b)