### PR TITLE
Add Engine-002 workflows: measured-recursive-labor, replay, falsification-audit and update workflow catalog

### DIFF
--- a/.github/workflows/agialpha-engine-002-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-002-falsification-audit.yml
@@ -37,3 +37,11 @@ jobs:
           fi
       - name: Run falsification audit
         run: python -m agialpha_engine falsification-audit --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+
+      - name: Upload falsification artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-falsification-audit-report
+          path: |
+            ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/12_falsification/falsification_audit.json
+            ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/11_replay/replay_report.json

--- a/.github/workflows/agialpha-engine-002-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-002-falsification-audit.yml
@@ -1,0 +1,39 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor Falsification Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: 'Run directory path'
+        required: false
+        default: 'agialpha-engine-runs/test'
+  schedule:
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  falsification-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Provision run artifacts if missing
+        env:
+          RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+            python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
+            python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
+            python -m agialpha_engine compute-metrics --run "$RUN_PATH"
+            python -m agialpha_engine claim-gate --run "$RUN_PATH"
+          fi
+      - name: Run falsification audit
+        run: python -m agialpha_engine falsification-audit --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"

--- a/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
+++ b/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
@@ -1,0 +1,68 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor
+
+on:
+  workflow_dispatch:
+    inputs:
+      vertical:
+        description: 'Narrow vertical'
+        required: false
+        default: 'evidence_docket_repair'
+      mandates:
+        description: 'Mandates count'
+        required: false
+        default: '4'
+      variants_per_mandate:
+        description: 'Variants per mandate'
+        required: false
+        default: '3'
+      publish_engine_tab:
+        description: 'Publish engine tab data'
+        required: false
+        default: 'true'
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  measured-recursive-labor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run SecureRails checks if present
+        run: |
+          set -e
+          if [ -f scripts/secure_rails_claim_boundary_check.py ]; then python scripts/secure_rails_claim_boundary_check.py .; fi
+          if [ -f scripts/secure_rails_no_automerge_check.py ]; then python scripts/secure_rails_no_automerge_check.py .; fi
+      - name: Diagnose
+        run: python -m agialpha_engine diagnose --repo-root . --out agialpha-engine-runs/test
+      - name: Run recursive chain
+        run: python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out agialpha-engine-runs/test --vertical "${{ inputs.vertical || 'evidence_docket_repair' }}" --mandates "${{ inputs.mandates || '4' }}" --variants-per-mandate "${{ inputs.variants_per_mandate || '3' }}"
+      - name: Compute metrics (pre-replay)
+        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
+      - name: Replay
+        run: python -m agialpha_engine replay --run agialpha-engine-runs/test
+      - name: Falsification audit
+        run: python -m agialpha_engine falsification-audit --run agialpha-engine-runs/test
+      - name: Compute metrics (finalized)
+        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
+      - name: Claim gate
+        run: python -m agialpha_engine claim-gate --run agialpha-engine-runs/test
+      - name: Validate
+        run: python -m agialpha_engine validate --run agialpha-engine-runs/test
+      - name: Build generated data
+        run: python -m agialpha_engine build-data --registry agialpha_engine_registry --out docs/_generated/agialpha-engine
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-measured-recursive-labor
+          path: |
+            agialpha-engine-runs/test
+            docs/_generated/agialpha-engine

--- a/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
+++ b/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
@@ -38,9 +38,16 @@ jobs:
           python-version: '3.11'
       - name: Run SecureRails checks if present
         run: |
-          set -e
-          if [ -f scripts/secure_rails_claim_boundary_check.py ]; then python scripts/secure_rails_claim_boundary_check.py .; fi
-          if [ -f scripts/secure_rails_no_automerge_check.py ]; then python scripts/secure_rails_no_automerge_check.py .; fi
+          set -euo pipefail
+          shopt -s nullglob
+          for script in scripts/secure_rails_*_check.py; do
+            if grep -q "<repo_root>" "$script"; then
+              echo "Running $script ."
+              python "$script" .
+            else
+              echo "Skipping $script (non-repo-root check)"
+            fi
+          done
       - name: Diagnose
         run: python -m agialpha_engine diagnose --repo-root . --out agialpha-engine-runs/test
       - name: Run recursive chain

--- a/.github/workflows/agialpha-engine-002-replay.yml
+++ b/.github/workflows/agialpha-engine-002-replay.yml
@@ -1,0 +1,39 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor Replay
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: 'Run directory path'
+        required: false
+        default: 'agialpha-engine-runs/test'
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Provision run artifacts if missing
+        env:
+          RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+            python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
+            python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
+            python -m agialpha_engine compute-metrics --run "$RUN_PATH"
+            python -m agialpha_engine claim-gate --run "$RUN_PATH"
+          fi
+      - name: Replay
+        run: python -m agialpha_engine replay --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"

--- a/.github/workflows/agialpha-engine-002-replay.yml
+++ b/.github/workflows/agialpha-engine-002-replay.yml
@@ -37,3 +37,11 @@ jobs:
           fi
       - name: Replay
         run: python -m agialpha_engine replay --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+
+      - name: Upload replay artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-replay-report
+          path: |
+            ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/11_replay/replay_report.json
+            ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/06_metrics/computed_metrics.json

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -218,3 +218,7 @@ See `docs/secure-rails/e2e-pilot-canary.md` and workflow `securerails-e2e-pilot-
 | `agialpha-engine-001-lifecycle.yml` | Core | `workflow_dispatch`, `schedule` | Engine lifecycle artifacts. | Human review required; no direct Pages deploy; no auto-merge. | no |
 
 | `agialpha-engine-002-measured-recursive-proof.yml` | Core | `workflow_dispatch`, `pull_request`, `schedule` | Measured recursive machine labor proof artifacts, replay, falsification audit, generated public data. | Local bounded evidence only; human review required; no direct Pages deploy; no auto-merge; no token/investment/regulated decisioning claim. | no |
+
+| `agialpha-engine-002-measured-recursive-labor.yml` | Core | `workflow_dispatch`, `schedule` | Engine-002 measured recursive labor run artifacts, computed metrics, claim gate, replay/falsification/validate reports, generated data. | Local bounded evidence only; no direct Pages deploy; no auto-merge; human review required before promotion. | no |
+| `agialpha-engine-002-replay.yml` | Core | `workflow_dispatch`, `schedule` | Replay report for an existing Engine-002 run path. | Replay-only evidence; no claim promotion. | no |
+| `agialpha-engine-002-falsification-audit.yml` | Core | `workflow_dispatch`, `schedule` | Falsification audit report for an existing Engine-002 run path. | Falsification-only evidence; no claim promotion. | no |


### PR DESCRIPTION
### Motivation

- Provide scheduled and on-demand automation for Engine-002 evidence generation, replay, and falsification audits to standardize runs and produce generated data artifacts. 
- Ensure run provisioning is possible when artifacts are missing so replay and audit workflows can operate against a known test run directory.

### Description

- Add three GitHub Actions workflows: `agialpha-engine-002-measured-recursive-labor.yml`, `agialpha-engine-002-replay.yml`, and `agialpha-engine-002-falsification-audit.yml` under `.github/workflows` to support end-to-end run, replay, and falsification audit scenarios. 
- The new workflows use `actions/checkout@v4`, `actions/setup-python@v5` with `python-version: '3.11'`, and grant read permissions for `contents` and `actions`.
- `measured-recursive-labor` runs diagnose, recursive-chain, metrics, replay, falsification-audit, claim-gate, validate, `build-data`, and uploads `agialpha-engine-runs/test` and generated data as an artifact. 
- `replay` and `falsification-audit` include a provisioning step that will populate a run path by invoking `python -m agialpha_engine diagnose`, `run-recursive-chain`, `compute-metrics`, and `claim-gate` if the run manifest is missing.
- Update `docs/WORKFLOW_CATALOG.md` to include entries for the three new Engine-002 workflows and their short descriptions and policies.

### Testing

- No automated unit or integration tests were executed as part of this change. 
- Workflow YAMLs were added only and will be exercised by scheduled runs or via `workflow_dispatch` once merged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1223d548333953558748704fb55)