### PR TITLE
Add human_review_gate evaluator and tests (Engine-003)

### DIFF
--- a/agialpha_engine/human_review_gate.py
+++ b/agialpha_engine/human_review_gate.py
@@ -4,6 +4,25 @@ from typing import Any
 
 
 VALID_HUMAN_REVIEW_STATUSES = {"pending", "accepted", "needs_changes", "rejected"}
+REQUIRED_CHECK_FIELDS = (
+    "evidence_docket_present",
+    "proofbundle_present",
+    "replay_pass",
+    "falsification_pass",
+    "claim_boundary_pass",
+    "token_boundary_pass",
+    "regulated_boundary_pass",
+    "no_auto_merge",
+    "no_autonomous_persistence",
+)
+
+
+def _parse_strict_bool(rec: dict[str, Any], field_name: str) -> tuple[bool, bool]:
+    """Return (value, strict_bool_type) for a required gate field."""
+    value = rec.get(field_name)
+    if isinstance(value, bool):
+        return value, True
+    return False, False
 
 
 def evaluate_human_review_gate(record: dict[str, Any] | None) -> dict[str, Any]:
@@ -12,23 +31,19 @@ def evaluate_human_review_gate(record: dict[str, Any] | None) -> dict[str, Any]:
     status = str(rec.get("human_review_status", "pending")).strip().lower()
     if status not in VALID_HUMAN_REVIEW_STATUSES:
         status = "pending"
-    required = {
-        "evidence_docket_present": bool(rec.get("evidence_docket_present", False)),
-        "proofbundle_present": bool(rec.get("proofbundle_present", False)),
-        "replay_pass": bool(rec.get("replay_pass", False)),
-        "falsification_pass": bool(rec.get("falsification_pass", False)),
-        "claim_boundary_pass": bool(rec.get("claim_boundary_pass", False)),
-        "token_boundary_pass": bool(rec.get("token_boundary_pass", False)),
-        "regulated_boundary_pass": bool(rec.get("regulated_boundary_pass", False)),
-        "no_auto_merge": bool(rec.get("no_auto_merge", True)),
-        "no_autonomous_persistence": bool(rec.get("no_autonomous_persistence", True)),
-    }
+    required: dict[str, bool] = {}
+    non_boolean_required_checks: list[str] = []
+    for field_name in REQUIRED_CHECK_FIELDS:
+        parsed_value, is_strict_bool = _parse_strict_bool(rec, field_name)
+        required[field_name] = parsed_value
+        if not is_strict_bool:
+            non_boolean_required_checks.append(field_name)
     failures = [name for name, ok in required.items() if not ok]
     outside_sandbox_activation_allowed = status == "accepted" and not failures
     return {
         "human_review_status": status,
         "required_checks": required,
+        "non_boolean_required_checks": non_boolean_required_checks,
         "missing_or_failed_checks": failures,
         "outside_sandbox_activation_allowed": outside_sandbox_activation_allowed,
     }
-

--- a/agialpha_engine/human_review_gate.py
+++ b/agialpha_engine/human_review_gate.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+VALID_HUMAN_REVIEW_STATUSES = {"pending", "accepted", "needs_changes", "rejected"}
+
+
+def evaluate_human_review_gate(record: dict[str, Any] | None) -> dict[str, Any]:
+    """Evaluate local human-review requirements for sandbox-to-production activation."""
+    rec = record or {}
+    status = str(rec.get("human_review_status", "pending")).strip().lower()
+    if status not in VALID_HUMAN_REVIEW_STATUSES:
+        status = "pending"
+    required = {
+        "evidence_docket_present": bool(rec.get("evidence_docket_present", False)),
+        "proofbundle_present": bool(rec.get("proofbundle_present", False)),
+        "replay_pass": bool(rec.get("replay_pass", False)),
+        "falsification_pass": bool(rec.get("falsification_pass", False)),
+        "claim_boundary_pass": bool(rec.get("claim_boundary_pass", False)),
+        "token_boundary_pass": bool(rec.get("token_boundary_pass", False)),
+        "regulated_boundary_pass": bool(rec.get("regulated_boundary_pass", False)),
+        "no_auto_merge": bool(rec.get("no_auto_merge", True)),
+        "no_autonomous_persistence": bool(rec.get("no_autonomous_persistence", True)),
+    }
+    failures = [name for name, ok in required.items() if not ok]
+    outside_sandbox_activation_allowed = status == "accepted" and not failures
+    return {
+        "human_review_status": status,
+        "required_checks": required,
+        "missing_or_failed_checks": failures,
+        "outside_sandbox_activation_allowed": outside_sandbox_activation_allowed,
+    }
+

--- a/tests/test_agialpha_human_review_gate.py
+++ b/tests/test_agialpha_human_review_gate.py
@@ -23,3 +23,41 @@ def test_human_review_gate_allows_activation_only_with_all_checks_and_acceptance
         }
     )
     assert result["outside_sandbox_activation_allowed"] is True
+
+
+def test_human_review_gate_rejects_non_boolean_false_like_strings():
+    result = evaluate_human_review_gate(
+        {
+            "human_review_status": "accepted",
+            "evidence_docket_present": True,
+            "proofbundle_present": True,
+            "replay_pass": "false",
+            "falsification_pass": True,
+            "claim_boundary_pass": True,
+            "token_boundary_pass": True,
+            "regulated_boundary_pass": True,
+            "no_auto_merge": True,
+            "no_autonomous_persistence": True,
+        }
+    )
+    assert result["outside_sandbox_activation_allowed"] is False
+    assert "replay_pass" in result["missing_or_failed_checks"]
+    assert "replay_pass" in result["non_boolean_required_checks"]
+
+
+def test_human_review_gate_requires_explicit_safety_flags():
+    result = evaluate_human_review_gate(
+        {
+            "human_review_status": "accepted",
+            "evidence_docket_present": True,
+            "proofbundle_present": True,
+            "replay_pass": True,
+            "falsification_pass": True,
+            "claim_boundary_pass": True,
+            "token_boundary_pass": True,
+            "regulated_boundary_pass": True,
+        }
+    )
+    assert result["outside_sandbox_activation_allowed"] is False
+    assert "no_auto_merge" in result["missing_or_failed_checks"]
+    assert "no_autonomous_persistence" in result["missing_or_failed_checks"]

--- a/tests/test_agialpha_human_review_gate.py
+++ b/tests/test_agialpha_human_review_gate.py
@@ -1,63 +1,67 @@
+import unittest
+
 from agialpha_engine.human_review_gate import evaluate_human_review_gate
 
 
-def test_human_review_gate_defaults_pending_and_blocks_activation():
-    result = evaluate_human_review_gate({})
-    assert result["human_review_status"] == "pending"
-    assert result["outside_sandbox_activation_allowed"] is False
+class TestHumanReviewGate(unittest.TestCase):
+    def test_defaults_pending_and_blocks_activation(self) -> None:
+        result = evaluate_human_review_gate({})
+        self.assertEqual(result["human_review_status"], "pending")
+        self.assertFalse(result["outside_sandbox_activation_allowed"])
+
+    def test_allows_activation_only_with_all_checks_and_acceptance(self) -> None:
+        result = evaluate_human_review_gate(
+            {
+                "human_review_status": "accepted",
+                "evidence_docket_present": True,
+                "proofbundle_present": True,
+                "replay_pass": True,
+                "falsification_pass": True,
+                "claim_boundary_pass": True,
+                "token_boundary_pass": True,
+                "regulated_boundary_pass": True,
+                "no_auto_merge": True,
+                "no_autonomous_persistence": True,
+            }
+        )
+        self.assertTrue(result["outside_sandbox_activation_allowed"])
+
+    def test_rejects_non_boolean_false_like_strings(self) -> None:
+        result = evaluate_human_review_gate(
+            {
+                "human_review_status": "accepted",
+                "evidence_docket_present": True,
+                "proofbundle_present": True,
+                "replay_pass": "false",
+                "falsification_pass": True,
+                "claim_boundary_pass": True,
+                "token_boundary_pass": True,
+                "regulated_boundary_pass": True,
+                "no_auto_merge": True,
+                "no_autonomous_persistence": True,
+            }
+        )
+        self.assertFalse(result["outside_sandbox_activation_allowed"])
+        self.assertIn("replay_pass", result["missing_or_failed_checks"])
+        self.assertIn("replay_pass", result["non_boolean_required_checks"])
+
+    def test_requires_explicit_safety_flags(self) -> None:
+        result = evaluate_human_review_gate(
+            {
+                "human_review_status": "accepted",
+                "evidence_docket_present": True,
+                "proofbundle_present": True,
+                "replay_pass": True,
+                "falsification_pass": True,
+                "claim_boundary_pass": True,
+                "token_boundary_pass": True,
+                "regulated_boundary_pass": True,
+            }
+        )
+        self.assertFalse(result["outside_sandbox_activation_allowed"])
+        self.assertIn("no_auto_merge", result["missing_or_failed_checks"])
+        self.assertIn("no_autonomous_persistence", result["missing_or_failed_checks"])
 
 
-def test_human_review_gate_allows_activation_only_with_all_checks_and_acceptance():
-    result = evaluate_human_review_gate(
-        {
-            "human_review_status": "accepted",
-            "evidence_docket_present": True,
-            "proofbundle_present": True,
-            "replay_pass": True,
-            "falsification_pass": True,
-            "claim_boundary_pass": True,
-            "token_boundary_pass": True,
-            "regulated_boundary_pass": True,
-            "no_auto_merge": True,
-            "no_autonomous_persistence": True,
-        }
-    )
-    assert result["outside_sandbox_activation_allowed"] is True
-
-
-def test_human_review_gate_rejects_non_boolean_false_like_strings():
-    result = evaluate_human_review_gate(
-        {
-            "human_review_status": "accepted",
-            "evidence_docket_present": True,
-            "proofbundle_present": True,
-            "replay_pass": "false",
-            "falsification_pass": True,
-            "claim_boundary_pass": True,
-            "token_boundary_pass": True,
-            "regulated_boundary_pass": True,
-            "no_auto_merge": True,
-            "no_autonomous_persistence": True,
-        }
-    )
-    assert result["outside_sandbox_activation_allowed"] is False
-    assert "replay_pass" in result["missing_or_failed_checks"]
-    assert "replay_pass" in result["non_boolean_required_checks"]
-
-
-def test_human_review_gate_requires_explicit_safety_flags():
-    result = evaluate_human_review_gate(
-        {
-            "human_review_status": "accepted",
-            "evidence_docket_present": True,
-            "proofbundle_present": True,
-            "replay_pass": True,
-            "falsification_pass": True,
-            "claim_boundary_pass": True,
-            "token_boundary_pass": True,
-            "regulated_boundary_pass": True,
-        }
-    )
-    assert result["outside_sandbox_activation_allowed"] is False
-    assert "no_auto_merge" in result["missing_or_failed_checks"]
-    assert "no_autonomous_persistence" in result["missing_or_failed_checks"]
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agialpha_human_review_gate.py
+++ b/tests/test_agialpha_human_review_gate.py
@@ -1,0 +1,25 @@
+from agialpha_engine.human_review_gate import evaluate_human_review_gate
+
+
+def test_human_review_gate_defaults_pending_and_blocks_activation():
+    result = evaluate_human_review_gate({})
+    assert result["human_review_status"] == "pending"
+    assert result["outside_sandbox_activation_allowed"] is False
+
+
+def test_human_review_gate_allows_activation_only_with_all_checks_and_acceptance():
+    result = evaluate_human_review_gate(
+        {
+            "human_review_status": "accepted",
+            "evidence_docket_present": True,
+            "proofbundle_present": True,
+            "replay_pass": True,
+            "falsification_pass": True,
+            "claim_boundary_pass": True,
+            "token_boundary_pass": True,
+            "regulated_boundary_pass": True,
+            "no_auto_merge": True,
+            "no_autonomous_persistence": True,
+        }
+    )
+    assert result["outside_sandbox_activation_allowed"] is True


### PR DESCRIPTION
### Motivation
- Provide a deterministic local human-review gate for ENGINE-003 that enforces Evidence Docket / ProofBundle / replay / falsification and safety/token/regulated boundaries before allowing outside-sandbox activation.

### Description
- Add `agialpha_engine/human_review_gate.py` with `evaluate_human_review_gate(record)` to normalize `human_review_status`, validate required checks, list missing/failed checks, and compute `outside_sandbox_activation_allowed`, and add `tests/test_agialpha_human_review_gate.py` covering default blocking and full-acceptance cases.

### Testing
- Ran `python -m unittest discover -s tests` (all tests, including the new human-review tests) and executed the ENGINE-003 CLI flow with `python -m agialpha_engine network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, all of which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10662b23688333be3628898cd602ce)