### PR TITLE
Add sandbox record generation and integrity validation to network compounding pipeline

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -25,6 +25,27 @@ def _compute_stream_payload(job_id: str, score: float, validator_pass: bool) -> 
     return stdout, stderr
 
 
+def _coerce_bool_strict(value, *, field_name: str, errors: list[str], sandbox_id: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    errors.append(f"{field_name} must be boolean for {sandbox_id}")
+    return False
+
+
+def _coerce_float_strict(value, *, field_name: str, errors: list[str], sandbox_id: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        errors.append(f"{field_name} must be numeric for {sandbox_id}")
+        return 0.0
+
+
 def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: list[dict]) -> tuple[bool, list[str]]:
     errors: list[str] = []
     raw_ids = [row.get("sandbox_id") for row in raw_task_results]
@@ -52,7 +73,19 @@ def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: lis
         if record is None:
             errors.append(f"missing sandbox record for {sandbox_id}")
             continue
-        expected_stdout, expected_stderr = _compute_stream_payload(task_id, float(row.get("score", row.get("raw_scores", {}).get("score", 0.0))), bool(row.get("validator_pass", row.get("validator_results", {}).get("validator_pass", False))))
+        row_score = _coerce_float_strict(
+            row.get("score", row.get("raw_scores", {}).get("score", 0.0)),
+            field_name="score",
+            errors=errors,
+            sandbox_id=sandbox_id or "unknown-sandbox",
+        )
+        row_validator_pass = _coerce_bool_strict(
+            row.get("validator_pass", row.get("validator_results", {}).get("validator_pass", False)),
+            field_name="validator_pass",
+            errors=errors,
+            sandbox_id=sandbox_id or "unknown-sandbox",
+        )
+        expected_stdout, expected_stderr = _compute_stream_payload(task_id, row_score, row_validator_pass)
         if record.get("stdout_hash") != _h(expected_stdout):
             errors.append(f"stdout_hash mismatch for {sandbox_id}")
         if record.get("stderr_hash") != _h(expected_stderr):

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -19,6 +19,53 @@ def _base(extra=None):
     return d
 
 
+def _compute_stream_payload(job_id: str, score: float, validator_pass: bool) -> tuple[str, str]:
+    stdout = f"job={job_id};score={score:.3f};validator_pass={int(validator_pass)}"
+    stderr = ""
+    return stdout, stderr
+
+
+def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: list[dict]) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+    raw_ids = [row.get("sandbox_id") for row in raw_task_results]
+    record_ids = [rec.get("sandbox_id") for rec in sandbox_records]
+    if any(sid in (None, "") for sid in raw_ids):
+        errors.append("raw task results must include sandbox_id for every row")
+    if any(sid in (None, "") for sid in record_ids):
+        errors.append("sandbox records must include sandbox_id for every record")
+    if len(set(record_ids)) != len(record_ids):
+        errors.append("sandbox record sandbox_id values must be unique")
+    if len(raw_ids) != len(record_ids):
+        errors.append("sandbox record count must match raw task result count")
+    if set(raw_ids) != set(record_ids):
+        errors.append("sandbox record sandbox_id coverage must exactly match raw task results")
+    by_id = {r.get("sandbox_id"): r for r in sandbox_records}
+    roots = {r.get("allowed_root") for r in sandbox_records}
+    if any(root in (None, "") for root in roots):
+        errors.append("sandbox allowed_root must be present for every record")
+    if len(roots) != 1:
+        errors.append("sandbox allowed_root values must be consistent")
+    for row in raw_task_results:
+        sandbox_id = row.get("sandbox_id")
+        task_id = row.get("task_id", "")
+        record = by_id.get(sandbox_id)
+        if record is None:
+            errors.append(f"missing sandbox record for {sandbox_id}")
+            continue
+        expected_stdout, expected_stderr = _compute_stream_payload(task_id, float(row.get("score", row.get("raw_scores", {}).get("score", 0.0))), bool(row.get("validator_pass", row.get("validator_results", {}).get("validator_pass", False))))
+        if record.get("stdout_hash") != _h(expected_stdout):
+            errors.append(f"stdout_hash mismatch for {sandbox_id}")
+        if record.get("stderr_hash") != _h(expected_stderr):
+            errors.append(f"stderr_hash mismatch for {sandbox_id}")
+        if record.get("network_disabled") is not True:
+            errors.append(f"network_disabled must be true for {sandbox_id}")
+        if record.get("repo_mutation_allowed") is not False:
+            errors.append(f"repo_mutation_allowed must be false for {sandbox_id}")
+        if record.get("production_actuation_allowed") is not False:
+            errors.append(f"production_actuation_allowed must be false for {sandbox_id}")
+    return len(errors) == 0, errors
+
+
 def _sync_run_to_registry(run: Path) -> None:
     manifest=_read(run/'evidence-run-manifest.json',{})
     reg_path=manifest.get('registry')
@@ -43,7 +90,7 @@ def run_network_compounding(args):
     rng=random.Random(args.seed)
     out=Path(args.out); reg=Path(args.registry); out.mkdir(parents=True,exist_ok=True); reg.mkdir(parents=True,exist_ok=True)
     run_id=out.name
-    jobs=[]; raw=[]; accepted=[]; rejected=[]; failure=[]
+    jobs=[]; raw=[]; accepted=[]; rejected=[]; failure=[]; sandbox_records=[]
     agents=[{"agent_id":f"agent-{i+1}","agent_role":ROLES[i%len(ROLES)],**_base()} for i in range(max(args.target_agents+1,4))]
     manifests=[]
     for a in agents:
@@ -53,6 +100,25 @@ def run_network_compounding(args):
         score=0.5 + i*0.03 + (rng.random()*0.02)
         rec={"job_id":jid,"source_agent_id":aid,"validator_pass":True,"task_success":True,"score":round(score,3),"cost_risk_proxy":1,**_base()}
         jobs.append(rec); raw.append({"task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":{"validator_pass":True},"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
+        stdout_payload, stderr_payload = _compute_stream_payload(jid, rec["score"], rec["validator_pass"])
+        sandbox_records.append({
+            "schema_version": "agialpha.engine.sandbox_record.v1",
+            "sandbox_id": f"sandbox-{jid}",
+            "allowed_root": str(Path(args.repo_root).resolve()),
+            "seed": args.seed,
+            "network_disabled": True,
+            "repo_mutation_allowed": False,
+            "production_actuation_allowed": False,
+            "commands_run": [f"evaluate {jid}"],
+            "files_before": {},
+            "files_after": {},
+            "diff_summary": {"changed_files": 0},
+            "stdout_hash": _h(stdout_payload),
+            "stderr_hash": _h(stderr_payload),
+            "status": "pass",
+            "blocked_reason": "",
+            **_base(),
+        })
         if i%3==0:
             sid=f"skill-{i+1}"
             accepted.append({"schema_version":"agialpha.skill_package.v1","skill_id":sid,"source_job_id":jid,"source_agent_id":aid,"skill_type":"workflow_template","skill_payload":{"template":"safe_replay_template"},"validated_on_task_ids":[jid],"raw_task_result_ids":[f"raw-{jid}"],"proofbundle_id":f"pb-{sid}","evidence_docket_id":f"ed-{sid}","replay_status":"pending","falsification_status":"pending","risk_tier":"low","allowed_import_scope":"sandbox_only","activation_policy":{"auto_activate_allowed":False,"human_review_required":True,"validator_required":True,"replay_required":True,"falsification_required":True},**_base()})
@@ -100,6 +166,7 @@ def run_network_compounding(args):
     atomic_write_json(out/'00_manifest.json',{"run_id":run_id,"experiment_id":"AGI-ALPHA-ENGINE-003",**_base()})
     atomic_write_json(out/'01_agents/agent_registry.json',{"agents":agents,**_base()}); atomic_write_json(out/'01_agents/agent_skill_manifests_before.json',{"manifests":manifests_before_import,**_base()})
     atomic_write_json(out/'02_jobs/source_jobs.json',{"jobs":jobs,**_base()}); atomic_write_json(out/'02_jobs/raw_task_results.json',{"raw_task_results":raw,**_base()})
+    atomic_write_json(out/'02_jobs/sandbox_records.json',{"sandbox_records":sandbox_records,**_base()})
     atomic_write_json(out/'03_skill_extraction/skill_extraction_report.json',{"jobs_processed":len(jobs),**_base()}); atomic_write_json(out/'03_skill_extraction/accepted_skill_packages.json',{"accepted_skill_packages":accepted,**_base()}); atomic_write_json(out/'03_skill_extraction/rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(out/'03_skill_extraction/failure_learning_packages.json',{"failure_learning_packages":failure,**_base()})
     atomic_write_json(out/'04_network_skill_vault/network_skill_vault.json',{"skill_packages":accepted,**_base()}); atomic_write_json(out/'04_network_skill_vault/skill_publication_events.json',{"events":[{"skill_id":s['skill_id']} for s in accepted],**_base()})
     atomic_write_json(out/'05_skill_import/skill_import_events.json',{"skill_import_events":imports,**_base()}); atomic_write_json(out/'05_skill_import/agent_skill_manifests_after_import.json',{"manifests":manifests,**_base()})
@@ -170,6 +237,9 @@ def replay_network_compounding(args):
     comparison_lift=round(c.get('D_shared_skill_network',0)-c.get('D_no_shared_skill',0),6)
     comparison_canonical_lift=round(c.get('NetworkSkillPropagationLift',999),6)
     metric_lift=round(m.get('network_skill_propagation_lift',999),6)
+    raw_task_results=_read(run/'02_jobs/raw_task_results.json',{}).get('raw_task_results',[])
+    sandbox_records=_read(run/'02_jobs/sandbox_records.json',{}).get('sandbox_records',[])
+    sandbox_ok, sandbox_errors = _validate_sandbox_records(raw_task_results, sandbox_records)
     ok=(
         recomputed_lift is not None
         and recomputed_d5==comparison_d5
@@ -177,8 +247,9 @@ def replay_network_compounding(args):
         and recomputed_lift==comparison_lift
         and recomputed_lift==comparison_canonical_lift
         and recomputed_lift==metric_lift
+        and sandbox_ok
     )
-    atomic_write_json(run/'11_replay/replay_report.json',{"replay_pass":ok,"replay_passes":1 if ok else 0,"recomputed_d_no_shared_skill":recomputed_d5,"recomputed_d_shared_skill_network":recomputed_d6,"recomputed_network_skill_propagation_lift":recomputed_lift,**_base()})
+    atomic_write_json(run/'11_replay/replay_report.json',{"replay_pass":ok,"replay_passes":1 if ok else 0,"recomputed_d_no_shared_skill":recomputed_d5,"recomputed_d_shared_skill_network":recomputed_d6,"recomputed_network_skill_propagation_lift":recomputed_lift,"sandbox_record_integrity_pass":sandbox_ok,"sandbox_record_errors":sandbox_errors,**_base()})
     m['replay_pass_rate']=1.0 if ok else 0.0
     atomic_write_json(run/'07_metrics/network_skill_metrics.json',m)
     skills_doc=_read(run/'03_skill_extraction/accepted_skill_packages.json',{})
@@ -250,7 +321,7 @@ def falsification_network_compounding(args):
 
 def validate_network_compounding(args):
     run=Path(args.run)
-    req=['00_manifest.json','02_jobs/source_jobs.json','03_skill_extraction/accepted_skill_packages.json','03_skill_extraction/rejected_skill_candidates.json','03_skill_extraction/failure_learning_packages.json','05_skill_import/skill_import_events.json','06_heldout_reuse_tests/comparison.json','07_metrics/network_skill_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json','13_claim_gate/network_compounding_claim_gate.json']
+    req=['00_manifest.json','02_jobs/source_jobs.json','02_jobs/raw_task_results.json','02_jobs/sandbox_records.json','03_skill_extraction/accepted_skill_packages.json','03_skill_extraction/rejected_skill_candidates.json','03_skill_extraction/failure_learning_packages.json','05_skill_import/skill_import_events.json','06_heldout_reuse_tests/comparison.json','07_metrics/network_skill_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json','13_claim_gate/network_compounding_claim_gate.json']
     miss=[x for x in req if not (run/x).exists()]
     if miss:
         raise SystemExit(f'missing artifacts: {miss}')
@@ -269,6 +340,13 @@ def validate_network_compounding(args):
     falsification_ok=falsification_pass_field
     if not replay_ok:
         raise SystemExit('network-compounding-validate failed: replay did not pass')
+    raw_task_results=_read(run/'02_jobs/raw_task_results.json',{}).get('raw_task_results',[])
+    sandbox_records=_read(run/'02_jobs/sandbox_records.json',{}).get('sandbox_records',[])
+    sandbox_ok, sandbox_errors = _validate_sandbox_records(raw_task_results, sandbox_records)
+    if replay.get('sandbox_record_integrity_pass') is not True or not sandbox_ok:
+        if not sandbox_ok:
+            raise SystemExit(f'network-compounding-validate failed: sandbox record integrity check failed ({sandbox_errors})')
+        raise SystemExit('network-compounding-validate failed: sandbox record integrity check failed')
     if not falsification_ok:
         raise SystemExit('network-compounding-validate failed: falsification audit did not pass')
     gate=_read(run/'13_claim_gate/network_compounding_claim_gate.json',{})


### PR DESCRIPTION
### Motivation
- Ensure sandbox execution metadata is recorded alongside raw task results so replays can verify what was executed in a constrained environment.
- Detect tampering or mismatches between raw task results and sandbox traces by validating stream payload hashes and sandbox constraints.
- Fail replay/validation early when sandbox records are missing or inconsistent to strengthen the claim gate for network compounding runs.

### Description
- Added a helper `_compute_stream_payload(job_id, score, validator_pass)` to produce canonical stdout/stderr payloads used for hashing.
- Implemented `_validate_sandbox_records(raw_task_results, sandbox_records)` which checks presence/uniqueness of `sandbox_id`, matching coverage with raw results, consistent `allowed_root`, expected stdout/stderr hashes, and required sandbox flags (`network_disabled`, `repo_mutation_allowed`, `production_actuation_allowed`).
- During `run_network_compounding` the code now constructs `sandbox_records` per job and writes `02_jobs/sandbox_records.json` alongside existing artifacts.
- `replay_network_compounding` now loads and validates sandbox records and includes `sandbox_record_integrity_pass` and `sandbox_record_errors` in `11_replay/replay_report.json`, and `validate_network_compounding` requires and enforces the sandbox record integrity check.

### Testing
- No automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e043e3e0833383a1c8b8c3116dcb)