### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import hashlib
 import json
 import random
+import subprocess
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -82,3 +84,46 @@ class LocalSandbox:
                 "repo_source_hash_unchanged": file_hash(fixture_path) == before_hash,
                 "autonomous_persistence_allowed": False,
             }
+
+    def run_local_command(self, *, sandbox_id: str, command: list[str], allowed_root: Path, timeout_seconds: float = 5.0) -> dict[str, Any]:
+        """Run a deterministic local-only command inside `allowed_root`.
+
+        The command is executed with shell=False and with no network action by policy.
+        This returns a normalized sandbox record schema used by Engine-003.
+        """
+        root = Path(allowed_root).resolve()
+        if not root.exists() or not root.is_dir():
+            raise ValueError("allowed_root must be an existing directory")
+        if ".." in Path(*command).parts:
+            raise ValueError("path traversal rejected in command")
+        self.assert_safe_text(" ".join(command))
+        start = time.time()
+        result = subprocess.run(
+            command,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        elapsed_ms = int((time.time() - start) * 1000)
+        return {
+            "schema_version": "agialpha.engine.sandbox_record.v1",
+            "sandbox_id": sandbox_id,
+            "allowed_root": str(root),
+            "seed": self.seed,
+            "network_disabled": True,
+            "repo_mutation_allowed": False,
+            "production_actuation_allowed": False,
+            "commands_run": [" ".join(command)],
+            "files_before": {},
+            "files_after": {},
+            "diff_summary": {"changed_files": 0},
+            "stdout_hash": artifact_hash(result.stdout),
+            "stderr_hash": artifact_hash(result.stderr),
+            "status": "pass" if result.returncode == 0 else "fail",
+            "blocked_reason": "" if result.returncode == 0 else f"exit_code_{result.returncode}",
+            "timeout_ms": int(timeout_seconds * 1000),
+            "elapsed_ms": elapsed_ms,
+            **BOUNDARIES,
+        }

--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -36,6 +36,14 @@ def snapshot_tree(root: Path) -> dict[str, str]:
     return snapshot
 
 
+def _coerce_text_stream(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
 class LocalSandbox:
     """A deterministic local-only execution boundary.
 
@@ -121,13 +129,13 @@ class LocalSandbox:
                 timeout=timeout_seconds,
                 check=False,
             )
-            stdout = result.stdout
-            stderr = result.stderr
+            stdout = _coerce_text_stream(result.stdout)
+            stderr = _coerce_text_stream(result.stderr)
             blocked_reason = "" if result.returncode == 0 else f"exit_code_{result.returncode}"
         except subprocess.TimeoutExpired as exc:
             timeout = True
-            stdout = exc.stdout or ""
-            stderr = exc.stderr or ""
+            stdout = _coerce_text_stream(exc.stdout)
+            stderr = _coerce_text_stream(exc.stderr)
             blocked_reason = "timeout_expired"
         elapsed_ms = int((time.time() - start) * 1000)
         files_after = snapshot_tree(root)
@@ -138,6 +146,10 @@ class LocalSandbox:
             rel for rel in changed_files
             if files_before.get(rel) != files_after.get(rel)
         ]
+        mutation_detected = len(changed_files) > 0
+        if mutation_detected and not blocked_reason:
+            blocked_reason = "repo_mutation_detected"
+        status = "pass" if (result is not None and result.returncode == 0 and not timeout and not mutation_detected) else "fail"
         return {
             "schema_version": "agialpha.engine.sandbox_record.v1",
             "sandbox_id": sandbox_id,
@@ -152,7 +164,7 @@ class LocalSandbox:
             "diff_summary": {"changed_files": len(changed_files), "changed_paths": changed_files},
             "stdout_hash": artifact_hash(stdout),
             "stderr_hash": artifact_hash(stderr),
-            "status": "pass" if (result is not None and result.returncode == 0 and not timeout) else "fail",
+            "status": status,
             "blocked_reason": blocked_reason,
             "timeout_ms": int(timeout_seconds * 1000),
             "elapsed_ms": elapsed_ms,

--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -28,6 +28,14 @@ def file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def snapshot_tree(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = str(path.relative_to(root))
+        snapshot[rel] = file_hash(path)
+    return snapshot
+
+
 class LocalSandbox:
     """A deterministic local-only execution boundary.
 
@@ -97,16 +105,39 @@ class LocalSandbox:
         if ".." in Path(*command).parts:
             raise ValueError("path traversal rejected in command")
         self.assert_safe_text(" ".join(command))
+        files_before = snapshot_tree(root)
         start = time.time()
-        result = subprocess.run(
-            command,
-            cwd=root,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
+        timeout = False
+        result = None
+        stdout = ""
+        stderr = ""
+        blocked_reason = ""
+        try:
+            result = subprocess.run(
+                command,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+            stdout = result.stdout
+            stderr = result.stderr
+            blocked_reason = "" if result.returncode == 0 else f"exit_code_{result.returncode}"
+        except subprocess.TimeoutExpired as exc:
+            timeout = True
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            blocked_reason = "timeout_expired"
         elapsed_ms = int((time.time() - start) * 1000)
+        files_after = snapshot_tree(root)
+        changed_files = sorted(
+            set(files_before.keys()) | set(files_after.keys())
+        )
+        changed_files = [
+            rel for rel in changed_files
+            if files_before.get(rel) != files_after.get(rel)
+        ]
         return {
             "schema_version": "agialpha.engine.sandbox_record.v1",
             "sandbox_id": sandbox_id,
@@ -116,13 +147,13 @@ class LocalSandbox:
             "repo_mutation_allowed": False,
             "production_actuation_allowed": False,
             "commands_run": [" ".join(command)],
-            "files_before": {},
-            "files_after": {},
-            "diff_summary": {"changed_files": 0},
-            "stdout_hash": artifact_hash(result.stdout),
-            "stderr_hash": artifact_hash(result.stderr),
-            "status": "pass" if result.returncode == 0 else "fail",
-            "blocked_reason": "" if result.returncode == 0 else f"exit_code_{result.returncode}",
+            "files_before": files_before,
+            "files_after": files_after,
+            "diff_summary": {"changed_files": len(changed_files), "changed_paths": changed_files},
+            "stdout_hash": artifact_hash(stdout),
+            "stderr_hash": artifact_hash(stderr),
+            "status": "pass" if (result is not None and result.returncode == 0 and not timeout) else "fail",
+            "blocked_reason": blocked_reason,
             "timeout_ms": int(timeout_seconds * 1000),
             "elapsed_ms": elapsed_ms,
             **BOUNDARIES,

--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -44,6 +44,12 @@ def _coerce_text_stream(value: Any) -> str:
     return str(value)
 
 
+def _contains_parent_segment(arg: str) -> bool:
+    normalized = arg.replace("\\", "/")
+    segments = [seg for seg in normalized.split("/") if seg not in ("", ".")]
+    return any(seg == ".." for seg in segments)
+
+
 class LocalSandbox:
     """A deterministic local-only execution boundary.
 
@@ -110,7 +116,9 @@ class LocalSandbox:
         root = Path(allowed_root).resolve()
         if not root.exists() or not root.is_dir():
             raise ValueError("allowed_root must be an existing directory")
-        if ".." in Path(*command).parts:
+        if root != self.repo_root and self.repo_root not in root.parents:
+            raise ValueError("allowed_root must stay within repo root")
+        if any(_contains_parent_segment(part) for part in command):
             raise ValueError("path traversal rejected in command")
         self.assert_safe_text(" ".join(command))
         files_before = snapshot_tree(root)


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local-only sandbox execution path and normalized sandbox record for Engine-003 so evaluated jobs can be safely replayed, hashed, and validated while blocking network/production actions and preventing repo mutation.

### Description
- Implemented `run_local_command` in `agialpha_engine/sandbox.py` (added `subprocess` and `time` imports) to execute commands inside an allowed root, assert no external-target markers or path traversal, capture `stdout`/`stderr` hashes, timeout/elapsed timing, and emit a `agialpha.engine.sandbox_record.v1` record including boundary and safety fields.

### Testing
- Ran `python -m agialpha_engine network-compounding-run ...`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, `network-compounding-build-data` and `python -m unittest discover -s tests`, and all executed successfully with the test suite reporting 467 tests run and passing (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1468bab1848333a38f7ec0e27e2bce)