### PR TITLE
Improve replay prerequisite error messages for network compounding checks

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -163,7 +163,7 @@ def falsification_network_compounding(args):
     replay=_read(run/'11_replay/replay_report.json',{})
     replay_pass_field=replay.get('replay_pass')
     if not isinstance(replay_pass_field,bool):
-        raise SystemExit('network-compounding-falsification-audit failed: replay_pass must be boolean')
+        raise SystemExit('network-compounding-falsification-audit failed: replay_pass must be boolean (run network-compounding-replay first)')
     replay_passes=int(replay.get('replay_passes',0))
     if replay_pass_field != (replay_passes > 0):
         raise SystemExit('network-compounding-falsification-audit failed: replay report inconsistent (replay_pass vs replay_passes)')
@@ -209,7 +209,7 @@ def validate_network_compounding(args):
     replay_pass_field=replay.get('replay_pass')
     replay_passes=int(replay.get('replay_passes',0))
     if not isinstance(replay_pass_field,bool):
-        raise SystemExit('network-compounding-validate failed: replay_pass must be boolean')
+        raise SystemExit('network-compounding-validate failed: replay_pass must be boolean (run network-compounding-replay first)')
     if replay_pass_field != (replay_passes > 0):
         raise SystemExit('network-compounding-validate failed: replay report inconsistent (replay_pass vs replay_passes)')
     replay_ok=replay_pass_field and replay_passes > 0


### PR DESCRIPTION
### Motivation
- Reduce operator confusion when falsification/validation fails due to missing replay artifacts by making the replay prerequisite explicit for the Engine-003 network compounding flow.

### Description
- Update `agialpha_engine/network_compounding.py` to clarify error messages in `falsification_network_compounding` and `validate_network_compounding` so the failures now instruct to `run network-compounding-replay` when `replay_pass` is not a boolean.

### Testing
- Ran the full Engine-003 pipeline end-to-end with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123 && python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test && python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test && python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test && python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network` which completed successfully.
- Ran `pytest -q tests/test_agialpha_skill_network_run.py` which passed (`19 passed`).
- Ran `python -m unittest discover -s tests` which completed successfully (`462 tests, OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbf055acc83339201c890c600389f)