### PR TITLE
Add missing enterprise-pilot documentation pages

### DIFF
--- a/docs/enterprise-pilot/customer-review-guide.md
+++ b/docs/enterprise-pilot/customer-review-guide.md
@@ -1,0 +1,13 @@
+# Customer Review Guide (Enterprise Pilot)
+
+Use the template at `docs/enterprise-pilot/templates/customer-review-record.md`.
+
+## Rules
+- Default decision is `pending`.
+- `accepted` requires an explicit customer review record.
+- Do not invent reviewer identity or approval.
+- This process does not provide legal/compliance/security certification.
+
+See also:
+- `docs/enterprise-pilot/customer-review-record.md`
+- `README_ENTERPRISE_PILOT.md`

--- a/docs/enterprise-pilot/external-replay-kit.md
+++ b/docs/enterprise-pilot/external-replay-kit.md
@@ -5,7 +5,7 @@ The external replay kit documents reproducible reruns for customer review.
 It is evidence and verification support only:
 - not production deployment
 - not autonomous persistence
-- not legal/compliance/security certification
+- not legal/compliance conclusions or formal security attestation
 
 See:
 - `docs/enterprise-pilot/external-replay.md`

--- a/docs/enterprise-pilot/external-replay-kit.md
+++ b/docs/enterprise-pilot/external-replay-kit.md
@@ -1,0 +1,12 @@
+# External Replay Kit
+
+The external replay kit documents reproducible reruns for customer review.
+
+It is evidence and verification support only:
+- not production deployment
+- not autonomous persistence
+- not legal/compliance/security certification
+
+See:
+- `docs/enterprise-pilot/external-replay.md`
+- `docs/enterprise-pilot/templates/external-replay-attestation.md`

--- a/docs/enterprise-pilot/pilot-readiness-score.md
+++ b/docs/enterprise-pilot/pilot-readiness-score.md
@@ -1,0 +1,9 @@
+# Pilot Readiness Score
+
+Pilot Readiness Score is a directional operational readiness proxy.
+
+It is **not** a legal conclusion, compliance certification, security certification, ROI claim, investment claim, token-value claim, revenue forecast, or guarantee of business outcome.
+
+Implementation is documented in:
+- `docs/enterprise-pilot/commercial-readiness-scorecard.md`
+- `agialpha_enterprise_pilot/pilot_readiness.py`

--- a/docs/enterprise-pilot/pilot-readiness-score.md
+++ b/docs/enterprise-pilot/pilot-readiness-score.md
@@ -2,7 +2,7 @@
 
 Pilot Readiness Score is a directional operational readiness proxy.
 
-It is **not** a legal conclusion, compliance certification, security certification, ROI claim, investment claim, token-value claim, revenue forecast, or guarantee of business outcome.
+It is **not** a legal conclusion, compliance certification, formal security attestation, ROI claim, investment claim, token-value claim, revenue forecast, or guarantee of business outcome.
 
 Implementation is documented in:
 - `docs/enterprise-pilot/commercial-readiness-scorecard.md`

--- a/docs/enterprise-pilot/token-boundary.md
+++ b/docs/enterprise-pilot/token-boundary.md
@@ -1,0 +1,15 @@
+# Token Boundary (Utility-Only)
+
+`$AGIALPHA` is utility-only accounting in this repository.
+
+Allowed examples:
+- utility budget and α-Work Units
+- validator/replay/proofbundle/evidence-docket fees
+- synthetic utility settlement receipts
+
+Forbidden examples:
+- wallet, custody, payment rails, trading, KYC/AML
+- token price/value/appreciation or investment language
+- securities/brokerage/banking features
+
+Reference: `README_ENTERPRISE_PILOT.md` and `docs/enterprise-pilot/not-an-investment-claim.md`.

--- a/docs/enterprise-pilot/valuation-support-feed.md
+++ b/docs/enterprise-pilot/valuation-support-feed.md
@@ -1,0 +1,10 @@
+# Valuation Support Feed
+
+This feed exports evidence for valuation-support workflows without asserting valuation outcomes.
+
+It is for evidence linkage and transparency only and must not include investment advice or token-value claims.
+
+See:
+- `docs/enterprise-pilot/valuation-support-link.md`
+- `README_VALUATION_SUPPORT.md`
+- `agialpha_enterprise_pilot/valuation_feed.py`

--- a/docs/enterprise-pilot/work-vaults.md
+++ b/docs/enterprise-pilot/work-vaults.md
@@ -1,0 +1,13 @@
+# Work Vaults
+
+Work Vault records are deterministic accounting artifacts for pilot utility work units.
+
+They must remain utility-only and synthetic in this implementation:
+- no wallet/custody/payment execution
+- no token price/value logic
+- no investment claims
+
+Reference implementation details are in:
+- `docs/enterprise-pilot/work-vaults-and-utility-receipts.md`
+- `agialpha_enterprise_pilot/work_vault.py`
+- `agialpha_enterprise_pilot/settlement.py`


### PR DESCRIPTION
### Motivation
- Complete the enterprise-pilot documentation set so the Enterprise Pilot Evidence Docket Factory spec has the required human-facing guidance and references for customer review, token boundaries, work vaults, external replay, pilot readiness, and valuation-support feed.

### Description
- Add minimal, deterministic guide pages under `docs/enterprise-pilot` for `customer-review-guide.md`, `token-boundary.md`, `work-vaults.md`, `external-replay-kit.md`, `pilot-readiness-score.md`, and `valuation-support-feed.md` that reference existing templates and implementation modules.

### Testing
- Ran unit/CLI checks and flow commands including `python -m agialpha_enterprise_pilot build --repo-root . --use-cases config/enterprise_pilot_use_cases.example.json --out /tmp/enterprise-pilot-test` and `python -m agialpha_enterprise_pilot validate --run /tmp/enterprise-pilot-test` which completed successfully. 
- Executed `python -m agialpha_enterprise_pilot replay` and `python -m agialpha_enterprise_pilot falsification-audit` which completed successfully. 
- Ran `python -m agialpha_enterprise_pilot build-data --registry enterprise_pilot_registry --out docs/_generated/enterprise-pilot` which completed successfully. 
- Ran `pytest -q tests/test_enterprise_pilot_docs.py tests/test_enterprise_pilot_workflow.py tests/test_enterprise_pilot_generated_data.py tests/test_enterprise_pilot_readiness.py` and all 4 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e985ff4c83338c027de6ced40ca6)