### PR TITLE
Engine-003: require 5 jobs for claim gate and emit registry.json

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -99,6 +99,7 @@ def run_network_compounding(args):
     atomic_write_json(out/'evidence-run-manifest.json',{"run":str(out),"run_id":run_id,"registry":str(reg),**_base()})
     # registry + generated placeholders
     atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json',{"receipts":[receipt],**_base()}); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()})
+    atomic_write_json(reg/'registry.json',{"latest_run_id":run_id,"runs":[run_id],**_base()})
 
 def replay_network_compounding(args):
     run=Path(args.run)
@@ -166,7 +167,7 @@ def falsification_network_compounding(args):
     comparison=_read(run/'06_heldout_reuse_tests/comparison.json',{})
     distinct_targets=len({i.get('target_agent_id') for i in imports if i.get('target_agent_id')})
     claim_ok=(
-        len(jobs) >= 3
+        len(jobs) >= 5
         and len(accepted) >= 1
         and distinct_targets >= 3
         and comparison.get('D_shared_skill_network',0) > comparison.get('D_no_shared_skill',0)
@@ -206,7 +207,7 @@ def validate_network_compounding(args):
     imports=_read(run/'05_skill_import/skill_import_events.json',{}).get('skill_import_events',[])
     comparison=_read(run/'06_heldout_reuse_tests/comparison.json',{})
     recomputed_gate_supported=(
-        len(jobs) >= 3
+        len(jobs) >= 5
         and len(accepted) >= 1
         and len({i.get('target_agent_id') for i in imports if i.get('target_agent_id')}) >= 3
         and comparison.get('D_shared_skill_network',0) > comparison.get('D_no_shared_skill',0)


### PR DESCRIPTION
### Motivation
- Enforce the Engine-003 local-bounded evidence requirement more strictly and ensure the skill-network registry exposes a simple run-level index for generated runs.

### Description
- Tighten the Engine-003 claim gate to require at least `5` jobs when computing the falsification-time gate and during validation recomputation in `agialpha_engine/network_compounding.py`.
- Emit an explicit `agialpha_skill_network_registry/registry.json` with `latest_run_id` and `runs` entries at the end of `network-compounding-run` so consumers can find run-level metadata.

### Testing
- Ran the end-to-end sequence: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`, `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`, and `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network`, all of which completed successfully.
- Ran the test suite with `python -m unittest discover -s tests`, which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f814e75a88333a1229a2bbddf46db)