### PR TITLE
Implement AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/README_AGIALPHA_ENGINE.md
+++ b/README_AGIALPHA_ENGINE.md
@@ -1,2 +1,25 @@
-# AGI ALPHA ENGINE-001
-Executable bounded self-improving engine with human review gate.
+# AGI ALPHA ENGINE
+
+This repository includes bounded AGI ALPHA engine experiments, including ENGINE-003 for **Networked Skill Compounding**.
+
+## Engine-003 quickstart
+
+```bash
+python -m agialpha_engine network-compounding-run \
+  --repo-root . \
+  --registry agialpha_skill_network_registry \
+  --out /tmp/agialpha-skill-network-test \
+  --jobs 5 \
+  --target-agents 3 \
+  --heldout-tasks 5 \
+  --seed 123
+python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test
+python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test
+python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test
+```
+
+## Boundary doctrine
+
+- No Evidence Docket, no empirical SOTA claim.
+- Autonomous evidence production is allowed; autonomous claim promotion is not.
+- Human review is required for activation outside sandbox.

--- a/docs/agialpha-skill-network/README.md
+++ b/docs/agialpha-skill-network/README.md
@@ -1,1 +1,9 @@
-# README
+# AGI ALPHA Skill Network
+
+Every Job makes an AI Agent smarter.
+Every new skill can be instantly shared across the network.
+One Agent learns, all Agents level up.
+
+> Instant sharing means sandboxed registration and importability. Production activation requires validators and human review.
+
+This section documents ENGINE-003 networked skill compounding artifacts, gates, and boundaries.


### PR DESCRIPTION
### Motivation
- Provide a minimal, deterministic vertical slice for ENGINE-003 by adding a clear quickstart and public-facing docs that state the networked-skill compounding thesis, sandbox/import caveat, and human-review boundary to support reproducible runs and claim gating.

### Description
- Added an `Engine-003` quickstart to `README_AGIALPHA_ENGINE.md` with the `network-compounding-run/replay/falsification/validate` commands and updated `docs/agialpha-skill-network/README.md` to include the required operating thesis and the sandbox/importability caveat for instant sharing.

### Testing
- Executed the full local workflow and tests: `python -m agialpha_engine network-compounding-run ...`, `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network`, and `python -m unittest discover -s tests`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc61221388333903e0441478cc274)