### PR TITLE
Normalize claim gate status to 'blocked', add schema + wording keys, update CLI and tests

### DIFF
--- a/agialpha_engine/claim_gate.py
+++ b/agialpha_engine/claim_gate.py
@@ -4,8 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-SUPPORTED_SENTENCE = "AGI ALPHA ENGINE-002 demonstrates local bounded recursive machine-labor improvement under replayable falsifiable controls."
-NOT_SUPPORTED_SENTENCE = "AGI ALPHA ENGINE-002 did not yet support the stronger recursive-improvement claim. It remains evidence of safe, replayable, proof-docketed automation workflow orchestration with strict claim boundaries."
+SUPPORTED_SENTENCE = "In this local repo-owned benchmark, AGI ALPHA demonstrated machine labor that recursively improves in a measured, falsifiable way."
+NOT_SUPPORTED_SENTENCE = "Not demonstrated yet."
 
 class RecursiveMachineLaborClaimGate:
     claim = "machine_labor_recursively_improves_measured_falsifiable"
@@ -31,15 +31,18 @@ class RecursiveMachineLaborClaimGate:
             'safety_zero': metrics.get('critical_safety_incidents') == 0,
         }
         failed = [k for k,v in req.items() if not v]
-        status = 'supported' if not failed else 'not_supported'
+        status = 'supported' if not failed else 'blocked'
         return {
+            'schema_version': 'agialpha.engine.claim_gate.v2',
             'claim': RecursiveMachineLaborClaimGate.claim,
+            'claim_text': SUPPORTED_SENTENCE,
             'status': status,
-            'allowed_public_sentence': SUPPORTED_SENTENCE if status == 'supported' else NOT_SUPPORTED_SENTENCE,
-            'failed_requirements': failed,
+            'allowed_public_wording': SUPPORTED_SENTENCE if status == 'supported' else NOT_SUPPORTED_SENTENCE,
+            'blocked_reasons': failed,
             'supporting_artifacts': ['06_metrics/computed_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json'],
             'raw_metric_sources': metrics.get('raw_metric_sources',[]),
             'computed_not_hardcoded': req['computed_not_hardcoded'],
             'human_review_required': True,
             'autonomous_persistence_allowed': False,
+            'claim_boundary': metrics.get('claim_boundary', ''),
         }

--- a/agialpha_engine/cli.py
+++ b/agialpha_engine/cli.py
@@ -199,9 +199,9 @@ def validate(args):
             and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons'))
             and gate.get('computed_not_hardcoded') == recomputed_gate.get('computed_not_hardcoded')
         )
-        status='ok' if (gate_ok and replay_ok and falsification_ok) else 'failed'
-        atomic_write_json(run/'validate.json',{'status':status,'replay_ok':replay_ok,'falsification_ok':falsification_ok,'gate_ok':gate_ok,'gate_matches_metrics': status == _normalize_claim_gate_status(recomputed_gate.get('status')) and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons')),**BOUNDARIES})
-        if status!='ok':
+        validation_status='ok' if (gate_ok and replay_ok and falsification_ok) else 'failed'
+        atomic_write_json(run/'validate.json',{'status':validation_status,'replay_ok':replay_ok,'falsification_ok':falsification_ok,'gate_ok':gate_ok,'gate_matches_metrics': gate.get('status') == recomputed_gate.get('status') or _normalize_claim_gate_status(gate.get('status')) == _normalize_claim_gate_status(recomputed_gate.get('status')) and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons')),**BOUNDARIES})
+        if validation_status!='ok':
             raise SystemExit('validate failed: recursive replay/falsification or claim gate invalid')
         return
     _require_run_artifacts(run,['00_manifest.json','05_evaluation/lock_then_reveal.json','06_baselines/B4_ungated_self_modification.json','07_archives/qd_archive.json','07_archives/capability_archive.json','08_descendants/descendant_experiments.json','12_falsification/falsification_audit.json'], 'validate')

--- a/agialpha_engine/cli.py
+++ b/agialpha_engine/cli.py
@@ -176,16 +176,16 @@ def validate(args):
         recomputed_gate = RecursiveMachineLaborClaimGate.evaluate(run)
         replay_ok = replay_report.get('replay_pass') is True or replay_report.get('replay_passes',0) > 0
         falsification_ok = falsification_report.get('falsification_pass') is True
-        failed_requirements = gate.get('failed_requirements') if isinstance(gate.get('failed_requirements'), list) else None
-        allowed_sentence = gate.get('allowed_public_sentence') if isinstance(gate.get('allowed_public_sentence'), str) else ''
-        status = gate.get('status')
+        failed_requirements = gate.get('failed_requirements') if isinstance(gate.get('failed_requirements'), list) else (gate.get('blocked_reasons') if isinstance(gate.get('blocked_reasons'), list) else None)
+        allowed_sentence = gate.get('allowed_public_sentence') if isinstance(gate.get('allowed_public_sentence'), str) else (gate.get('allowed_public_wording') if isinstance(gate.get('allowed_public_wording'), str) else '')
+        status = _normalize_claim_gate_status(gate.get('status'))
         status_consistent = (
             (status == 'supported' and failed_requirements == [])
-            or (status == 'not_supported' and isinstance(failed_requirements, list) and len(failed_requirements) > 0)
+            or (status == 'blocked' and isinstance(failed_requirements, list) and len(failed_requirements) > 0)
         )
         gate_ok = (
             gate.get('claim') == 'machine_labor_recursively_improves_measured_falsifiable'
-            and status in {'supported','not_supported'}
+            and status in {'supported','blocked'}
             and isinstance(failed_requirements, list)
             and status_consistent
             and isinstance(gate.get('supporting_artifacts'), list)
@@ -195,12 +195,12 @@ def validate(args):
             and gate.get('autonomous_persistence_allowed') is False
             and bool(allowed_sentence.strip())
             and not _has_forbidden_overclaim(allowed_sentence)
-            and gate.get('status') == recomputed_gate.get('status')
-            and gate.get('failed_requirements') == recomputed_gate.get('failed_requirements')
+            and status == _normalize_claim_gate_status(recomputed_gate.get('status'))
+            and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons'))
             and gate.get('computed_not_hardcoded') == recomputed_gate.get('computed_not_hardcoded')
         )
         status='ok' if (gate_ok and replay_ok and falsification_ok) else 'failed'
-        atomic_write_json(run/'validate.json',{'status':status,'replay_ok':replay_ok,'falsification_ok':falsification_ok,'gate_ok':gate_ok,'gate_matches_metrics': gate.get('status') == recomputed_gate.get('status') and gate.get('failed_requirements') == recomputed_gate.get('failed_requirements'),**BOUNDARIES})
+        atomic_write_json(run/'validate.json',{'status':status,'replay_ok':replay_ok,'falsification_ok':falsification_ok,'gate_ok':gate_ok,'gate_matches_metrics': status == _normalize_claim_gate_status(recomputed_gate.get('status')) and failed_requirements == (recomputed_gate.get('failed_requirements') if isinstance(recomputed_gate.get('failed_requirements'), list) else recomputed_gate.get('blocked_reasons')),**BOUNDARIES})
         if status!='ok':
             raise SystemExit('validate failed: recursive replay/falsification or claim gate invalid')
         return
@@ -280,6 +280,11 @@ def _adversarial_pass(run: Path) -> bool:
 
 
 
+
+def _normalize_claim_gate_status(status: str | None) -> str | None:
+    if status == "not_supported":
+        return "blocked"
+    return status
 
 def _has_forbidden_overclaim(text: str) -> bool:
     forbidden = [

--- a/tests/test_engine_002_claim_gate.py
+++ b/tests/test_engine_002_claim_gate.py
@@ -8,8 +8,8 @@ class TestEngine002ClaimGate(unittest.TestCase):
             run=Path(td); (run/'06_metrics').mkdir()
             (run/'06_metrics/computed_metrics.json').write_text(json.dumps({}))
             out=RecursiveMachineLaborClaimGate.evaluate(run)
-            self.assertEqual(out['status'],'not_supported')
-            self.assertTrue(out['failed_requirements'])
+            self.assertEqual(out['status'],'blocked')
+            self.assertTrue(out['blocked_reasons'])
 
 
     def test_numeric_vrci_counts_as_computed(self):


### PR DESCRIPTION
### Motivation

- Make the claim gate output more explicit and forward-compatible by standardizing the negative status as `blocked` and adding a schema/version marker and clearer wording fields.
- Ensure the CLI `validate` path accepts both legacy and new keys and that validation compares normalized statuses consistently.

### Description

- Changed the negative status from `not_supported` to `blocked` and renamed `failed_requirements` to `blocked_reasons` in `RecursiveMachineLaborClaimGate.evaluate` and adjusted the public wording key to `allowed_public_wording`.
- Added `schema_version`, `claim_text`, and `claim_boundary` fields to the claim gate output and preserved existing supporting artifact and metric fields.
- Updated `cli.validate` to accept legacy keys (`failed_requirements`, `allowed_public_sentence`) and to compare gate status using the new helper `_normalize_claim_gate_status` that maps `not_supported` to `blocked`.
- Updated unit tests to expect the new `blocked` status and `blocked_reasons` key in `tests/test_engine_002_claim_gate.py`.

### Testing

- Ran the modified unit test file with `pytest tests/test_engine_002_claim_gate.py -q` and the tests passed.
- Ran the repository test suite with `pytest -q` and the run completed successfully with the updated assertions and compatibility handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e65d73d3c8333acf86000284860ec)