### PR TITLE
docs: clarify exponential compounding claim boundary for Engine-003

### DIFF
--- a/README_AGIALPHA_ENGINE.md
+++ b/README_AGIALPHA_ENGINE.md
@@ -16,6 +16,8 @@ python -m agialpha_engine network-compounding-run \
 python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test
 python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test
 python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test
+
+Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.
 ```
 
 ## Boundary doctrine


### PR DESCRIPTION
### Motivation
- Prevent overclaiming by making the Engine-003 quickstart explicitly state that exponential compounding is a strategic target and current evidence only supports local bounded network skill propagation.

### Description
- Added the sentence "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only." to `README_AGIALPHA_ENGINE.md` under the Engine-003 quickstart.

### Testing
- Executed the Engine-003 CLI sequence (`python -m agialpha_engine network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`) and ran the unit test suite (`python -m unittest discover -s tests`), all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcfe05ad48333afd64104dbf700d4)