### PR TITLE
Implement AGI ALPHA Engine 002: measured recursive machine labor

### DIFF
--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import hashlib
 import json
 import random
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -54,3 +56,29 @@ class LocalSandbox:
 
     def describe(self) -> dict[str, Any]:
         return dict(self.constraints)
+
+    def apply_candidate_patch(self, fixture_path: Path, replacement_text: str) -> dict[str, Any]:
+        fixture_path = Path(fixture_path).resolve()
+        if not fixture_path.is_file():
+            raise ValueError("fixture_path must be a file")
+        if self.repo_root not in fixture_path.parents:
+            raise ValueError("fixture_path must stay within repo root")
+        rel = fixture_path.relative_to(self.repo_root)
+        if ".." in rel.parts:
+            raise ValueError("path traversal rejected")
+        with tempfile.TemporaryDirectory(prefix="agialpha-sandbox-") as td:
+            temp_root = Path(td)
+            temp_fixture = temp_root / rel
+            temp_fixture.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(fixture_path, temp_fixture)
+            before_hash = file_hash(temp_fixture)
+            temp_fixture.write_text(replacement_text, encoding="utf-8")
+            after_hash = file_hash(temp_fixture)
+            return {
+                "sandbox_root": str(temp_root),
+                "relative_fixture": str(rel),
+                "input_hash": before_hash,
+                "sandbox_output_hash": after_hash,
+                "repo_source_hash_unchanged": file_hash(fixture_path) == before_hash,
+                "autonomous_persistence_allowed": False,
+            }

--- a/tests/test_engine_002_sandbox.py
+++ b/tests/test_engine_002_sandbox.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from agialpha_engine.sandbox import LocalSandbox
+
+
+def test_sandbox_patch_does_not_modify_repo_source(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    fixture = repo / "fixture.txt"
+    fixture.write_text("before", encoding="utf-8")
+    sb = LocalSandbox(repo_root=repo, seed=1337)
+    result = sb.apply_candidate_patch(fixture, "after")
+    assert result["repo_source_hash_unchanged"] is True
+    assert fixture.read_text(encoding="utf-8") == "before"
+    assert result["autonomous_persistence_allowed"] is False
+
+
+def test_sandbox_blocks_path_outside_repo(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x", encoding="utf-8")
+    sb = LocalSandbox(repo_root=repo, seed=1)
+    try:
+        sb.apply_candidate_patch(outside, "y")
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "within repo root" in str(exc)


### PR DESCRIPTION
### Motivation
- Ensure candidate patch application is sandboxed so generated patches are applied only to temporary fixture copies, reject path traversal/out-of-repo writes, and prevent autonomous persistence during ENGINE-002 proof runs.

### Description
- Added `LocalSandbox.apply_candidate_patch(...)` in `agialpha_engine/sandbox.py` which validates fixture paths, copies the fixture into a temporary sandbox, applies the candidate replacement there, records deterministic pre/post file hashes, and enforces `autonomous_persistence_allowed: False`.
- Added semantic tests `tests/test_engine_002_sandbox.py` that assert the sandbox does not modify repository source files and that paths outside the repo are rejected.

### Testing
- Ran `pytest -q tests/test_engine_002_sandbox.py tests/test_engine_proof_no_hardcoded_vrci.py tests/test_engine_proof_no_hardcoded_b6.py tests/test_securerails_human_review_decision.py`, and the test batch completed successfully (`9 passed`).
- Changes were committed (updated `agialpha_engine/sandbox.py`, added `tests/test_engine_002_sandbox.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e12f69dd0833399cb2ae943e33d9a)