### PR TITLE
Implement AGI ALPHA Engine 002: measured recursive machine-labor proof

### DIFF
--- a/agialpha_engine/claim_gate.py
+++ b/agialpha_engine/claim_gate.py
@@ -34,7 +34,8 @@ class RecursiveMachineLaborClaimGate:
         status = 'supported' if not failed else 'blocked'
         return {
             'schema_version': 'agialpha.engine.claim_gate.v2',
-            'claim': SUPPORTED_SENTENCE,
+            'claim': RecursiveMachineLaborClaimGate.claim,
+            'claim_text': SUPPORTED_SENTENCE,
             'status': status,
             'allowed_public_wording': SUPPORTED_SENTENCE if status == 'supported' else NOT_SUPPORTED_SENTENCE,
             'blocked_reasons': failed,

--- a/agialpha_engine/claim_gate.py
+++ b/agialpha_engine/claim_gate.py
@@ -4,8 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-SUPPORTED_SENTENCE = "AGI ALPHA ENGINE-002 demonstrates local bounded recursive machine-labor improvement under replayable falsifiable controls."
-NOT_SUPPORTED_SENTENCE = "AGI ALPHA ENGINE-002 did not yet support the stronger recursive-improvement claim. It remains evidence of safe, replayable, proof-docketed automation workflow orchestration with strict claim boundaries."
+SUPPORTED_SENTENCE = "In this local repo-owned benchmark, AGI ALPHA demonstrated machine labor that recursively improves in a measured, falsifiable way."
+NOT_SUPPORTED_SENTENCE = "Not demonstrated yet."
 
 class RecursiveMachineLaborClaimGate:
     claim = "machine_labor_recursively_improves_measured_falsifiable"
@@ -31,15 +31,17 @@ class RecursiveMachineLaborClaimGate:
             'safety_zero': metrics.get('critical_safety_incidents') == 0,
         }
         failed = [k for k,v in req.items() if not v]
-        status = 'supported' if not failed else 'not_supported'
+        status = 'supported' if not failed else 'blocked'
         return {
-            'claim': RecursiveMachineLaborClaimGate.claim,
+            'schema_version': 'agialpha.engine.claim_gate.v2',
+            'claim': SUPPORTED_SENTENCE,
             'status': status,
-            'allowed_public_sentence': SUPPORTED_SENTENCE if status == 'supported' else NOT_SUPPORTED_SENTENCE,
-            'failed_requirements': failed,
+            'allowed_public_wording': SUPPORTED_SENTENCE if status == 'supported' else NOT_SUPPORTED_SENTENCE,
+            'blocked_reasons': failed,
             'supporting_artifacts': ['06_metrics/computed_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json'],
             'raw_metric_sources': metrics.get('raw_metric_sources',[]),
             'computed_not_hardcoded': req['computed_not_hardcoded'],
             'human_review_required': True,
             'autonomous_persistence_allowed': False,
+            'claim_boundary': metrics.get('claim_boundary', ''),
         }

--- a/agialpha_engine/cli.py
+++ b/agialpha_engine/cli.py
@@ -176,16 +176,16 @@ def validate(args):
         recomputed_gate = RecursiveMachineLaborClaimGate.evaluate(run)
         replay_ok = replay_report.get('replay_pass') is True or replay_report.get('replay_passes',0) > 0
         falsification_ok = falsification_report.get('falsification_pass') is True
-        failed_requirements = gate.get('failed_requirements') if isinstance(gate.get('failed_requirements'), list) else None
-        allowed_sentence = gate.get('allowed_public_sentence') if isinstance(gate.get('allowed_public_sentence'), str) else ''
+        failed_requirements = gate.get('failed_requirements') if isinstance(gate.get('failed_requirements'), list) else (gate.get('blocked_reasons') if isinstance(gate.get('blocked_reasons'), list) else None)
+        allowed_sentence = gate.get('allowed_public_sentence') if isinstance(gate.get('allowed_public_sentence'), str) else (gate.get('allowed_public_wording') if isinstance(gate.get('allowed_public_wording'), str) else '')
         status = gate.get('status')
         status_consistent = (
             (status == 'supported' and failed_requirements == [])
-            or (status == 'not_supported' and isinstance(failed_requirements, list) and len(failed_requirements) > 0)
+            or (status == 'blocked' and isinstance(failed_requirements, list) and len(failed_requirements) > 0)
         )
         gate_ok = (
             gate.get('claim') == 'machine_labor_recursively_improves_measured_falsifiable'
-            and status in {'supported','not_supported'}
+            and status in {'supported','blocked'}
             and isinstance(failed_requirements, list)
             and status_consistent
             and isinstance(gate.get('supporting_artifacts'), list)
@@ -196,11 +196,11 @@ def validate(args):
             and bool(allowed_sentence.strip())
             and not _has_forbidden_overclaim(allowed_sentence)
             and gate.get('status') == recomputed_gate.get('status')
-            and gate.get('failed_requirements') == recomputed_gate.get('failed_requirements')
+            and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons'))
             and gate.get('computed_not_hardcoded') == recomputed_gate.get('computed_not_hardcoded')
         )
         status='ok' if (gate_ok and replay_ok and falsification_ok) else 'failed'
-        atomic_write_json(run/'validate.json',{'status':status,'replay_ok':replay_ok,'falsification_ok':falsification_ok,'gate_ok':gate_ok,'gate_matches_metrics': gate.get('status') == recomputed_gate.get('status') and gate.get('failed_requirements') == recomputed_gate.get('failed_requirements'),**BOUNDARIES})
+        atomic_write_json(run/'validate.json',{'status':status,'replay_ok':replay_ok,'falsification_ok':falsification_ok,'gate_ok':gate_ok,'gate_matches_metrics': gate.get('status') == recomputed_gate.get('status') and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons')),**BOUNDARIES})
         if status!='ok':
             raise SystemExit('validate failed: recursive replay/falsification or claim gate invalid')
         return

--- a/tests/test_engine_002_claim_gate.py
+++ b/tests/test_engine_002_claim_gate.py
@@ -8,8 +8,8 @@ class TestEngine002ClaimGate(unittest.TestCase):
             run=Path(td); (run/'06_metrics').mkdir()
             (run/'06_metrics/computed_metrics.json').write_text(json.dumps({}))
             out=RecursiveMachineLaborClaimGate.evaluate(run)
-            self.assertEqual(out['status'],'not_supported')
-            self.assertTrue(out['failed_requirements'])
+            self.assertEqual(out['status'],'blocked')
+            self.assertTrue(out['blocked_reasons'])
 
 
     def test_numeric_vrci_counts_as_computed(self):


### PR DESCRIPTION
### Motivation
- Align Engine-002 claim gate with the ENGINE-002 doctrine so public wording, schema, and gate semantics are unambiguous and auditable. 
- Ensure the claim gate emits a stable v2 schema, explicit allowed/blocked public wording, and precise failure reasons so public UI and validation logic can depend on computed metrics rather than implicit strings.

### Description
- Replace legacy claim wording and normalize status semantics by using `schema_version: agialpha.engine.claim_gate.v2`, exposing `allowed_public_wording`, `blocked_reasons`, and a `claim_boundary` field in `agialpha_engine/claim_gate.py`. 
- Use `supported|blocked` status values (instead of the older `not_supported`) and return the scoped allowed claim sentence when supported or the phrase `Not demonstrated yet.` when blocked. 
- Make CLI validation compatible with the new claim-gate shape by accepting both old/new wording keys and comparing recomputed gate results for consistency in `agialpha_engine/cli.py`. 
- Update the unit test `tests/test_engine_002_claim_gate.py` to reflect the new `blocked` contract and `blocked_reasons` key while keeping coverage for numeric vRCI/hardcoding checks. 

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests`, which executed 460 tests and completed successfully (`OK`). 
- Updated and ran the Engine-002 claim-gate unit (`tests/test_engine_002_claim_gate.py`) to verify blocked/supported semantics and numeric vRCI gating; the test passed as part of the full suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e65d73d3c8333acf86000284860ec)