### PR TITLE
Add integration test for network compounding metrics computed from raw logs

### DIFF
--- a/tests/test_agialpha_network_compounding_metrics.py
+++ b/tests/test_agialpha_network_compounding_metrics.py
@@ -1,2 +1,66 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import tempfile
+import sys
+from pathlib import Path
+
+
+def test_network_compounding_metrics_computed_from_raw_logs_without_fixed_wins():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / "run"
+        reg = Path(td) / "reg"
+
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "agialpha_engine",
+                "network-compounding-run",
+                "--repo-root",
+                ".",
+                "--registry",
+                str(reg),
+                "--out",
+                str(run),
+                "--jobs",
+                "5",
+                "--target-agents",
+                "3",
+                "--heldout-tasks",
+                "5",
+                "--seed",
+                "123",
+            ]
+        )
+
+        metrics = json.loads((run / "07_metrics/network_skill_metrics.json").read_text())
+        comparison = json.loads((run / "06_heldout_reuse_tests/comparison.json").read_text())
+        raw_b5 = json.loads((run / "06_heldout_reuse_tests/B5_no_shared_skill.json").read_text())["results"]
+        raw_b6 = json.loads((run / "06_heldout_reuse_tests/B6_shared_skill_network.json").read_text())["results"]
+
+        def d_metric(rows):
+            return sum(
+                row["success_score"]
+                * row["validator_pass"]
+                * row["replay_pass"]
+                * row["proofbundle"]
+                * row["docket"]
+                / max(1, row["cost_risk_proxy"])
+                for row in rows
+            ) / len(rows)
+
+        d5 = round(d_metric(raw_b5), 6)
+        d6 = round(d_metric(raw_b6), 6)
+        lift = round(d6 - d5, 6)
+
+        assert comparison["D_no_shared_skill"] == d5
+        assert comparison["D_shared_skill_network"] == d6
+        assert comparison["NetworkSkillPropagationLift"] == lift
+
+        assert metrics["B6_shared_skill_advantage_delta"] == lift
+        assert metrics["network_skill_propagation_lift"] == lift
+        assert metrics["B6_shared_skill_beats_B5_no_shared_skill"] == (d6 > d5)
+
+        assert isinstance(metrics["hard_coded_metric_count"], int)
+        assert isinstance(metrics["fake_zero_metric_count"], int)
+        assert metrics["hard_coded_metric_count"] >= metrics["fake_zero_metric_count"] >= 0


### PR DESCRIPTION
### Motivation

- Replace a placeholder test with an integration-style test that validates network compounding metrics are computed correctly from raw heldout run logs.  
- Ensure the reported metrics (including propagation lift and per-experiment D metrics) match values recomputed from raw JSON outputs.  
- Verify metric counts and boolean comparisons are present and have the correct types.

### Description

- Replaces the placeholder `test_placeholder` with `test_network_compounding_metrics_computed_from_raw_logs_without_fixed_wins` in `tests/test_agialpha_network_compounding_metrics.py`.  
- The new test runs the CLI `agialpha_engine network-compounding-run` in a temporary directory with specific arguments to produce `run` and `registry` artifacts.  
- It reads `network_skill_metrics.json`, the `comparison.json`, and raw heldout JSON logs (`B5_no_shared_skill.json` and `B6_shared_skill_network.json`), recomputes a `D` metric from raw rows, and asserts equality with the reported comparison and metrics values, including `NetworkSkillPropagationLift` and `B6_shared_skill_beats_B5_no_shared_skill`.  
- Adds checks that `hard_coded_metric_count` and `fake_zero_metric_count` are integers and that the counts satisfy expected inequalities.

### Testing

- Ran the new test file with `pytest -q tests/test_agialpha_network_compounding_metrics.py`, and the test passed.  
- The test is suitable for CI and will be executed as part of the repository test suite to validate end-to-end metric computation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a124b4ecccc8333af417fa8e32ec9f8)