### PR TITLE
Harden Engine-003 network validation artifact requirements

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -200,7 +200,7 @@ def falsification_network_compounding(args):
 
 def validate_network_compounding(args):
     run=Path(args.run)
-    req=['00_manifest.json','03_skill_extraction/accepted_skill_packages.json','05_skill_import/skill_import_events.json','06_heldout_reuse_tests/comparison.json','07_metrics/network_skill_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json','13_claim_gate/network_compounding_claim_gate.json']
+    req=['00_manifest.json','02_jobs/source_jobs.json','03_skill_extraction/accepted_skill_packages.json','03_skill_extraction/rejected_skill_candidates.json','03_skill_extraction/failure_learning_packages.json','05_skill_import/skill_import_events.json','06_heldout_reuse_tests/comparison.json','07_metrics/network_skill_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json','13_claim_gate/network_compounding_claim_gate.json']
     miss=[x for x in req if not (run/x).exists()]
     if miss:
         raise SystemExit(f'missing artifacts: {miss}')


### PR DESCRIPTION
### Motivation
- Prevent bypass of per-job outcome coverage checks by ensuring validation requires the full set of skill-extraction and source-job artifacts so the claim gate cannot be satisfied with partial outputs.

### Description
- Tighten `validate_network_compounding` in `agialpha_engine/network_compounding.py` to require `02_jobs/source_jobs.json`, `03_skill_extraction/rejected_skill_candidates.json`, and `03_skill_extraction/failure_learning_packages.json` in addition to the existing artifacts before validation proceeds.

### Testing
- Executed the Engine-003 pipeline with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` followed by `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and the flow completed without validation artifact errors.
- Ran the full test suite with `python -m unittest discover -s tests` which executed 462 tests and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa7d6894083338cc784d0f9c501a5)