### PR TITLE
Enhance network compounding workflows with run-path resolution, inputs, and local-run fallback

### DIFF
--- a/.github/workflows/agialpha-engine-003-network-claim-gate.yml
+++ b/.github/workflows/agialpha-engine-003-network-claim-gate.yml
@@ -1,13 +1,24 @@
-name: AGI ALPHA Engine 003 / Networked Skill Compounding
-on: {workflow_dispatch: {}, schedule: [{cron: '0 4 * * 1'}]}
-permissions: {contents: read, actions: read}
+name: AGI ALPHA Engine 003 / Networked Skill Compounding Claim Gate
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: Existing run path
+        required: false
+        default: ''
+  schedule:
+    - cron: '0 4 * * 1'
+permissions:
+  contents: read
+  actions: read
 jobs:
-  run:
+  claim-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
+        with:
+          python-version: '3.11'
       - name: SecureRails checks (if available)
         run: |
           RUNNABLE_CHECKS=(
@@ -15,18 +26,46 @@ jobs:
             scripts/secure_rails_no_automerge_check.py
             scripts/secure_rails_trust_center_check.py
           )
-          ran_any=0
           for s in "${RUNNABLE_CHECKS[@]}"; do
-            if [ -f "$s" ]; then
-              python "$s"
-              ran_any=1
-            fi
+            if [ -f "$s" ]; then python "$s"; fi
           done
-          if [ "$ran_any" -eq 0 ]; then
-            echo 'No zero-argument SecureRails checks found; skipping.'
+      - name: Resolve or create run path
+        run: |
+          if [ -n "${{ inputs.run_path }}" ]; then
+            echo "RUN_PATH=${{ inputs.run_path }}" >> "$GITHUB_ENV"
+            exit 0
           fi
-      - run: python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123
-      - run: python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network
+
+          RESOLVED_PATH=$(python - <<'PY'
+import json
+from pathlib import Path
+latest_path = Path('agialpha_skill_network_registry/latest.json')
+if not latest_path.exists():
+    print("")
+    raise SystemExit(0)
+latest = json.loads(latest_path.read_text())
+run_id = latest.get('run_id')
+if not run_id:
+    print("")
+    raise SystemExit(0)
+candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+for path in candidates:
+    if path.exists() and path.is_dir():
+        print(path)
+        break
+else:
+    print("")
+PY
+)
+
+          if [ -z "$RESOLVED_PATH" ]; then
+            echo "No runnable registry run found; creating deterministic local run for claim-gate validation."
+            RUN_PATH="/tmp/agialpha-skill-network-test"
+            python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out "$RUN_PATH" --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123
+            python -m agialpha_engine network-compounding-replay --run "$RUN_PATH"
+            python -m agialpha_engine network-compounding-falsification-audit --run "$RUN_PATH"
+            echo "RUN_PATH=$RUN_PATH" >> "$GITHUB_ENV"
+          else
+            echo "RUN_PATH=$RESOLVED_PATH" >> "$GITHUB_ENV"
+          fi
+      - run: python -m agialpha_engine network-compounding-validate --run "$RUN_PATH"

--- a/.github/workflows/agialpha-engine-003-network-compounding.yml
+++ b/.github/workflows/agialpha-engine-003-network-compounding.yml
@@ -1,13 +1,40 @@
 name: AGI ALPHA Engine 003 / Networked Skill Compounding
-on: {workflow_dispatch: {}, schedule: [{cron: '0 4 * * 1'}]}
-permissions: {contents: read, actions: read}
+on:
+  workflow_dispatch:
+    inputs:
+      jobs:
+        description: Number of source jobs
+        required: false
+        default: '5'
+      target_agents:
+        description: Number of target agents
+        required: false
+        default: '3'
+      heldout_tasks:
+        description: Number of held-out tasks
+        required: false
+        default: '5'
+      seed:
+        description: Deterministic seed
+        required: false
+        default: '123'
+      publish_skill_network_tab:
+        description: Build generated skill-network data
+        required: false
+        default: 'true'
+  schedule:
+    - cron: '0 4 * * 1'
+permissions:
+  contents: read
+  actions: read
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
+        with:
+          python-version: '3.11'
       - name: SecureRails checks (if available)
         run: |
           RUNNABLE_CHECKS=(
@@ -15,18 +42,31 @@ jobs:
             scripts/secure_rails_no_automerge_check.py
             scripts/secure_rails_trust_center_check.py
           )
-          ran_any=0
           for s in "${RUNNABLE_CHECKS[@]}"; do
-            if [ -f "$s" ]; then
-              python "$s"
-              ran_any=1
-            fi
+            if [ -f "$s" ]; then python "$s"; fi
           done
-          if [ "$ran_any" -eq 0 ]; then
-            echo 'No zero-argument SecureRails checks found; skipping.'
-          fi
-      - run: python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123
-      - run: python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network
+      - name: Run network compounding
+        run: |
+          RUN_PATH=agialpha-engine-runs/${{ github.run_id }}
+          python -m agialpha_engine network-compounding-run \
+            --repo-root . \
+            --registry agialpha_skill_network_registry \
+            --out "$RUN_PATH" \
+            --jobs "${{ inputs.jobs || '5' }}" \
+            --target-agents "${{ inputs.target_agents || '3' }}" \
+            --heldout-tasks "${{ inputs.heldout_tasks || '5' }}" \
+            --seed "${{ inputs.seed || '123' }}"
+          echo "RUN_PATH=$RUN_PATH" >> "$GITHUB_ENV"
+      - run: python -m agialpha_engine network-compounding-replay --run "$RUN_PATH"
+      - run: python -m agialpha_engine network-compounding-falsification-audit --run "$RUN_PATH"
+      - run: python -m agialpha_engine network-compounding-validate --run "$RUN_PATH"
+      - name: Build generated data
+        if: ${{ inputs.publish_skill_network_tab != 'false' }}
+        run: python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agialpha-engine-003-network-compounding
+          path: |
+            ${{ env.RUN_PATH }}
+            agialpha_skill_network_registry
+            docs/_generated/agialpha-skill-network

--- a/.github/workflows/agialpha-engine-003-network-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-003-network-falsification-audit.yml
@@ -1,13 +1,24 @@
-name: AGI ALPHA Engine 003 / Networked Skill Compounding
-on: {workflow_dispatch: {}, schedule: [{cron: '0 4 * * 1'}]}
-permissions: {contents: read, actions: read}
+name: AGI ALPHA Engine 003 / Networked Skill Compounding Falsification Audit
+on:
+  workflow_dispatch:
+    inputs:
+      run_path:
+        description: Existing run path
+        required: false
+        default: ''
+  schedule:
+    - cron: '0 4 * * 1'
+permissions:
+  contents: read
+  actions: read
 jobs:
-  run:
+  falsification:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
+        with:
+          python-version: '3.11'
       - name: SecureRails checks (if available)
         run: |
           RUNNABLE_CHECKS=(
@@ -15,18 +26,46 @@ jobs:
             scripts/secure_rails_no_automerge_check.py
             scripts/secure_rails_trust_center_check.py
           )
-          ran_any=0
           for s in "${RUNNABLE_CHECKS[@]}"; do
-            if [ -f "$s" ]; then
-              python "$s"
-              ran_any=1
-            fi
+            if [ -f "$s" ]; then python "$s"; fi
           done
-          if [ "$ran_any" -eq 0 ]; then
-            echo 'No zero-argument SecureRails checks found; skipping.'
+      - name: Resolve or create run path
+        run: |
+          if [ -n "${{ inputs.run_path }}" ]; then
+            echo "RUN_PATH=${{ inputs.run_path }}" >> "$GITHUB_ENV"
+            exit 0
           fi
-      - run: python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123
-      - run: python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test
-      - run: python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network
+
+          RESOLVED_PATH=$(python - <<'PY'
+import json
+from pathlib import Path
+latest_path = Path('agialpha_skill_network_registry/latest.json')
+if not latest_path.exists():
+    print("")
+    raise SystemExit(0)
+latest = json.loads(latest_path.read_text())
+run_id = latest.get('run_id')
+if not run_id:
+    print("")
+    raise SystemExit(0)
+candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+for path in candidates:
+    if path.exists() and path.is_dir():
+        print(path)
+        break
+else:
+    print("")
+PY
+)
+
+          if [ -z "$RESOLVED_PATH" ]; then
+            echo "No runnable registry run found; creating deterministic local run for falsification audit."
+            RUN_PATH="/tmp/agialpha-skill-network-test"
+            python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out "$RUN_PATH" --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123
+            python -m agialpha_engine network-compounding-replay --run "$RUN_PATH"
+            echo "RUN_PATH=$RUN_PATH" >> "$GITHUB_ENV"
+          else
+            echo "RUN_PATH=$RESOLVED_PATH" >> "$GITHUB_ENV"
+          fi
+      - run: python -m agialpha_engine network-compounding-falsification-audit --run "$RUN_PATH"
+      - run: python -m agialpha_engine network-compounding-validate --run "$RUN_PATH"

--- a/.github/workflows/agialpha-engine-003-network-replay.yml
+++ b/.github/workflows/agialpha-engine-003-network-replay.yml
@@ -3,19 +3,22 @@ on:
   workflow_dispatch:
     inputs:
       run_path:
-        description: "Existing run path to replay (optional; defaults to registry latest run)"
+        description: Existing run path
         required: false
-        type: string
+        default: ''
   schedule:
     - cron: '0 4 * * 1'
-permissions: {contents: read, actions: read}
+permissions:
+  contents: read
+  actions: read
 jobs:
   replay:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
+        with:
+          python-version: '3.11'
       - name: SecureRails checks (if available)
         run: |
           RUNNABLE_CHECKS=(
@@ -23,33 +26,44 @@ jobs:
             scripts/secure_rails_no_automerge_check.py
             scripts/secure_rails_trust_center_check.py
           )
-          ran_any=0
           for s in "${RUNNABLE_CHECKS[@]}"; do
-            if [ -f "$s" ]; then
-              python "$s"
-              ran_any=1
-            fi
+            if [ -f "$s" ]; then python "$s"; fi
           done
-          if [ "$ran_any" -eq 0 ]; then
-            echo 'No zero-argument SecureRails checks found; skipping.'
-          fi
-      - name: Resolve run path
-        id: runpath
+      - name: Resolve or create run path
         run: |
           if [ -n "${{ inputs.run_path }}" ]; then
             echo "RUN_PATH=${{ inputs.run_path }}" >> "$GITHUB_ENV"
-          else
-            python - <<'PY'
+            exit 0
+          fi
+
+          RESOLVED_PATH=$(python - <<'PY'
 import json
 from pathlib import Path
-latest = json.loads(Path('agialpha_skill_network_registry/latest.json').read_text())
+latest_path = Path('agialpha_skill_network_registry/latest.json')
+if not latest_path.exists():
+    print("")
+    raise SystemExit(0)
+latest = json.loads(latest_path.read_text())
 run_id = latest.get('run_id')
 if not run_id:
-    raise SystemExit('No run_id in agialpha_skill_network_registry/latest.json')
-print(f'RUN_PATH=agialpha_skill_network_registry/runs/{run_id}')
+    print("")
+    raise SystemExit(0)
+candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+for path in candidates:
+    if path.exists() and path.is_dir():
+        print(path)
+        break
+else:
+    print("")
 PY
+)
+
+          if [ -z "$RESOLVED_PATH" ]; then
+            echo "No runnable registry run found; creating deterministic local run for replay."
+            RUN_PATH="/tmp/agialpha-skill-network-test"
+            python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out "$RUN_PATH" --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123
+            echo "RUN_PATH=$RUN_PATH" >> "$GITHUB_ENV"
+          else
+            echo "RUN_PATH=$RESOLVED_PATH" >> "$GITHUB_ENV"
           fi
       - run: python -m agialpha_engine network-compounding-replay --run "$RUN_PATH"
-      - run: python -m agialpha_engine network-compounding-falsification-audit --run "$RUN_PATH"
-      - run: python -m agialpha_engine network-compounding-validate --run "$RUN_PATH"
-      - run: python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network


### PR DESCRIPTION
### Motivation
- Make workflow runs more flexible by allowing callers to provide an existing `run_path` and other execution parameters.  
- Ensure replay, falsification, claim-gate and compounding workflows can operate when the registry has no published latest run by creating a deterministic local run for validation.  
- Simplify and standardize pre-run checks and job naming to improve maintainability and artifact capture.

### Description
- Added workflow inputs for `run_path`, `jobs`, `target_agents`, `heldout_tasks`, `seed`, and `publish_skill_network_tab` and switched several job names for clarity (e.g. `claim-gate`, `falsification`).  
- Implemented run path resolution logic in the jobs that checks `agialpha_skill_network_registry/latest.json` and examines candidate directories, and falls back to creating a deterministic local run using `python -m agialpha_engine network-compounding-run` when no runnable registry run is found.  
- Simplified the SecureRails check loop to call available checks if present and removed the unused `ran_any` tracking.  
- Made the compounding job emit `RUN_PATH` to the environment, conditionally build generated data when `publish_skill_network_tab` is not `false`, and upload artifacts via `actions/upload-artifact@v4`.

### Testing
- No automated tests were executed as part of this change to the workflow YAML files.  
- The changes are limited to GitHub Actions workflow definitions and were prepared to be exercised by CI when the workflows are triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107fe0ba1083339b452d57352bc589)