### PR TITLE
Add smoke unittest for Engine-003 network-compounding CLI flow

### DIFF
--- a/tests/test_network_compounding_unittest_smoke.py
+++ b/tests/test_network_compounding_unittest_smoke.py
@@ -1,0 +1,28 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestNetworkCompoundingUnittestSmoke(unittest.TestCase):
+    def test_run_replay_falsification_validate(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory(prefix='agialpha-engine003-smoke-') as td:
+            run_dir = Path(td) / 'run'
+            registry = Path(td) / 'registry'
+            cmds = [
+                [
+                    'python', '-m', 'agialpha_engine', 'network-compounding-run',
+                    '--repo-root', str(repo_root), '--registry', str(registry), '--out', str(run_dir),
+                    '--jobs', '5', '--target-agents', '3', '--heldout-tasks', '5', '--seed', '123'
+                ],
+                ['python', '-m', 'agialpha_engine', 'network-compounding-replay', '--run', str(run_dir)],
+                ['python', '-m', 'agialpha_engine', 'network-compounding-falsification-audit', '--run', str(run_dir)],
+                ['python', '-m', 'agialpha_engine', 'network-compounding-validate', '--run', str(run_dir)],
+            ]
+            for cmd in cmds:
+                subprocess.run(cmd, cwd=repo_root, check=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_network_compounding_unittest_smoke.py
+++ b/tests/test_network_compounding_unittest_smoke.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,13 +13,13 @@ class TestNetworkCompoundingUnittestSmoke(unittest.TestCase):
             registry = Path(td) / 'registry'
             cmds = [
                 [
-                    'python', '-m', 'agialpha_engine', 'network-compounding-run',
+                    sys.executable, '-m', 'agialpha_engine', 'network-compounding-run',
                     '--repo-root', str(repo_root), '--registry', str(registry), '--out', str(run_dir),
                     '--jobs', '5', '--target-agents', '3', '--heldout-tasks', '5', '--seed', '123'
                 ],
-                ['python', '-m', 'agialpha_engine', 'network-compounding-replay', '--run', str(run_dir)],
-                ['python', '-m', 'agialpha_engine', 'network-compounding-falsification-audit', '--run', str(run_dir)],
-                ['python', '-m', 'agialpha_engine', 'network-compounding-validate', '--run', str(run_dir)],
+                [sys.executable, '-m', 'agialpha_engine', 'network-compounding-replay', '--run', str(run_dir)],
+                [sys.executable, '-m', 'agialpha_engine', 'network-compounding-falsification-audit', '--run', str(run_dir)],
+                [sys.executable, '-m', 'agialpha_engine', 'network-compounding-validate', '--run', str(run_dir)],
             ]
             for cmd in cmds:
                 subprocess.run(cmd, cwd=repo_root, check=True)


### PR DESCRIPTION
### Motivation
- Provide deterministic end-to-end smoke coverage for the AGI ALPHA Engine-003 CLI so CI no longer reports "NO TESTS RAN" and to ensure the `network-compounding` run/replay/falsification/validate sequence is exercised in a temporary sandbox.

### Description
- Add `tests/test_network_compounding_unittest_smoke.py`, a unittest that runs `python -m agialpha_engine network-compounding-run --repo-root <repo> --registry <registry> --out <run> --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` followed by `network-compounding-replay`, `network-compounding-falsification-audit`, and `network-compounding-validate` in a temporary directory to verify the CLI vertical slice.

### Testing
- Ran the new smoke test as part of the test suite with `python -m unittest discover -s tests` and also ran targeted `pytest` checks; both the targeted `pytest` run and the full `unittest` discovery completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12178f4f448333a38eace90b556dc1)