### PR TITLE
Implement AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -165,8 +165,10 @@ def falsification_network_compounding(args):
     imports=_read(run/'05_skill_import/skill_import_events.json',{}).get('skill_import_events',[])
     comparison=_read(run/'06_heldout_reuse_tests/comparison.json',{})
     distinct_targets=len({i.get('target_agent_id') for i in imports if i.get('target_agent_id')})
+    extraction_total=len(accepted)+len(_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[]))+len(_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[]))
     claim_ok=(
-        len(jobs) >= 3
+        len(jobs) >= 5
+        and extraction_total == len(jobs)
         and len(accepted) >= 1
         and distinct_targets >= 3
         and comparison.get('D_shared_skill_network',0) > comparison.get('D_no_shared_skill',0)
@@ -205,8 +207,11 @@ def validate_network_compounding(args):
     accepted=_read(run/'03_skill_extraction/accepted_skill_packages.json',{}).get('accepted_skill_packages',[])
     imports=_read(run/'05_skill_import/skill_import_events.json',{}).get('skill_import_events',[])
     comparison=_read(run/'06_heldout_reuse_tests/comparison.json',{})
+    rejected=_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[])
+    failures=_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[])
     recomputed_gate_supported=(
-        len(jobs) >= 3
+        len(jobs) >= 5
+        and (len(accepted)+len(rejected)+len(failures) == len(jobs))
         and len(accepted) >= 1
         and len({i.get('target_agent_id') for i in imports if i.get('target_agent_id')}) >= 3
         and comparison.get('D_shared_skill_network',0) > comparison.get('D_no_shared_skill',0)

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -140,6 +140,24 @@ def replay_network_compounding(args):
     atomic_write_json(run/'03_skill_extraction/accepted_skill_packages.json',{'accepted_skill_packages':skills, **_base()})
     _sync_run_to_registry(run)
 
+
+
+def _job_outcome_coverage(jobs, accepted, rejected, failures):
+    job_ids=[j.get('job_id') for j in jobs if j.get('job_id')]
+    if len(job_ids) != len(jobs):
+        return False
+    outcome_job_ids=[]
+    outcome_job_ids.extend([r.get('source_job_id') for r in accepted])
+    outcome_job_ids.extend([r.get('source_job_id') for r in rejected])
+    outcome_job_ids.extend([r.get('source_job_id') for r in failures])
+    if any(jid is None for jid in outcome_job_ids):
+        return False
+    if len(outcome_job_ids) != len(jobs):
+        return False
+    if len(set(outcome_job_ids)) != len(outcome_job_ids):
+        return False
+    return set(outcome_job_ids) == set(job_ids)
+
 def falsification_network_compounding(args):
     run=Path(args.run)
     replay=_read(run/'11_replay/replay_report.json',{})
@@ -165,10 +183,12 @@ def falsification_network_compounding(args):
     imports=_read(run/'05_skill_import/skill_import_events.json',{}).get('skill_import_events',[])
     comparison=_read(run/'06_heldout_reuse_tests/comparison.json',{})
     distinct_targets=len({i.get('target_agent_id') for i in imports if i.get('target_agent_id')})
-    extraction_total=len(accepted)+len(_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[]))+len(_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[]))
+    rejected=_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[])
+    failures=_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[])
+    exact_one_outcome_per_job=_job_outcome_coverage(jobs, accepted, rejected, failures)
     claim_ok=(
         len(jobs) >= 5
-        and extraction_total == len(jobs)
+        and exact_one_outcome_per_job
         and len(accepted) >= 1
         and distinct_targets >= 3
         and comparison.get('D_shared_skill_network',0) > comparison.get('D_no_shared_skill',0)
@@ -209,9 +229,10 @@ def validate_network_compounding(args):
     comparison=_read(run/'06_heldout_reuse_tests/comparison.json',{})
     rejected=_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[])
     failures=_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[])
+    exact_one_outcome_per_job=_job_outcome_coverage(jobs, accepted, rejected, failures)
     recomputed_gate_supported=(
         len(jobs) >= 5
-        and (len(accepted)+len(rejected)+len(failures) == len(jobs))
+        and exact_one_outcome_per_job
         and len(accepted) >= 1
         and len({i.get('target_agent_id') for i in imports if i.get('target_agent_id')}) >= 3
         and comparison.get('D_shared_skill_network',0) > comparison.get('D_no_shared_skill',0)

--- a/agialpha_skill_network_registry/lineage_graph.json
+++ b/agialpha_skill_network_registry/lineage_graph.json
@@ -5,6 +5,10 @@
     {
       "from": "job-1",
       "to": "skill-1"
+    },
+    {
+      "from": "job-4",
+      "to": "skill-4"
     }
   ],
   "human_review_required": true,

--- a/agialpha_skill_network_registry/network_skill_metrics.json
+++ b/agialpha_skill_network_registry/network_skill_metrics.json
@@ -1,5 +1,5 @@
 {
-  "B6_shared_skill_advantage_delta": 0.08,
+  "B6_shared_skill_advantage_delta": 0.0746,
   "B6_shared_skill_beats_B5_no_shared_skill": true,
   "accepted_skill_packages": 2,
   "adversarial_failures_caught": 8,
@@ -23,8 +23,8 @@
   "jobs_run": 5,
   "jobs_with_skill_extraction": 5,
   "malware_generation_count": 0,
-  "network_skill_multiplier": 1.1515,
-  "network_skill_propagation_lift": 0.08,
+  "network_skill_multiplier": 1.1464,
+  "network_skill_propagation_lift": 0.0746,
   "no_auto_merge": true,
   "raw_secret_leak_count": 0,
   "raw_task_result_ids": [

--- a/docs/_generated/agialpha-skill-network/b6_vs_b5.json
+++ b/docs/_generated/agialpha-skill-network/b6_vs_b5.json
@@ -1,5 +1,5 @@
 {
-  "B6_shared_skill_advantage_delta": 0.08,
+  "B6_shared_skill_advantage_delta": 0.0746,
   "B6_shared_skill_beats_B5_no_shared_skill": true,
   "accepted_skill_packages": 2,
   "adversarial_failures_caught": 8,
@@ -23,8 +23,8 @@
   "jobs_run": 5,
   "jobs_with_skill_extraction": 5,
   "malware_generation_count": 0,
-  "network_skill_multiplier": 1.1515,
-  "network_skill_propagation_lift": 0.08,
+  "network_skill_multiplier": 1.1464,
+  "network_skill_propagation_lift": 0.0746,
   "no_auto_merge": true,
   "raw_secret_leak_count": 0,
   "raw_task_result_ids": [

--- a/docs/_generated/agialpha-skill-network/lineage_graph.json
+++ b/docs/_generated/agialpha-skill-network/lineage_graph.json
@@ -5,6 +5,10 @@
     {
       "from": "job-1",
       "to": "skill-1"
+    },
+    {
+      "from": "job-4",
+      "to": "skill-4"
     }
   ],
   "human_review_required": true,

--- a/docs/_generated/agialpha-skill-network/network_skill_metrics.json
+++ b/docs/_generated/agialpha-skill-network/network_skill_metrics.json
@@ -1,5 +1,5 @@
 {
-  "B6_shared_skill_advantage_delta": 0.08,
+  "B6_shared_skill_advantage_delta": 0.0746,
   "B6_shared_skill_beats_B5_no_shared_skill": true,
   "accepted_skill_packages": 2,
   "adversarial_failures_caught": 8,
@@ -23,8 +23,8 @@
   "jobs_run": 5,
   "jobs_with_skill_extraction": 5,
   "malware_generation_count": 0,
-  "network_skill_multiplier": 1.1515,
-  "network_skill_propagation_lift": 0.08,
+  "network_skill_multiplier": 1.1464,
+  "network_skill_propagation_lift": 0.0746,
   "no_auto_merge": true,
   "raw_secret_leak_count": 0,
   "raw_task_result_ids": [

--- a/docs/_generated/agialpha-skill-network/summary.json
+++ b/docs/_generated/agialpha-skill-network/summary.json
@@ -1,5 +1,5 @@
 {
-  "B6_shared_skill_advantage_delta": 0.08,
+  "B6_shared_skill_advantage_delta": 0.0746,
   "B6_shared_skill_beats_B5_no_shared_skill": true,
   "accepted_skill_packages": 2,
   "adversarial_failures_caught": 8,
@@ -23,8 +23,8 @@
   "jobs_run": 5,
   "jobs_with_skill_extraction": 5,
   "malware_generation_count": 0,
-  "network_skill_multiplier": 1.1515,
-  "network_skill_propagation_lift": 0.08,
+  "network_skill_multiplier": 1.1464,
+  "network_skill_propagation_lift": 0.0746,
   "no_auto_merge": true,
   "raw_secret_leak_count": 0,
   "raw_task_result_ids": [


### PR DESCRIPTION
### Motivation
- Enforce the ENGINE-003 evidence rules so a networked skill-compounding claim is only allowed when strict, measurable evidence exists (sufficient jobs, one extraction outcome per job, proof + docket + replay + falsification, and multi-agent imports). 
- Replace placeholder/hard-coded metrics with values derived from deterministic run/replay/falsification artifacts so metrics and claim gates come from raw evaluator logs and replay-resolved data.

### Description
- Tightened the Network Compounding claim gate to require at least `5` jobs and that every job produced exactly one extraction outcome (accepted skill, rejected candidate, or failure-learning package) before allowing `supported_local_bounded` in the falsification logic. 
- Strengthened the validation recomputation to require the same evidence coverage (`jobs >= 5` and accepted+rejected+failures == jobs) and to fail if the claim-gate does not match recomputed evidence. 
- Regenerated and committed deterministic run-derived artifacts (network skill metrics, B6-vs-B5 documents, lineage graph) so registry and generated docs reflect computed lifts and multipliers rather than stale placeholders. 
- Preserved existing boundaries and safety metadata (human review required, no auto-merge, regulated/token/claim boundaries) in all produced artifacts and ensured metrics are recomputed from raw held-out results during replay and falsification steps.

### Testing
- Ran the deterministic end-to-end sequence: `python -m agialpha_engine network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and each step completed successfully. 
- Executed the full test suite with `python -m unittest discover -s tests`, which ran 462 tests and completed with `OK`.
- Verified that `network-compounding-validate` fails when required replay/falsification or evidence coverage are missing, and verified replay/falsification update metrics and claim-gate artifacts as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f85d6e83c83338bcd160be45e199b)