### PR TITLE
Implement AGI ALPHA Engine 002: measured recursive machine labor proof

### DIFF
--- a/agialpha_engine/recursive_improvement.py
+++ b/agialpha_engine/recursive_improvement.py
@@ -291,15 +291,27 @@ def render_proof(run_dir: Path, out: Path) -> None:
     out.mkdir(parents=True, exist_ok=True)
     summary = json.loads((run_dir / "15_public_summary" / "summary.json").read_text())
     metrics = summary["metrics"]
+    status_text = (run_dir / "15_public_summary" / "stronger_claim_status.md").read_text().strip()
+    unsupported_notice = "" if summary["stronger_claim_supported"] else "<p><strong>The stronger claim is not supported by this run.</strong></p>"
+    safety_counters = {
+        k: metrics[k]
+        for k in metrics
+        if k.endswith("_count") or k.endswith("violations") or k == "critical_safety_incidents"
+    }
     html = f"""<!doctype html><meta charset='utf-8'><title>AGI ALPHA Engine Proof</title>
 <h1>AGI ALPHA Engine Proof</h1>
-<section><h2>Stronger claim status: {summary['stronger_claim_status']}</h2><p>{(run_dir / '15_public_summary' / 'stronger_claim_status.md').read_text().strip()}</p></section>
+<section><h2>Stronger claim status: {summary['stronger_claim_status']}</h2>{unsupported_notice}<p>{status_text}</p></section>
 <section><h2>Mandate A → Frozen Capability → Held-out Mandate B</h2><p>Each pair freezes a capability hash before held-out evaluation.</p></section>
 <section><h2>Treatment vs Shadow Control</h2><table><tr><th>Treatment</th><th>Shadow control</th><th>Delta</th></tr><tr><td>{metrics['treatment_score']}</td><td>{metrics['shadow_control_score']}</td><td>{metrics['improvement_delta']}</td></tr></table></section>
 <section><h2>Computed vRCI / recursive-improvement metrics</h2><p>vRCI: {metrics['vRCI_computed']}; B6 vs B5: {metrics['B6_beats_B5_computed']}</p></section>
-<section><h2>Falsification panel</h2><p>Replay: {metrics['replay_pass']}; falsification: {metrics['falsification_pass']}</p></section>
+<section><h2>Falsification panel</h2><p>Falsification audit: {metrics['falsification_pass']}</p></section>
 <section><h2>Semantic negative tests panel</h2><p>{metrics['semantic_negative_tests_passed']}</p></section>
 <section><h2>Adversarial Evidence Docket panel</h2><p>Failed variants, rejected claims, disagreements, baseline regressions, and falsification attempts are preserved.</p></section>
-<section><h2>ProofBundles</h2><p>See run artifacts.</p></section><section><h2>Evidence Dockets</h2><p>Human review gate required.</p></section><section><h2>Safety and boundary counters</h2><pre>{json.dumps({k: metrics[k] for k in metrics if k.endswith('_count') or k.endswith('violations')}, indent=2)}</pre></section><section><h2>Raw data links</h2><p>Raw JSON is secondary to this summary.</p></section>"""
+<section><h2>ProofBundles</h2><p>See run artifacts.</p></section>
+<section><h2>Evidence Dockets</h2><p>Evidence Dockets are complete before claim support is considered.</p></section>
+<section><h2>Replay status</h2><p>Replay pass: {metrics['replay_pass']}</p></section>
+<section><h2>Safety and boundary counters</h2><pre>{json.dumps(safety_counters, indent=2)}</pre></section>
+<section><h2>Human review gate</h2><p>Human review remains required before public promotion; this renderer does not auto-promote claims.</p></section>
+<section><h2>Raw data links</h2><p>Raw JSON is secondary to this summary.</p></section>"""
     _write_text(out / "index.html", html)
     atomic_write_json(out / "routes.json", {"routes": ["/agialpha-engine-proof/", "/experiments/agialpha-engine-002/"], "nav_label": "AGI ALPHA Engine Proof", **BOUNDARIES})

--- a/docs/agialpha-engine-proof/generated/index.html
+++ b/docs/agialpha-engine-proof/generated/index.html
@@ -4,11 +4,15 @@
 <section><h2>Mandate A → Frozen Capability → Held-out Mandate B</h2><p>Each pair freezes a capability hash before held-out evaluation.</p></section>
 <section><h2>Treatment vs Shadow Control</h2><table><tr><th>Treatment</th><th>Shadow control</th><th>Delta</th></tr><tr><td>1.0</td><td>0.333333</td><td>0.666667</td></tr></table></section>
 <section><h2>Computed vRCI / recursive-improvement metrics</h2><p>vRCI: 2.000001; B6 vs B5: True</p></section>
-<section><h2>Falsification panel</h2><p>Replay: True; falsification: True</p></section>
+<section><h2>Falsification panel</h2><p>Falsification audit: True</p></section>
 <section><h2>Semantic negative tests panel</h2><p>True</p></section>
 <section><h2>Adversarial Evidence Docket panel</h2><p>Failed variants, rejected claims, disagreements, baseline regressions, and falsification attempts are preserved.</p></section>
-<section><h2>ProofBundles</h2><p>See run artifacts.</p></section><section><h2>Evidence Dockets</h2><p>Human review gate required.</p></section><section><h2>Safety and boundary counters</h2><pre>{
+<section><h2>ProofBundles</h2><p>See run artifacts.</p></section>
+<section><h2>Evidence Dockets</h2><p>Evidence Dockets are complete before claim support is considered.</p></section>
+<section><h2>Replay status</h2><p>Replay pass: True</p></section>
+<section><h2>Safety and boundary counters</h2><pre>{
   "claim_boundary_violations": 0,
+  "critical_safety_incidents": 0,
   "exploit_execution_count": 0,
   "external_target_scan_count": 0,
   "malware_generation_count": 0,
@@ -17,4 +21,6 @@
   "social_engineering_content_count": 0,
   "token_boundary_violations": 0,
   "unsafe_automerge_count": 0
-}</pre></section><section><h2>Raw data links</h2><p>Raw JSON is secondary to this summary.</p></section>
+}</pre></section>
+<section><h2>Human review gate</h2><p>Human review remains required before public promotion; this renderer does not auto-promote claims.</p></section>
+<section><h2>Raw data links</h2><p>Raw JSON is secondary to this summary.</p></section>

--- a/tests/test_engine_proof_public_ui_data.py
+++ b/tests/test_engine_proof_public_ui_data.py
@@ -1,4 +1,5 @@
-from engine_proof_helpers import make_run, run_cmd
+from engine_proof_helpers import make_run, read_json, run_cmd
+from agialpha_engine.context import atomic_write_json
 
 
 def test_generated_public_data_exists(tmp_path):
@@ -7,3 +8,21 @@ def test_generated_public_data_exists(tmp_path):
     run_cmd("build-proof-data", "--run", str(out), "--out", str(gen))
     for name in ["latest.json", "summary.json", "mandate_pairs.json", "computed_metrics.json", "treatment_vs_control.json", "stronger_claim_status.json", "falsification.json", "adversarial_docket.json"]:
         assert (gen / name).exists()
+
+
+def test_render_proof_prominently_marks_unsupported_runs(tmp_path):
+    out = make_run(tmp_path)
+    summary_path = out / "15_public_summary" / "summary.json"
+    summary = read_json(summary_path)
+    summary["stronger_claim_status"] = "NOT_SUPPORTED"
+    summary["stronger_claim_supported"] = False
+    atomic_write_json(summary_path, summary)
+    (out / "15_public_summary" / "stronger_claim_status.md").write_text(
+        "This run does not support the stronger recursive-improvement claim.\n",
+        encoding="utf-8",
+    )
+    rendered = tmp_path / "rendered"
+    run_cmd("render-proof", "--run", str(out), "--out", str(rendered))
+    html = (rendered / "index.html").read_text(encoding="utf-8")
+    assert "Stronger claim status: NOT_SUPPORTED" in html
+    assert "The stronger claim is not supported by this run." in html


### PR DESCRIPTION
### Motivation

- Make the Engine-002 public rendering and gating stricter and more transparent so unsupported runs are clearly labeled and safety/falsification/replay gates are visible to humans. 
- Prevent regressions where the public UI might obscure a failing gate by adding an automated test that asserts unsupported runs are rendered prominently.

### Description

- Harden `render_proof` in `agialpha_engine/recursive_improvement.py` to read gated status text, display an explicit unsupported-run notice when `stronger_claim_supported` is false, and add UI sections for falsification audit, replay status, Evidence Docket gating, safety/boundary counters (including `critical_safety_incidents`), and a human-review gate. 
- Regenerate the static proof page at `docs/agialpha-engine-proof/generated/index.html` to match the new renderer layout and language. 
- Add/modify a test `tests/test_engine_proof_public_ui_data.py` to force a `NOT_SUPPORTED` summary and assert the rendered HTML includes the stronger-claim-not-supported notice and the NOT_SUPPORTED status line. 
- Keep raw JSON artifacts secondary and ensure the renderer surfaces the human-review promotion gate rather than auto-promoting claims.

### Testing

- Ran the full Engine-002 proof flow with `python -m agialpha_engine run-proof --repo-root . --out /tmp/agialpha-engine-proof-test --mandate-pairs 3 --seed 1337` and followed by `python -m agialpha_engine replay-proof`, `python -m agialpha_engine falsification-audit-proof`, `python -m agialpha_engine validate-proof`, `python -m agialpha_engine build-proof-data`, and `python -m agialpha_engine render-proof`, and all commands completed successfully. 
- Automated tests were run and passed: the repository test suite (`pytest`/`unittest`) completed successfully (suite run reported passing), and the Engine-002 proof-specific tests passed (`pytest` on `tests/test_engine_proof*.py` produced `23 passed`). 
- Added a regression test `tests/test_engine_proof_public_ui_data.py` that verifies unsupported runs are rendered with the prominent notice, and it passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ba2d4c2e48333a381b3da55a9fb9f)