### PR TITLE
Implement AGI ALPHA Engine 002: measured recursive machine-labor proof

### DIFF
--- a/agialpha_engine/evaluator.py
+++ b/agialpha_engine/evaluator.py
@@ -1,1 +1,34 @@
-"""AGI ALPHA ENGINE-001 module placeholder."""
+"""Baseline evaluator for measured recursive machine-labor runs."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _safe_rate(num: float, den: float) -> float:
+    return 0.0 if den <= 0 else round(num / den, 6)
+
+
+def evaluate_baseline(results: list[dict[str, Any]], *, use_archive: bool) -> dict[str, Any]:
+    total = len(results)
+    accepted = [r for r in results if r.get("accepted") is True]
+    replayed = [r for r in accepted if r.get("replay_pass") is True]
+    validated = [r for r in accepted if r.get("validator_pass") is True]
+    verified_work_score = round(sum(float(r.get("score", 0.0)) for r in accepted), 6)
+    return {
+        "task_count": total,
+        "accepted_task_count": len(accepted),
+        "accepted_task_rate": _safe_rate(len(accepted), total),
+        "validator_pass_rate": _safe_rate(len(validated), len(accepted) or 1),
+        "replay_pass_rate": _safe_rate(len(replayed), len(accepted) or 1),
+        "verified_work_score": verified_work_score,
+        "archive_used": bool(use_archive),
+    }
+
+
+def evaluate_all_baselines(raw: dict[str, Any]) -> dict[str, Any]:
+    b5 = evaluate_baseline(raw.get("b5_results", []), use_archive=False)
+    b6 = evaluate_baseline(raw.get("b6_results", []), use_archive=True)
+    return {
+        "B5_no_archive": b5,
+        "B6_archive_reuse": b6,
+    }

--- a/agialpha_engine/redaction.py
+++ b/agialpha_engine/redaction.py
@@ -10,18 +10,27 @@ PATTERNS = {
     "anthropic_key": re.compile(r"\bsk-ant-[A-Za-z0-9\-_]{16,}\b"),
     "aws_access_key": re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     "bearer": re.compile(r"\bBearer\s+[A-Za-z0-9\-_.=]{16,}\b", re.IGNORECASE),
+    "ssh_private_key": re.compile(r"-----BEGIN OPENSSH PRIVATE KEY-----[\s\S]+?-----END OPENSSH PRIVATE KEY-----"),
+    "pem_private_key": re.compile(r"-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----[\s\S]+?-----END (?:RSA |EC |DSA )?PRIVATE KEY-----"),
+    "jwt_like": re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+    "high_entropy_hex": re.compile(r"\b[a-fA-F0-9]{40,}\b"),
+    "high_entropy_b64": re.compile(r"\b[A-Za-z0-9+/]{48,}={0,2}\b"),
     "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+    "card_like": re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
 }
 
 
 def redact_text(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
     salt = hashlib.sha256(f"{run_id}{root_hash}redaction-salt".encode()).hexdigest()
-    findings = []
-    out = text
-    for name, pattern in PATTERNS.items():
-        for m in list(pattern.finditer(out)):
-            secret = m.group(0)
-            digest = hashlib.sha256((salt + secret).encode()).hexdigest()[:16]
-            findings.append({"finding_type": name, "salted_hash": digest, "redacted_preview": "[REDACTED]"})
-            out = out.replace(secret, "[REDACTED]")
-    return out, findings
+    findings: list[dict[str, Any]] = []
+    out_lines = text.splitlines()
+    for i, line in enumerate(out_lines):
+        updated = line
+        for name, pattern in PATTERNS.items():
+            for m in list(pattern.finditer(updated)):
+                secret = m.group(0)
+                digest = hashlib.sha256((salt + secret).encode()).hexdigest()[:16]
+                findings.append({"line": i + 1, "finding_type": name, "salted_hash": digest, "redacted_preview": "[REDACTED]"})
+                updated = updated.replace(secret, "[REDACTED]")
+        out_lines[i] = updated
+    return "\n".join(out_lines), findings

--- a/secure_rails/human_review.py
+++ b/secure_rails/human_review.py
@@ -19,6 +19,9 @@ def validate_promotion_gate(record: dict) -> list[str]:
     if cond.get("human_review_decision_present") is not True: errs.append("human_review_decision_present must be true")
     if cond.get("hard_safety_counters_zero") is not True: errs.append("hard_safety_counters_zero must be true")
     if cond.get("auto_merge_allowed") is not False: errs.append("auto_merge_allowed must be false")
+    if cond.get("proofbundle_present") is not True: errs.append("proofbundle_present must be true")
+    if cond.get("replay_present") is not True: errs.append("replay_present must be true")
+    if cond.get("falsification_audit_present") is not True: errs.append("falsification_audit_present must be true")
     review_status = str(record.get("human_review_status", "accepted")).strip().lower()
     if review_status not in {"accepted", "rejected", "needs_changes", "pending"}:
         errs.append("human_review_status invalid")

--- a/tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json
+++ b/tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json
@@ -10,7 +10,9 @@
     "safety_ledger_present": true,
     "claim_boundary_present": true,
     "hard_safety_counters_zero": true,
-    "auto_merge_allowed": false
+    "auto_merge_allowed": false,
+    "replay_present": true,
+    "falsification_audit_present": true
   },
   "gate_status": "pass",
   "failure_reasons": [],

--- a/tests/test_engine_002_human_review_gate.py
+++ b/tests/test_engine_002_human_review_gate.py
@@ -3,16 +3,16 @@ from secure_rails.human_review import validate_promotion_gate
 
 class TestHumanReviewGate002(unittest.TestCase):
     def test_missing_human_review_fails(self):
-        rec={"schema_version":"securerails.promotion_gate.v1","promotion_gate_id":"x","source_decision_id":"d","promotion_target":"safe_pr","required_conditions":{"human_review_decision_present":False,"hard_safety_counters_zero":True,"auto_merge_allowed":False,"evidence_docket_present":True},"claim_boundary":"ok"}
+        rec={"schema_version":"securerails.promotion_gate.v1","promotion_gate_id":"x","source_decision_id":"d","promotion_target":"safe_pr","required_conditions":{"human_review_decision_present":False,"hard_safety_counters_zero":True,"auto_merge_allowed":False,"evidence_docket_present":True,"proofbundle_present":True,"replay_present":True,"falsification_audit_present":True},"claim_boundary":"ok"}
         errs=validate_promotion_gate(rec)
         self.assertTrue(any('human_review_decision_present' in e for e in errs))
 
     def test_needs_changes_blocks_promotion(self):
-        rec={"schema_version":"securerails.promotion_gate.v1","promotion_gate_id":"x","source_decision_id":"d","promotion_target":"safe_pr","human_review_status":"needs_changes","required_conditions":{"human_review_decision_present":True,"hard_safety_counters_zero":True,"auto_merge_allowed":False,"evidence_docket_present":True},"claim_boundary":"ok"}
+        rec={"schema_version":"securerails.promotion_gate.v1","promotion_gate_id":"x","source_decision_id":"d","promotion_target":"safe_pr","human_review_status":"needs_changes","required_conditions":{"human_review_decision_present":True,"hard_safety_counters_zero":True,"auto_merge_allowed":False,"evidence_docket_present":True,"proofbundle_present":True,"replay_present":True,"falsification_audit_present":True},"claim_boundary":"ok"}
         errs=validate_promotion_gate(rec)
         self.assertTrue(any('accepted human review' in e for e in errs))
 
     def test_accepted_allows_gate(self):
-        rec={"schema_version":"securerails.promotion_gate.v1","promotion_gate_id":"x","source_decision_id":"d","promotion_target":"safe_pr","human_review_status":"accepted","required_conditions":{"human_review_decision_present":True,"hard_safety_counters_zero":True,"auto_merge_allowed":False,"evidence_docket_present":True},"claim_boundary":"ok"}
+        rec={"schema_version":"securerails.promotion_gate.v1","promotion_gate_id":"x","source_decision_id":"d","promotion_target":"safe_pr","human_review_status":"accepted","required_conditions":{"human_review_decision_present":True,"hard_safety_counters_zero":True,"auto_merge_allowed":False,"evidence_docket_present":True,"proofbundle_present":True,"replay_present":True,"falsification_audit_present":True},"claim_boundary":"ok"}
         errs=validate_promotion_gate(rec)
         self.assertEqual(errs,[])


### PR DESCRIPTION
### Motivation
- Replace placeholder/hard-coded pieces with real, computed components so B6 vs B5 and vRCI are derived from raw results rather than constants.
- Harden redaction and promotion gates to ensure secret-like values are never leaked and human review + replay/falsification evidence are required before promotion.
- Convert smoke assertions into semantic checks so the engine can produce bounded, falsifiable evidence for the stronger recursive-improvement claim.

### Description
- Added a baseline evaluator (`agialpha_engine/evaluator.py`) that computes accepted-task counts, validator/replay pass rates and verified-work scores and exposes `evaluate_all_baselines` for B5/B6 comparison. 
- Strengthened redaction (`agialpha_engine/redaction.py`) with additional secret detectors (SSH/PEM private keys, JWT-like tokens, high-entropy hex/base64, card-like patterns), per-run salted hashes, and line-aware findings without exposing raw secret values. 
- Hardened promotion gate logic (`secure_rails/human_review.py`) to require `proofbundle_present`, `replay_present`, and `falsification_audit_present` in promotion `required_conditions` alongside existing human-review and safety checks. 
- Updated fixture and semantic test for human-review gate (`tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json` and `tests/test_engine_002_human_review_gate.py`) to reflect the stronger gate semantics. 

### Testing
- Ran targeted unit tests for the human-review gate and related engine semantics (`tests.test_engine_002_human_review_gate`, `tests.test_securerails_promotion_gate`, `tests.test_engine_002_sandbox`, `tests.test_engine_archive_reuse_computed`, `tests.test_engine_claim_gate`) and verified they passed after the changes. 
- Executed the full test suite with `python -m unittest discover -s tests` and observed all tests pass (460 tests ran).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e65d73d3c8333acf86000284860ec)