### PR TITLE
Implement AGI ALPHA Engine 001: Alpha-Factory open-ended experiment engine

### DIFF
--- a/README_AGIALPHA_ENGINE.md
+++ b/README_AGIALPHA_ENGINE.md
@@ -1,4 +1,16 @@
-# AGI ALPHA Engine 001
-This is the engine, not just a recorder.
-TARGET→EMIT→FILTER→ATLAS→TEST-PLAN→EVAL→INSERT→PROMOTE.
-Human review required; no auto-merge; utility-only.
+# AGI ALPHA Engine 001: Alpha-Factory Open-Ended Experiment Engine
+
+AGI ALPHA ENGINE-001 upgrades the repo from an evidence harness into an executable, proof-gated experiment engine.
+
+`TARGET → EMIT → FILTER → ATLAS → TEST-PLAN → EVAL → INSERT → PROMOTE`
+
+- Generates deterministic experiment/validator/patch/workflow/agent candidates.
+- Runs bounded local sandbox evaluations for patch plans in temporary copies only.
+- Compares baseline ladder outcomes and reports B6 vs B5 honestly.
+- Archives accepted and rejected stepping stones in QD + capability archives.
+- Produces vNext descendant tasks, replayable ProofBundles, and Evidence Dockets.
+- Requires human review before any promotion or persistence.
+
+Boundary posture: no AGI/ASI/superintelligence/SOTA claim, `$AGIALPHA` utility-only accounting, regulated-domain blocking, no auto-merge, and no autonomous persistence.
+
+**No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**


### PR DESCRIPTION
### Motivation
- Make ENGINE-001 explicit and operational in the repository by clarifying that this is an executable Alpha-Factory loop (not only an evidence recorder) and by documenting governance/boundary posture to prevent overclaims and unsafe autonomy.

### Description
- Expanded `README_AGIALPHA_ENGINE.md` to present the canonical `TARGET → EMIT → FILTER → ATLAS → TEST-PLAN → EVAL → INSERT → PROMOTE` loop, add concise operational bullets (deterministic experiment/validator/patch/workflow/agent generation, sandbox-evaluated patch plans, baseline ladder and B6-vs-B5 comparison, QD/Capability archives, vNext, ProofBundles, Evidence Dockets), and include the explicit doctrine and boundary language (`No Evidence Docket, no empirical SOTA claim...`) and utility-only `$AGIALPHA` posture.

### Testing
- Ran the engine smoke/flow commands and CI-friendly checks including `python -m agialpha_engine discover`, `python -m agialpha_engine run-cycle`, `python -m agialpha_engine run-gauntlet`, `python -m agialpha_engine replay`, `python -m agialpha_engine falsification-audit`, `python -m agialpha_engine validate`, and `python -m agialpha_engine build-data`, all of which completed in the local run; additionally ran the test suite with `python -m unittest discover -s tests` (full test run completed successfully) and `pytest -q tests/test_agialpha_engine_docs.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a345281688333a295027693c8112c)