### PR TITLE
Implement AGI ALPHA Engine 003: Networked Skill Compounding (docs)

### DIFF
--- a/README_AGIALPHA_SKILL_NETWORK.md
+++ b/README_AGIALPHA_SKILL_NETWORK.md
@@ -1,2 +1,46 @@
 # AGI ALPHA Skill Network (ENGINE-003)
-Local bounded networked skill compounding with proof-bound skill packages, replay, falsification, and human review gate.
+
+AGI ALPHA ENGINE-003 implements a deterministic, local, replayable **Networked Skill Compounding Engine**.
+
+## Operating thesis
+
+Every Job makes an AI Agent smarter.  
+Every new skill can be instantly shared across the network.  
+One Agent learns, all Agents level up.
+
+### Boundary on “instant sharing”
+
+“Instant sharing” means **sandboxed registration and importability** through the Network Skill Vault. It does **not** mean production activation without validators and human review.
+
+## Canonical doctrine
+
+No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
+
+## Claim gate statuses
+
+- Claim gate status: supported_local_bounded.
+- Claim gate status: not_supported. Networked skill compounding claim not yet supported.
+- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.
+
+## What this does not claim
+
+This experiment does **not** claim achieved AGI, ASI, superintelligence, empirical SOTA, official benchmark victory, certification, legal exemption, safe autonomy, token value, token appreciation, or investment return.
+
+## Quickstart
+
+```bash
+python -m agialpha_engine network-compounding-run \
+  --repo-root . \
+  --registry agialpha_skill_network_registry \
+  --out /tmp/agialpha-skill-network-test \
+  --jobs 5 \
+  --target-agents 3 \
+  --heldout-tasks 5 \
+  --seed 123
+python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test
+python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test
+python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test
+python -m agialpha_engine network-compounding-build-data \
+  --registry agialpha_skill_network_registry \
+  --out docs/_generated/agialpha-skill-network
+```


### PR DESCRIPTION
### Motivation
- Ensure ENGINE-003 public wording and claim-boundary language are explicit and aligned with the networked-skill compounding experiment by adding the operating thesis, sandbox/import boundary, canonical doctrine, claim-gate statuses, non-claims, and quickstart commands.

### Description
- Expanded `README_AGIALPHA_SKILL_NETWORK.md` to include the exact operating thesis lines ("Every Job makes an AI Agent smarter..."), a clear boundary on "instant sharing" (sandboxed registration/importability), canonical doctrine, required claim gate status strings, an explicit non-claims list, and CLI quickstart examples for the ENGINE-003 run/replay/falsification/validate/build-data paths.

### Testing
- Executed `python -m agialpha_engine network-compounding-run ...`, `python -m agialpha_engine network-compounding-replay ...`, `python -m agialpha_engine network-compounding-falsification-audit ...`, `python -m agialpha_engine network-compounding-validate ...`, and `python -m agialpha_engine network-compounding-build-data ...`, all of which completed successfully; and ran `python -m unittest discover -s tests`, which passed (462 tests), while `python -m unittest discover -s tests -p 'test_agialpha_skill_network_docs.py'` matched no tests and reported "NO TESTS RAN."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fde8604f8833396d289c35e02bc08)