### PR TITLE
Add Engine-002 workflows for measured recursive labor, replay, and falsification audit; update workflow catalog

### DIFF
--- a/.github/workflows/agialpha-engine-002-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-002-falsification-audit.yml
@@ -29,7 +29,21 @@ jobs:
           RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
         run: |
           set -euo pipefail
-          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+          required=(
+            "$RUN_PATH/00_manifest.json"
+            "$RUN_PATH/02_experiment_generation/selected_experiments.json"
+            "$RUN_PATH/03_validator_synthesis/validators.json"
+            "$RUN_PATH/09_proofbundles/proofbundle_index.json"
+            "$RUN_PATH/10_evidence_dockets/docket_index.json"
+          )
+          needs_provision=0
+          for required_file in "${required[@]}"; do
+            if [ ! -f "$required_file" ]; then
+              needs_provision=1
+              break
+            fi
+          done
+          if [ "$needs_provision" -eq 1 ]; then
             python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
             python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
             python -m agialpha_engine compute-metrics --run "$RUN_PATH"

--- a/.github/workflows/agialpha-engine-002-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-002-falsification-audit.yml
@@ -1,0 +1,50 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor Falsification Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: 'Run directory path'
+        required: false
+        default: 'agialpha-engine-runs/test'
+  schedule:
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  falsification-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Provision run artifacts if missing
+        env:
+          RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+            python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
+            python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
+            python -m agialpha_engine compute-metrics --run "$RUN_PATH"
+            python -m agialpha_engine claim-gate --run "$RUN_PATH"
+          fi
+      - name: Ensure replay report exists
+        run: python -m agialpha_engine replay --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+      - name: Run falsification audit
+        run: python -m agialpha_engine falsification-audit --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-falsification-audit-report
+          if-no-files-found: error
+          path: |
+            ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/11_replay/replay_report.json
+            ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/12_falsification/falsification_audit.json

--- a/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
+++ b/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml
@@ -1,0 +1,76 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor
+
+on:
+  workflow_dispatch:
+    inputs:
+      vertical:
+        description: 'Narrow vertical'
+        required: false
+        default: 'evidence_docket_repair'
+      mandates:
+        description: 'Mandates count'
+        required: false
+        default: '4'
+      variants_per_mandate:
+        description: 'Variants per mandate'
+        required: false
+        default: '3'
+      publish_engine_tab:
+        description: 'Publish engine tab data'
+        required: false
+        default: 'true'
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  measured-recursive-labor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run SecureRails repo-root checks if present
+        run: |
+          set -euo pipefail
+          checks=(
+            scripts/secure_rails_claim_boundary_check.py
+            scripts/secure_rails_no_automerge_check.py
+            scripts/secure_rails_trust_center_check.py
+          )
+          for check in "${checks[@]}"; do
+            if [ -f "$check" ]; then
+              python "$check" .
+            fi
+          done
+      - name: Diagnose
+        run: python -m agialpha_engine diagnose --repo-root . --out agialpha-engine-runs/test
+      - name: Run recursive chain
+        run: python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out agialpha-engine-runs/test --vertical "${{ inputs.vertical || 'evidence_docket_repair' }}" --mandates "${{ inputs.mandates || '4' }}" --variants-per-mandate "${{ inputs.variants_per_mandate || '3' }}"
+      - name: Compute metrics (pre-replay)
+        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
+      - name: Replay
+        run: python -m agialpha_engine replay --run agialpha-engine-runs/test
+      - name: Falsification audit
+        run: python -m agialpha_engine falsification-audit --run agialpha-engine-runs/test
+      - name: Compute metrics (finalized)
+        run: python -m agialpha_engine compute-metrics --run agialpha-engine-runs/test
+      - name: Claim gate
+        run: python -m agialpha_engine claim-gate --run agialpha-engine-runs/test
+      - name: Validate
+        run: python -m agialpha_engine validate --run agialpha-engine-runs/test
+      - name: Build generated data
+        run: python -m agialpha_engine build-data --registry agialpha_engine_registry --out docs/_generated/agialpha-engine
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-measured-recursive-labor
+          path: |
+            agialpha-engine-runs/test
+            docs/_generated/agialpha-engine

--- a/.github/workflows/agialpha-engine-002-replay.yml
+++ b/.github/workflows/agialpha-engine-002-replay.yml
@@ -29,7 +29,21 @@ jobs:
           RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
         run: |
           set -euo pipefail
-          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+          required=(
+            "$RUN_PATH/00_manifest.json"
+            "$RUN_PATH/02_experiment_generation/selected_experiments.json"
+            "$RUN_PATH/03_validator_synthesis/validators.json"
+            "$RUN_PATH/09_proofbundles/proofbundle_index.json"
+            "$RUN_PATH/10_evidence_dockets/docket_index.json"
+          )
+          needs_provision=0
+          for required_file in "${required[@]}"; do
+            if [ ! -f "$required_file" ]; then
+              needs_provision=1
+              break
+            fi
+          done
+          if [ "$needs_provision" -eq 1 ]; then
             python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
             python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
             python -m agialpha_engine compute-metrics --run "$RUN_PATH"

--- a/.github/workflows/agialpha-engine-002-replay.yml
+++ b/.github/workflows/agialpha-engine-002-replay.yml
@@ -1,0 +1,46 @@
+name: AGI ALPHA Engine 002 / Measured Recursive Machine Labor Replay
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: 'Run directory path'
+        required: false
+        default: 'agialpha-engine-runs/test'
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Provision run artifacts if missing
+        env:
+          RUN_PATH: "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RUN_PATH/00_manifest.json" ]; then
+            python -m agialpha_engine diagnose --repo-root . --out "$RUN_PATH"
+            python -m agialpha_engine run-recursive-chain --repo-root . --registry agialpha_engine_registry --out "$RUN_PATH" --vertical evidence_docket_repair --mandates 4 --variants-per-mandate 3
+            python -m agialpha_engine compute-metrics --run "$RUN_PATH"
+            python -m agialpha_engine claim-gate --run "$RUN_PATH"
+          fi
+      - name: Replay
+        run: python -m agialpha_engine replay --run "${{ inputs.run_path || 'agialpha-engine-runs/test' }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-002-replay-report
+          if-no-files-found: error
+          path: ${{ inputs.run_path || 'agialpha-engine-runs/test' }}/11_replay/replay_report.json

--- a/docs/WORKFLOW_CATALOG.md
+++ b/docs/WORKFLOW_CATALOG.md
@@ -218,3 +218,7 @@ See `docs/secure-rails/e2e-pilot-canary.md` and workflow `securerails-e2e-pilot-
 | `agialpha-engine-001-lifecycle.yml` | Core | `workflow_dispatch`, `schedule` | Engine lifecycle artifacts. | Human review required; no direct Pages deploy; no auto-merge. | no |
 
 | `agialpha-engine-002-measured-recursive-proof.yml` | Core | `workflow_dispatch`, `pull_request`, `schedule` | Measured recursive machine labor proof artifacts, replay, falsification audit, generated public data. | Local bounded evidence only; human review required; no direct Pages deploy; no auto-merge; no token/investment/regulated decisioning claim. | no |
+
+| `agialpha-engine-002-measured-recursive-labor.yml` | Core | `workflow_dispatch`, `schedule` | Engine-002 measured recursive labor run artifacts, computed metrics, claim gate, replay/falsification/validate reports, generated data. | Local bounded evidence only; no direct Pages deploy; no auto-merge; human review required before promotion. | no |
+| `agialpha-engine-002-replay.yml` | Core | `workflow_dispatch`, `schedule` | Replay report for an existing Engine-002 run path. | Replay-only evidence; no claim promotion. | no |
+| `agialpha-engine-002-falsification-audit.yml` | Core | `workflow_dispatch`, `schedule` | Falsification audit report for an existing Engine-002 run path. | Falsification-only evidence; no claim promotion. | no |


### PR DESCRIPTION
### Motivation

- Provide scheduled and manual CI workflows for Engine-002 to run measured recursive machine labor experiments, replay existing runs, and run falsification audits. 
- Enable artifact provisioning, metrics computation, replay, falsification checks, and generated-data publication for reproducible evidence runs. 
- Make the new Engine-002 workflows discoverable by registering them in the `docs/WORKFLOW_CATALOG.md` file.

### Description

- Add `/.github/workflows/agialpha-engine-002-measured-recursive-labor.yml` which runs `python -m agialpha_engine` steps including `diagnose`, `run-recursive-chain`, `compute-metrics`, `replay`, `falsification-audit`, `claim-gate`, `validate`, `build-data`, and uploads `agialpha-engine-runs/test` and generated docs as artifacts, with `workflow_dispatch` inputs and a weekly schedule. 
- Add `/.github/workflows/agialpha-engine-002-replay.yml` which provisions missing run artifacts, runs `replay` for a provided `run_path`, and uploads the `11_replay/replay_report.json` artifact. 
- Add `/.github/workflows/agialpha-engine-002-falsification-audit.yml` which provisions missing run artifacts, ensures a replay report exists, runs `falsification-audit` for a provided `run_path`, and uploads `11_replay/replay_report.json` and `12_falsification/falsification_audit.json`. 
- Update `docs/WORKFLOW_CATALOG.md` to register the three new workflows and adjust nearby catalog entries for Engine-002.

### Testing

- No automated unit or integration tests were executed as part of this change. 
- The workflows are scheduled and `workflow_dispatch`-enabled and will be validated when run by GitHub Actions. 
- YAML and CI behavior should be verified on first run of each workflow; any run-time failures will appear in the Actions logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1223d548333953558748704fb55)