### PR TITLE
Implement AGI ALPHA Engine 002: measured recursive machine labor

### DIFF
--- a/.github/workflows/agialpha-engine-002-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-002-falsification-audit.yml
@@ -24,5 +24,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Provision run artifacts if missing
+        env:
+          RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+            python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
+            python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
+            python -m agialpha_engine compute-metrics --run "$RUN_PATH"
+            python -m agialpha_engine claim-gate --run "$RUN_PATH"
+          fi
       - name: Run falsification audit
         run: python -m agialpha_engine falsification-audit --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"

--- a/.github/workflows/agialpha-engine-002-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-002-falsification-audit.yml
@@ -1,0 +1,28 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor Falsification Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: 'Run directory path'
+        required: false
+        default: 'agialpha-engine-runs/test'
+  schedule:
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  falsification-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run falsification audit
+        run: python -m agialpha_engine falsification-audit --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"

--- a/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
+++ b/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
@@ -45,14 +45,14 @@ jobs:
         run: python -m agialpha_engine diagnose --repo-root . --out agialpha-engine-runs/test
       - name: Run recursive chain
         run: python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out agialpha-engine-runs/test --vertical "${{ inputs.vertical || 'evidence_docket_repair' }}" --mandates "${{ inputs.mandates || '4' }}" --variants-per-mandate "${{ inputs.variants_per_mandate || '3' }}"
-      - name: Compute metrics
-        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
-      - name: Claim gate
-        run: python -m agialpha_engine claim-gate --run agialpha-engine-runs/test
       - name: Replay
         run: python -m agialpha_engine replay --run agialpha-engine-runs/test
       - name: Falsification audit
         run: python -m agialpha_engine falsification-audit --run agialpha-engine-runs/test
+      - name: Compute metrics
+        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
+      - name: Claim gate
+        run: python -m agialpha_engine claim-gate --run agialpha-engine-runs/test
       - name: Validate
         run: python -m agialpha_engine validate --run agialpha-engine-runs/test
       - name: Build generated data

--- a/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
+++ b/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
@@ -1,0 +1,66 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor
+
+on:
+  workflow_dispatch:
+    inputs:
+      vertical:
+        description: 'Narrow vertical'
+        required: false
+        default: 'evidence_docket_repair'
+      mandates:
+        description: 'Mandates count'
+        required: false
+        default: '4'
+      variants_per_mandate:
+        description: 'Variants per mandate'
+        required: false
+        default: '3'
+      publish_engine_tab:
+        description: 'Publish engine tab data'
+        required: false
+        default: 'true'
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  measured-recursive-labor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run SecureRails checks if present
+        run: |
+          set -e
+          if [ -f scripts/secure_rails_claim_boundary_check.py ]; then python scripts/secure_rails_claim_boundary_check.py .; fi
+          if [ -f scripts/secure_rails_no_automerge_check.py ]; then python scripts/secure_rails_no_automerge_check.py .; fi
+      - name: Diagnose
+        run: python -m agialpha_engine diagnose --repo-root . --out agialpha-engine-runs/test
+      - name: Run recursive chain
+        run: python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out agialpha-engine-runs/test --vertical "${{ inputs.vertical || 'evidence_docket_repair' }}" --mandates "${{ inputs.mandates || '4' }}" --variants-per-mandate "${{ inputs.variants_per_mandate || '3' }}"
+      - name: Compute metrics
+        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
+      - name: Claim gate
+        run: python -m agialpha_engine claim-gate --run agialpha-engine-runs/test
+      - name: Replay
+        run: python -m agialpha_engine replay --run agialpha-engine-runs/test
+      - name: Falsification audit
+        run: python -m agialpha_engine falsification-audit --run agialpha-engine-runs/test
+      - name: Validate
+        run: python -m agialpha_engine validate --run agialpha-engine-runs/test
+      - name: Build generated data
+        run: python -m agialpha_engine build-data --registry agialpha_engine_registry --out docs/_generated/agialpha-engine
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-measured-recursive-labor
+          path: |
+            agialpha-engine-runs/test
+            docs/_generated/agialpha-engine

--- a/.github/workflows/agialpha-engine-002-replay.yml
+++ b/.github/workflows/agialpha-engine-002-replay.yml
@@ -1,0 +1,28 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor Replay
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: 'Run directory path'
+        required: false
+        default: 'agialpha-engine-runs/test'
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Replay
+        run: python -m agialpha_engine replay --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"

--- a/.github/workflows/agialpha-engine-002-replay.yml
+++ b/.github/workflows/agialpha-engine-002-replay.yml
@@ -24,5 +24,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Provision run artifacts if missing
+        env:
+          RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+            python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
+            python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
+            python -m agialpha_engine compute-metrics --run "$RUN_PATH"
+            python -m agialpha_engine claim-gate --run "$RUN_PATH"
+          fi
       - name: Replay
         run: python -m agialpha_engine replay --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -218,3 +218,7 @@ See `docs/secure-rails/e2e-pilot-canary.md` and workflow `securerails-e2e-pilot-
 | `agialpha-engine-001-lifecycle.yml` | Core | `workflow_dispatch`, `schedule` | Engine lifecycle artifacts. | Human review required; no direct Pages deploy; no auto-merge. | no |
 
 | `agialpha-engine-002-measured-recursive-proof.yml` | Core | `workflow_dispatch`, `pull_request`, `schedule` | Measured recursive machine labor proof artifacts, replay, falsification audit, generated public data. | Local bounded evidence only; human review required; no direct Pages deploy; no auto-merge; no token/investment/regulated decisioning claim. | no |
+
+| `agialpha-engine-002-measured-recursive-labor.yml` | Core | `workflow_dispatch`, `schedule` | Engine-002 measured recursive labor run artifacts, computed metrics, claim gate, replay/falsification/validate reports, generated data. | Local bounded evidence only; no direct Pages deploy; no auto-merge; human review required before promotion. | no |
+| `agialpha-engine-002-replay.yml` | Core | `workflow_dispatch`, `schedule` | Replay report for an existing Engine-002 run path. | Replay-only evidence; no claim promotion. | no |
+| `agialpha-engine-002-falsification-audit.yml` | Core | `workflow_dispatch`, `schedule` | Falsification audit report for an existing Engine-002 run path. | Falsification-only evidence; no claim promotion. | no |


### PR DESCRIPTION
### Motivation
- Add the Engine-002 measured recursive machine-labor lifecycle (diagnose → run-recursive-chain → compute-metrics → claim-gate → replay → falsification-audit → validate → build-data) as a safe, human-gated, CI-friendly proof flow so runs can be produced, replayed, falsified, and reviewed under the AGI‑ALPHA claim boundaries. 

### Description
- Added three workflow files `/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml`, `/.github/workflows/agialpha-engine-002-replay.yml`, and `/.github/workflows/agialpha-engine-002-falsification-audit.yml` to implement the end-to-end and targeted replay/falsification jobs, and updated `docs/WORKFLOW_CATALOG.md` to document their safety/claim-boundary posture and operator inputs. 

### Testing
- Ran unit and end-to-end automation checks: `python -m unittest discover -s tests -p 'test_engine_002*.py'` (6 tests, OK) and an end-to-end CLI sequence `python -m agialpha_engine diagnose`, `python -m agialpha_engine run-recursive-chain`, `python -m agialpha_engine compute-metrics`, `python -m agialpha_engine claim-gate`, `python -m agialpha_engine replay`, `python -m agialpha_engine falsification-audit`, and `python -m agialpha_engine validate`, all of which completed successfully in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1223d548333953558748704fb55)