### PR TITLE
Implement AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_skill_network_registry/evidence_dockets.json
+++ b/agialpha_skill_network_registry/evidence_dockets.json
@@ -1,0 +1,44 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "evidence_dockets": [
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
+      "human_review_required": true,
+      "includes_baseline_regressions": true,
+      "includes_evaluator_disagreement": true,
+      "includes_failures": true,
+      "includes_falsification_attempts": true,
+      "includes_rejected_claims": true,
+      "includes_successes": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "schema_version": "agialpha.engine003.evidence_docket.v1",
+      "skill_id": "skill-1",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
+      "human_review_required": true,
+      "includes_baseline_regressions": true,
+      "includes_evaluator_disagreement": true,
+      "includes_failures": true,
+      "includes_falsification_attempts": true,
+      "includes_rejected_claims": true,
+      "includes_successes": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "schema_version": "agialpha.engine003.evidence_docket.v1",
+      "skill_id": "skill-4",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    }
+  ],
+  "human_review_required": true,
+  "no_auto_merge": true,
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/agialpha_skill_network_registry/proofbundles.json
+++ b/agialpha_skill_network_registry/proofbundles.json
@@ -16,7 +16,7 @@
         "raw-job-1"
       ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
-      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run agialpha-engine-runs/network-skill-test",
       "schema_version": "agialpha.engine003.proofbundle.v1",
       "skill_id": "skill-1",
       "source_agent_id": "agent-1",
@@ -35,7 +35,7 @@
         "raw-job-4"
       ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
-      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run agialpha-engine-runs/network-skill-test",
       "schema_version": "agialpha.engine003.proofbundle.v1",
       "skill_id": "skill-4",
       "source_agent_id": "agent-1",

--- a/agialpha_skill_network_registry/proofbundles.json
+++ b/agialpha_skill_network_registry/proofbundles.json
@@ -1,0 +1,48 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "human_review_required": true,
+  "no_auto_merge": true,
+  "proofbundles": [
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "deterministic_seed": 123,
+      "human_review_required": true,
+      "human_review_status": "pending",
+      "no_auto_merge": true,
+      "proofbundle_id": "pb-skill-1",
+      "raw_task_result_ids": [
+        "raw-job-1"
+      ],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "schema_version": "agialpha.engine003.proofbundle.v1",
+      "skill_id": "skill-1",
+      "source_agent_id": "agent-1",
+      "source_job_id": "job-1",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "deterministic_seed": 123,
+      "human_review_required": true,
+      "human_review_status": "pending",
+      "no_auto_merge": true,
+      "proofbundle_id": "pb-skill-4",
+      "raw_task_result_ids": [
+        "raw-job-4"
+      ],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "schema_version": "agialpha.engine003.proofbundle.v1",
+      "skill_id": "skill-4",
+      "source_agent_id": "agent-1",
+      "source_job_id": "job-4",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    }
+  ],
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/docs/_generated/agialpha-skill-network/evidence_dockets.json
+++ b/docs/_generated/agialpha-skill-network/evidence_dockets.json
@@ -1,0 +1,44 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "evidence_dockets": [
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
+      "human_review_required": true,
+      "includes_baseline_regressions": true,
+      "includes_evaluator_disagreement": true,
+      "includes_failures": true,
+      "includes_falsification_attempts": true,
+      "includes_rejected_claims": true,
+      "includes_successes": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "schema_version": "agialpha.engine003.evidence_docket.v1",
+      "skill_id": "skill-1",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
+      "human_review_required": true,
+      "includes_baseline_regressions": true,
+      "includes_evaluator_disagreement": true,
+      "includes_failures": true,
+      "includes_falsification_attempts": true,
+      "includes_rejected_claims": true,
+      "includes_successes": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "schema_version": "agialpha.engine003.evidence_docket.v1",
+      "skill_id": "skill-4",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    }
+  ],
+  "human_review_required": true,
+  "no_auto_merge": true,
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/docs/_generated/agialpha-skill-network/proofbundles.json
+++ b/docs/_generated/agialpha-skill-network/proofbundles.json
@@ -16,7 +16,7 @@
         "raw-job-1"
       ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
-      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run agialpha-engine-runs/network-skill-test",
       "schema_version": "agialpha.engine003.proofbundle.v1",
       "skill_id": "skill-1",
       "source_agent_id": "agent-1",
@@ -35,7 +35,7 @@
         "raw-job-4"
       ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
-      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run agialpha-engine-runs/network-skill-test",
       "schema_version": "agialpha.engine003.proofbundle.v1",
       "skill_id": "skill-4",
       "source_agent_id": "agent-1",

--- a/docs/_generated/agialpha-skill-network/proofbundles.json
+++ b/docs/_generated/agialpha-skill-network/proofbundles.json
@@ -1,0 +1,48 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "human_review_required": true,
+  "no_auto_merge": true,
+  "proofbundles": [
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "deterministic_seed": 123,
+      "human_review_required": true,
+      "human_review_status": "pending",
+      "no_auto_merge": true,
+      "proofbundle_id": "pb-skill-1",
+      "raw_task_result_ids": [
+        "raw-job-1"
+      ],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "schema_version": "agialpha.engine003.proofbundle.v1",
+      "skill_id": "skill-1",
+      "source_agent_id": "agent-1",
+      "source_job_id": "job-1",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "deterministic_seed": 123,
+      "human_review_required": true,
+      "human_review_status": "pending",
+      "no_auto_merge": true,
+      "proofbundle_id": "pb-skill-4",
+      "raw_task_result_ids": [
+        "raw-job-4"
+      ],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "replay_command": "python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test",
+      "schema_version": "agialpha.engine003.proofbundle.v1",
+      "skill_id": "skill-4",
+      "source_agent_id": "agent-1",
+      "source_job_id": "job-4",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    }
+  ],
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}


### PR DESCRIPTION
### Motivation
- Complete a deterministic vertical slice for AGI ALPHA ENGINE-003 by producing missing ProofBundle and Evidence Docket artifacts required for the Networked Skill Compounding run and public/generated data. 
- Ensure the run outputs, registry entries, and generated docs contain the ProofBundles and Evidence Dockets so downstream replay, falsification, validation, and claim-gate logic have concrete artifacts to verify. 
- Preserve claim/boundary hygiene: evidence-only artifacts, human-review required, no autonomous persistence, and utility-only Work Vault semantics are maintained.

### Description
- Added registry artifacts `agialpha_skill_network_registry/proofbundles.json` and `agialpha_skill_network_registry/evidence_dockets.json` containing deterministic ProofBundle and Evidence Docket entries for produced skills. 
- Added generated docs mirror files `docs/_generated/agialpha-skill-network/proofbundles.json` and `docs/_generated/agialpha-skill-network/evidence_dockets.json` so the public data build includes these artifacts for the Skill Network UI. 
- Ran the Engine-003 deterministic run path to emit and synchronize the full minimal evidence chain (skill packages, proofbundles, evidence dockets, metrics, receipts) without introducing new engine code or overclaims.

### Testing
- Ran the end-to-end Engine-003 command chain which completed successfully: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` (passed). 
- Replayed, falsification-audited, validated, and built generated docs successfully using `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`, and `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network` (all passed). 
- Ran the full unit test suite with `python -m unittest discover -s tests` and all tests passed (`Ran 466 tests ... OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f9049abc8333afe72e425029dc61)