### PR TITLE
docs: add network-compounding verification commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@
 ## Build/test commands
 - `python -m unittest discover -s tests`
 - `pytest -q` (if pytest is available)
+- `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`
+- `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`
+- `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`
+- `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`
+- `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network`
 - SecureRails checks in `scripts/secure_rails_*.py`
 
 ## SecureRails + boundary rules


### PR DESCRIPTION
### Motivation
- Make the repository's operator instructions explicit for verifying AGI ALPHA ENGINE-003 by adding the local CLI workflow commands for networked skill compounding while preserving SecureRails boundaries.

### Description
- Updated `AGENTS.md` to add the ENGINE-003 verification commands: `python -m agialpha_engine network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, keeping existing boundary and test guidance intact.

### Testing
- Ran the full local verification sequence and tests: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`, `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network`, and `python -m unittest discover -s tests`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12553ad2608333b9d24eb870a07ed0)