### PR TITLE
Implement AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_skill_network_registry/network_compounding_runs.json
+++ b/agialpha_skill_network_registry/network_compounding_runs.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "agialpha-network-compounding-runs/v1",
+  "items": []
+}

--- a/agialpha_skill_network_registry/registry.json
+++ b/agialpha_skill_network_registry/registry.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "agialpha-skill-network-registry/v1",
+  "append_only": true,
+  "runs": [],
+  "updated_at": null
+}

--- a/agialpha_skill_network_registry/skill_propagation_events.json
+++ b/agialpha_skill_network_registry/skill_propagation_events.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "agialpha-skill-propagation-events/v1",
+  "items": []
+}

--- a/docs/agialpha-skill-network/exponential-compounding-boundary.md
+++ b/docs/agialpha-skill-network/exponential-compounding-boundary.md
@@ -1,0 +1,13 @@
+# Exponential Compounding Boundary
+
+Exponential compounding language is **strategic-target only** unless the exponential claim gate passes.
+
+Required evidence for measured exponential wording:
+- At least 3 completed cycles with superlinear growth signals.
+- Replay passes for all referenced cycle metrics and hashes.
+- Falsification audits pass with no unresolved critical boundary violations.
+- Claim-boundary, token-boundary, and regulated-boundary gates all pass.
+
+Default wording when evidence is insufficient:
+
+> Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.


### PR DESCRIPTION
### Motivation
- Provide missing registry scaffolding and documentation required by AGI ALPHA ENGINE-003 so networked skill compounding runs can produce append-only evidence and preserved events. 
- Make the exponential-compounding claim boundary explicit and publication-safe by encoding the evidence conditions and fallback wording.

### Description
- Add three registry scaffold files: `agialpha_skill_network_registry/registry.json`, `agialpha_skill_network_registry/network_compounding_runs.json`, and `agialpha_skill_network_registry/skill_propagation_events.json` with `schema_version` fields and empty append-only structures. 
- Add `docs/agialpha-skill-network/exponential-compounding-boundary.md` with strategic-target wording and required evidence conditions for measured exponential language. 
- Files are deterministic scaffolds (stable JSON ordering) and documentation only, with no external network calls or hidden state introduced.

### Testing
- Executed the network-compounding pipeline commands `python -m agialpha_engine network-compounding-run ...`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data` and they completed successfully. 
- Ran the repository test suite with `python -m unittest discover -s tests` and `pytest -q` and all tests passed. 
- Verified the new registry and doc files exist and are well-formed under `agialpha_skill_network_registry` and `docs/agialpha-skill-network` respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1058cd92908333b2904ff4b1448e86)