### PR TITLE
Implement AGI ALPHA Engine 002: measured recursive machine labor

### DIFF
--- a/agialpha_engine/empirical_tasks.py
+++ b/agialpha_engine/empirical_tasks.py
@@ -1,0 +1,27 @@
+"""Empirical task loading helpers for Engine-002 fixtures."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_task_manifest(task_dir: Path) -> dict[str, Any]:
+    task_dir = Path(task_dir)
+    task = json.loads((task_dir / "task.json").read_text(encoding="utf-8"))
+    fixture = json.loads((task_dir / "fixture.json").read_text(encoding="utf-8"))
+    return {
+        "task_id": task.get("task_id", task_dir.name),
+        "task_dir": str(task_dir),
+        "task": task,
+        "fixture": fixture,
+        "expected": task.get("expected", {}),
+    }
+
+
+def discover_tasks(root: Path) -> list[dict[str, Any]]:
+    root = Path(root)
+    manifests: list[dict[str, Any]] = []
+    for task_file in sorted(root.glob("**/task.json")):
+        manifests.append(load_task_manifest(task_file.parent))
+    return manifests

--- a/agialpha_engine/evaluator.py
+++ b/agialpha_engine/evaluator.py
@@ -1,1 +1,35 @@
-"""AGI ALPHA ENGINE-001 module placeholder."""
+"""Evaluator utilities for empirical task results."""
+from __future__ import annotations
+
+from typing import Any
+from .context import BOUNDARIES
+from .sandbox import artifact_hash
+
+
+def build_task_result(*, task_id: str, candidate_id: str, baseline_id: str, seed: int, sandbox_record: dict[str, Any], validator_results: list[dict[str, Any]], raw_scores: dict[str, Any], cost_proxy: float = 0.0, safety_counters: dict[str, Any] | None = None, source_logs: list[str] | None = None) -> dict[str, Any]:
+    safety_counters = safety_counters or {}
+    source_logs = source_logs or []
+    passed = all(bool(v.get("pass")) for v in validator_results) and sandbox_record.get("status") != "blocked"
+    record = {
+        "task_result_id": f"task-result-{task_id}-{candidate_id}-{seed}",
+        "task_id": task_id,
+        "candidate_id": candidate_id,
+        "baseline_id": baseline_id,
+        "seed": int(seed),
+        "sandbox_id": sandbox_record.get("sandbox_id", "unknown"),
+        "validator_results": validator_results,
+        "raw_scores": raw_scores,
+        "cost_proxy": float(cost_proxy),
+        "safety_counters": safety_counters,
+        "artifact_hashes": {
+            "sandbox_record_hash": artifact_hash(sandbox_record),
+            "validator_results_hash": artifact_hash(validator_results),
+            "raw_scores_hash": artifact_hash(raw_scores),
+        },
+        "passed": bool(passed),
+        "failure_reason": "" if passed else "validator_or_sandbox_failure",
+        "claim_boundary": BOUNDARIES["claim_boundary"],
+        "source_logs": list(source_logs),
+        **BOUNDARIES,
+    }
+    return record

--- a/secure_rails/human_review.py
+++ b/secure_rails/human_review.py
@@ -19,7 +19,7 @@ def validate_promotion_gate(record: dict) -> list[str]:
     if cond.get("human_review_decision_present") is not True: errs.append("human_review_decision_present must be true")
     if cond.get("hard_safety_counters_zero") is not True: errs.append("hard_safety_counters_zero must be true")
     if cond.get("auto_merge_allowed") is not False: errs.append("auto_merge_allowed must be false")
-    review_status = str(record.get("human_review_status", "accepted")).strip().lower()
+    review_status = str(record.get("human_review_status", "pending")).strip().lower()
     if review_status not in {"accepted", "rejected", "needs_changes", "pending"}:
         errs.append("human_review_status invalid")
     if review_status == "pending":

--- a/tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json
+++ b/tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json
@@ -14,5 +14,6 @@
   },
   "gate_status": "pass",
   "failure_reasons": [],
-  "claim_boundary": "Promotion gates enforce human-governed SecureRails promotion. Passing a gate is not a security certification."
+  "claim_boundary": "Promotion gates enforce human-governed SecureRails promotion. Passing a gate is not a security certification.",
+  "human_review_status": "accepted"
 }


### PR DESCRIPTION
### Motivation
- Replace placeholder modules with core deterministic utilities so the engine can produce and evaluate empirical recursive machine-labor evidence without hard-coded wins or implicit promotion.

### Description
- Add `agialpha_engine/empirical_tasks.py` to discover and load task fixtures deterministically from `task.json`/`fixture.json` directories.
- Implement `agialpha_engine/evaluator.py` with `build_task_result(...)` that emits raw task-result records including validator outcomes, artifact hashes, sandbox linkage, pass/fail status, and boundary metadata.
- Tighten human-review defaults in `secure_rails/human_review.py` so missing `human_review_status` defaults to `pending` (preventing implicit acceptance) and update the valid promotion fixture to include an explicit `human_review_status: "accepted"`.
- Small commit hygiene: new modules are importable and designed to integrate with the existing engine proof flow (no network calls, deterministic seeds, stable JSON hashing).

### Testing
- Ran `python -m unittest discover -s tests -p 'test_securerails_promotion_gate.py' -q`, and the promotion-gate test passed after the changes.
- An earlier broader test run surfaced an unrelated missing test helper (`engine_proof_helpers`), causing import errors; that issue is outside the narrow scope of these modules and is flagged for follow-up rather than masked by changes here.
- Performed local inspections to confirm the new modules are present, importable, and emit the expected structured outputs used by the engine proof flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1c5027248333b6678085458163d1)