### PR TITLE
Add local command runner and filesystem snapshot helpers to LocalSandbox

### DIFF
--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import random
+import signal
 import subprocess
 import shutil
 import tempfile
@@ -123,6 +125,27 @@ class LocalSandbox:
         root = Path(allowed_root).resolve()
         if not root.exists() or not root.is_dir():
             raise ValueError("allowed_root must be an existing directory")
+        if not command:
+            return {
+                "schema_version": "agialpha.engine.sandbox_record.v1",
+                "sandbox_id": sandbox_id,
+                "allowed_root": str(root),
+                "seed": self.seed,
+                "network_disabled": True,
+                "repo_mutation_allowed": False,
+                "production_actuation_allowed": False,
+                "commands_run": [],
+                "files_before": {},
+                "files_after": {},
+                "diff_summary": {"changed_files": 0, "changed_paths": []},
+                "stdout_hash": artifact_hash(""),
+                "stderr_hash": artifact_hash("empty command"),
+                "status": "fail",
+                "blocked_reason": "empty_command",
+                "timeout_ms": int(timeout_seconds * 1000),
+                "elapsed_ms": 0,
+                **BOUNDARIES,
+            }
         if self.repo_root != root and self.repo_root not in root.parents:
             raise ValueError("allowed_root must stay within repo root")
         for arg in command:
@@ -148,18 +171,28 @@ class LocalSandbox:
                 "https_proxy": "",
                 "all_proxy": "",
             }
-            result = subprocess.run(
+            proc = subprocess.Popen(
                 command,
                 cwd=root,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=timeout_seconds,
-                check=False,
                 env=safe_env,
+                start_new_session=True,
             )
-            stdout = _coerce_text_stream(result.stdout)
-            stderr = _coerce_text_stream(result.stderr)
-            blocked_reason = "" if result.returncode == 0 else f"exit_code_{result.returncode}"
+            try:
+                out, err = proc.communicate(timeout=timeout_seconds)
+                result = subprocess.CompletedProcess(command, proc.returncode, out, err)
+                stdout = _coerce_text_stream(result.stdout)
+                stderr = _coerce_text_stream(result.stderr)
+                blocked_reason = "" if result.returncode == 0 else f"exit_code_{result.returncode}"
+            except subprocess.TimeoutExpired as exc:
+                timeout = True
+                os.killpg(proc.pid, signal.SIGKILL)
+                out, err = proc.communicate()
+                stdout = _coerce_text_stream((exc.stdout or "") + (out or ""))
+                stderr = _coerce_text_stream((exc.stderr or "") + (err or ""))
+                blocked_reason = "timeout_expired"
         except subprocess.TimeoutExpired as exc:
             timeout = True
             stdout = _coerce_text_stream(exc.stdout)

--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 import hashlib
 import json
 import random
+import subprocess
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
 from .context import BOUNDARIES
 
 FORBIDDEN_TARGET_MARKERS = ("http://", "https://", "ssh://", "git@", "nmap ", "curl ", "wget ")
+FORBIDDEN_PATH_SEGMENTS = ("../", "..\\", "/..", "\\..")
 
 
 def canonical_json(data: Any) -> str:
@@ -24,6 +27,22 @@ def artifact_hash(data: Any) -> str:
 
 def file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def snapshot_tree(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = str(path.relative_to(root))
+        snapshot[rel] = file_hash(path)
+    return snapshot
+
+
+def _coerce_text_stream(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
 
 
 class LocalSandbox:
@@ -82,3 +101,77 @@ class LocalSandbox:
                 "repo_source_hash_unchanged": file_hash(fixture_path) == before_hash,
                 "autonomous_persistence_allowed": False,
             }
+
+    def run_local_command(self, *, sandbox_id: str, command: list[str], allowed_root: Path, timeout_seconds: float = 5.0) -> dict[str, Any]:
+        """Run a deterministic local-only command inside `allowed_root`.
+
+        The command is executed with shell=False and with no network action by policy.
+        This returns a normalized sandbox record schema used by Engine-003.
+        """
+        root = Path(allowed_root).resolve()
+        if not root.exists() or not root.is_dir():
+            raise ValueError("allowed_root must be an existing directory")
+        if self.repo_root != root and self.repo_root not in root.parents:
+            raise ValueError("allowed_root must stay within repo root")
+        for arg in command:
+            normalized = str(arg).replace("\\", "/")
+            if normalized == ".." or any(marker in normalized for marker in FORBIDDEN_PATH_SEGMENTS):
+                raise ValueError("path traversal rejected in command arguments")
+        self.assert_safe_text(" ".join(command))
+        files_before = snapshot_tree(root)
+        start = time.time()
+        timeout = False
+        result = None
+        stdout = ""
+        stderr = ""
+        blocked_reason = ""
+        try:
+            result = subprocess.run(
+                command,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+            stdout = _coerce_text_stream(result.stdout)
+            stderr = _coerce_text_stream(result.stderr)
+            blocked_reason = "" if result.returncode == 0 else f"exit_code_{result.returncode}"
+        except subprocess.TimeoutExpired as exc:
+            timeout = True
+            stdout = _coerce_text_stream(exc.stdout)
+            stderr = _coerce_text_stream(exc.stderr)
+            blocked_reason = "timeout_expired"
+        elapsed_ms = int((time.time() - start) * 1000)
+        files_after = snapshot_tree(root)
+        changed_files = sorted(
+            set(files_before.keys()) | set(files_after.keys())
+        )
+        changed_files = [
+            rel for rel in changed_files
+            if files_before.get(rel) != files_after.get(rel)
+        ]
+        mutation_detected = len(changed_files) > 0
+        if mutation_detected and not blocked_reason:
+            blocked_reason = "repo_mutation_detected"
+        status = "pass" if (result is not None and result.returncode == 0 and not timeout and not mutation_detected) else "fail"
+        return {
+            "schema_version": "agialpha.engine.sandbox_record.v1",
+            "sandbox_id": sandbox_id,
+            "allowed_root": str(root),
+            "seed": self.seed,
+            "network_disabled": True,
+            "repo_mutation_allowed": False,
+            "production_actuation_allowed": False,
+            "commands_run": [" ".join(command)],
+            "files_before": files_before,
+            "files_after": files_after,
+            "diff_summary": {"changed_files": len(changed_files), "changed_paths": changed_files},
+            "stdout_hash": artifact_hash(stdout),
+            "stderr_hash": artifact_hash(stderr),
+            "status": status,
+            "blocked_reason": blocked_reason,
+            "timeout_ms": int(timeout_seconds * 1000),
+            "elapsed_ms": elapsed_ms,
+            **BOUNDARIES,
+        }

--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -15,6 +15,16 @@ from .context import BOUNDARIES
 
 FORBIDDEN_TARGET_MARKERS = ("http://", "https://", "ssh://", "git@", "nmap ", "curl ", "wget ")
 FORBIDDEN_PATH_SEGMENTS = ("../", "..\\", "/..", "\\..")
+FORBIDDEN_NETWORK_CODE_MARKERS = (
+    "import socket",
+    "from socket",
+    "socket.",
+    "urllib.request",
+    "requests.",
+    "http.client",
+    "ftplib",
+    "telnetlib",
+)
 
 
 def canonical_json(data: Any) -> str:
@@ -72,6 +82,8 @@ class LocalSandbox:
         lowered = text.lower()
         if any(marker in lowered for marker in FORBIDDEN_TARGET_MARKERS):
             raise ValueError("sandbox rejected external target or network marker")
+        if any(marker in lowered for marker in FORBIDDEN_NETWORK_CODE_MARKERS):
+            raise ValueError("sandbox rejected potential network-capable code marker")
 
     def describe(self) -> dict[str, Any]:
         return dict(self.constraints)
@@ -126,6 +138,16 @@ class LocalSandbox:
         stderr = ""
         blocked_reason = ""
         try:
+            safe_env = {
+                "NO_PROXY": "*",
+                "no_proxy": "*",
+                "HTTP_PROXY": "",
+                "HTTPS_PROXY": "",
+                "ALL_PROXY": "",
+                "http_proxy": "",
+                "https_proxy": "",
+                "all_proxy": "",
+            }
             result = subprocess.run(
                 command,
                 cwd=root,
@@ -133,6 +155,7 @@ class LocalSandbox:
                 text=True,
                 timeout=timeout_seconds,
                 check=False,
+                env=safe_env,
             )
             stdout = _coerce_text_stream(result.stdout)
             stderr = _coerce_text_stream(result.stderr)
@@ -142,6 +165,10 @@ class LocalSandbox:
             stdout = _coerce_text_stream(exc.stdout)
             stderr = _coerce_text_stream(exc.stderr)
             blocked_reason = "timeout_expired"
+        except (FileNotFoundError, OSError) as exc:
+            stdout = ""
+            stderr = _coerce_text_stream(str(exc))
+            blocked_reason = "command_not_executable"
         elapsed_ms = int((time.time() - start) * 1000)
         files_after = snapshot_tree(root)
         changed_files = sorted(


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local-only mechanism to execute commands inside the sandbox while preventing network/external actions and detecting filesystem mutations.

### Description
- Introduce `FORBIDDEN_PATH_SEGMENTS` and import `subprocess` and `time` to support safe command execution and timing. 
- Add `snapshot_tree` to capture file hashes for all files under a root and `_coerce_text_stream` to normalize captured output. 
- Add `LocalSandbox.run_local_command` which validates `allowed_root` and command arguments, enforces text safety, snapshots files before and after execution, runs the command with `subprocess.run` (no shell), handles timeouts, computes changed files and mutation detection, and returns a normalized sandbox record schema. 
- Keep `apply_candidate_patch` behavior intact while using the new helpers to support deterministic local operations. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1468bab1848333a38f7ec0e27e2bce)