### PR TITLE
Implement `run_local_command` and enhance sandbox safety checks

### DIFF
--- a/agialpha_engine/sandbox.py
+++ b/agialpha_engine/sandbox.py
@@ -3,15 +3,35 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import random
+import re
+import subprocess
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
 from .context import BOUNDARIES
 
 FORBIDDEN_TARGET_MARKERS = ("http://", "https://", "ssh://", "git@", "nmap ", "curl ", "wget ")
+FORBIDDEN_PATH_SEGMENTS = ("../", "..\\", "/..", "\\..")
+FORBIDDEN_NETWORK_CODE_MARKERS = (
+    "import socket",
+    "from socket",
+    "socket.",
+    "urllib.request",
+    "requests.",
+    "http.client",
+    "ftplib",
+    "telnetlib",
+    "__import__(\"socket\"",
+    "__import__('socket'",
+    "importlib.import_module(\"socket\"",
+    "importlib.import_module('socket'",
+)
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[a-zA-Z]:[\\/]")
 
 
 def canonical_json(data: Any) -> str:
@@ -24,6 +44,22 @@ def artifact_hash(data: Any) -> str:
 
 def file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def snapshot_tree(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = str(path.relative_to(root))
+        snapshot[rel] = file_hash(path)
+    return snapshot
+
+
+def _coerce_text_stream(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
 
 
 class LocalSandbox:
@@ -53,6 +89,8 @@ class LocalSandbox:
         lowered = text.lower()
         if any(marker in lowered for marker in FORBIDDEN_TARGET_MARKERS):
             raise ValueError("sandbox rejected external target or network marker")
+        if any(marker in lowered for marker in FORBIDDEN_NETWORK_CODE_MARKERS):
+            raise ValueError("sandbox rejected potential network-capable code marker")
 
     def describe(self) -> dict[str, Any]:
         return dict(self.constraints)
@@ -82,3 +120,144 @@ class LocalSandbox:
                 "repo_source_hash_unchanged": file_hash(fixture_path) == before_hash,
                 "autonomous_persistence_allowed": False,
             }
+
+    def run_local_command(self, *, sandbox_id: str, command: list[str], allowed_root: Path, timeout_seconds: float = 5.0) -> dict[str, Any]:
+        """Run a deterministic local-only command inside `allowed_root`.
+
+        The command is executed with shell=False and with no network action by policy.
+        This returns a normalized sandbox record schema used by Engine-003.
+        """
+        root = Path(allowed_root).resolve()
+        if not root.exists() or not root.is_dir():
+            raise ValueError("allowed_root must be an existing directory")
+        if self.repo_root != root and self.repo_root not in root.parents:
+            raise ValueError("allowed_root must stay within repo root")
+        if not command:
+            files_now = snapshot_tree(root)
+            return {
+                "schema_version": "agialpha.engine.sandbox_record.v1",
+                "sandbox_id": sandbox_id,
+                "allowed_root": str(root),
+                "seed": self.seed,
+                "network_disabled": True,
+                "repo_mutation_allowed": False,
+                "production_actuation_allowed": False,
+                "commands_run": [],
+                "files_before": files_now,
+                "files_after": files_now,
+                "diff_summary": {"changed_files": 0, "changed_paths": []},
+                "stdout_hash": artifact_hash(""),
+                "stderr_hash": artifact_hash(""),
+                "status": "fail",
+                "blocked_reason": "empty_command",
+                "timeout_ms": int(timeout_seconds * 1000),
+                "elapsed_ms": 0,
+                **BOUNDARIES,
+            }
+        for arg in command:
+            normalized = str(arg).replace("\\", "/")
+            if normalized.startswith("/") or normalized.startswith("//") or WINDOWS_ABSOLUTE_PATH_RE.match(str(arg)):
+                raise ValueError("absolute path arguments are not allowed in sandbox commands")
+            if normalized == ".." or any(marker in normalized for marker in FORBIDDEN_PATH_SEGMENTS):
+                raise ValueError("path traversal rejected in command arguments")
+        self.assert_safe_text(" ".join(command))
+        files_before = snapshot_tree(root)
+        start = time.time()
+        timeout = False
+        result = None
+        stdout = ""
+        stderr = ""
+        blocked_reason = ""
+        with tempfile.TemporaryDirectory(prefix="agialpha-run-sandbox-") as td:
+            sandbox_root = Path(td) / "root"
+            shutil.copytree(root, sandbox_root)
+            try:
+                safe_env = dict(os.environ)
+                safe_env.update({
+                    "NO_PROXY": "*",
+                    "no_proxy": "*",
+                    "HTTP_PROXY": "",
+                    "HTTPS_PROXY": "",
+                    "ALL_PROXY": "",
+                    "http_proxy": "",
+                    "https_proxy": "",
+                    "all_proxy": "",
+                })
+                popen_kwargs = {
+                    "args": command,
+                    "cwd": sandbox_root,
+                    "stdout": subprocess.PIPE,
+                    "stderr": subprocess.PIPE,
+                    "text": True,
+                    "env": safe_env,
+                }
+                if os.name == "posix":
+                    popen_kwargs["start_new_session"] = True
+                process = subprocess.Popen(**popen_kwargs)
+                try:
+                    out_text, err_text = process.communicate(timeout=timeout_seconds)
+                except subprocess.TimeoutExpired:
+                    timeout = True
+                    if os.name == "posix":
+                        os.killpg(process.pid, 15)
+                    else:
+                        process.terminate()
+                    try:
+                        out_text, err_text = process.communicate(timeout=1.0)
+                    except subprocess.TimeoutExpired:
+                        if os.name == "posix":
+                            os.killpg(process.pid, 9)
+                        else:
+                            process.kill()
+                        out_text, err_text = process.communicate()
+                    stdout = _coerce_text_stream(out_text)
+                    stderr = _coerce_text_stream(err_text)
+                    blocked_reason = "timeout_expired"
+                    result = subprocess.CompletedProcess(command, returncode=124, stdout=stdout, stderr=stderr)
+                else:
+                    stdout = _coerce_text_stream(out_text)
+                    stderr = _coerce_text_stream(err_text)
+                    result = subprocess.CompletedProcess(command, returncode=process.returncode, stdout=stdout, stderr=stderr)
+                    blocked_reason = "" if result.returncode == 0 else f"exit_code_{result.returncode}"
+            except subprocess.TimeoutExpired as exc:
+                timeout = True
+                stdout = _coerce_text_stream(exc.stdout)
+                stderr = _coerce_text_stream(exc.stderr)
+                blocked_reason = "timeout_expired"
+            except (FileNotFoundError, OSError) as exc:
+                stdout = ""
+                stderr = _coerce_text_stream(str(exc))
+                blocked_reason = "command_not_executable"
+            elapsed_ms = int((time.time() - start) * 1000)
+            files_after = snapshot_tree(sandbox_root)
+        changed_files = sorted(
+            set(files_before.keys()) | set(files_after.keys())
+        )
+        changed_files = [
+            rel for rel in changed_files
+            if files_before.get(rel) != files_after.get(rel)
+        ]
+        mutation_detected = len(changed_files) > 0
+        if mutation_detected and not blocked_reason:
+            blocked_reason = "repo_mutation_detected"
+        status = "pass" if (result is not None and result.returncode == 0 and not timeout and not mutation_detected) else "fail"
+        return {
+            "schema_version": "agialpha.engine.sandbox_record.v1",
+            "sandbox_id": sandbox_id,
+            "allowed_root": str(root),
+            "seed": self.seed,
+            "network_disabled": True,
+            "repo_mutation_allowed": False,
+            "production_actuation_allowed": False,
+            "commands_run": [" ".join(command)],
+            "files_before": files_before,
+            "files_after": files_after,
+            "diff_summary": {"changed_files": len(changed_files), "changed_paths": changed_files},
+            "stdout_hash": artifact_hash(stdout),
+            "stderr_hash": artifact_hash(stderr),
+            "status": status,
+            "blocked_reason": blocked_reason,
+            "timeout_ms": int(timeout_seconds * 1000),
+            "elapsed_ms": elapsed_ms,
+            **BOUNDARIES,
+        }


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local-only command execution helper that can run and record commands against a sandboxed copy of repository content.
- Prevent accidental network access, external targets, and path traversal from sandboxed commands or candidate patch text.
- Produce a normalized sandbox record schema for Engine-003 that captures file snapshots, stdout/stderr artifacts, and execution metadata.

### Description
- Added new forbidden markers and path checks (`FORBIDDEN_PATH_SEGMENTS`, `FORBIDDEN_NETWORK_CODE_MARKERS`, `WINDOWS_ABSOLUTE_PATH_RE`) and updated `assert_safe_text` to reject potential network-capable code markers. 
- Introduced `snapshot_tree` to capture file-hash snapshots and `_coerce_text_stream` to normalize process output into text. 
- Implemented `LocalSandbox.run_local_command` which copies `allowed_root` to a temporary sandbox, runs the provided command with `subprocess.Popen` (no shell), disables proxy env vars, enforces timeouts and termination, detects repo mutations by comparing snapshots, and returns a structured sandbox record including `files_before`, `files_after`, `diff_summary`, `stdout_hash`, `stderr_hash`, `status`, and `blocked_reason`.
- Added imports for `os`, `re`, `subprocess`, and `time` and ensured Windows/posix-specific process termination handling and argument path validation to reject absolute paths and traversal.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1468bab1848333a38f7ec0e27e2bce)