### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/render.py
+++ b/agialpha_engine/render.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+from .context import atomic_write_json, BOUNDARIES
+
+
+def render_network_routes(out: Path) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(out / "routes.json", {
+        "routes": ["/agialpha-skill-network/", "/experiments/agialpha-engine-003/"],
+        "nav_label": "Skill Network",
+        **BOUNDARIES,
+    })

--- a/agialpha_engine/settlement.py
+++ b/agialpha_engine/settlement.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+def synthesize_local_settlement(receipt: dict) -> dict:
+    return {
+        "settlement_id": f"settlement-{receipt.get('receipt_id', 'unknown')}",
+        "mode": "synthetic_local_json_receipt_only",
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "status": "recorded",
+    }

--- a/agialpha_engine/settlement.py
+++ b/agialpha_engine/settlement.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .context import BOUNDARIES
+
 
 def synthesize_local_settlement(receipt: dict) -> dict:
     return {
@@ -11,4 +13,8 @@ def synthesize_local_settlement(receipt: dict) -> dict:
         "token_price_used": False,
         "investment_claim_made": False,
         "status": "recorded",
+        **BOUNDARIES,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
     }

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from .context import BOUNDARIES
+
+
+RECEIPT_NOTE = (
+    "Synthetic local utility receipt only. No wallet, custody, payment, trading, KYC/AML, "
+    "money transmission, securities functionality, token price, token value, token appreciation, "
+    "or investment return."
+)
+
+
+def build_skill_work_vault_receipt(*, receipt_id: str, skill_id: str, source_job_id: str, source_agent_id: str, target_agent_ids: list[str], utility_budget_units: int = 100) -> dict:
+    spent = 42 + 8 + 5 + 3 + 3 + 2 + len(target_agent_ids)
+    return {
+        "schema_version": "agialpha.skill_network.work_vault_receipt.v1",
+        "receipt_id": receipt_id,
+        "skill_id": skill_id,
+        "source_job_id": source_job_id,
+        "source_agent_id": source_agent_id,
+        "target_agent_ids": list(target_agent_ids),
+        "utility_budget_units": utility_budget_units,
+        "alpha_work_units_estimated": 42,
+        "validator_fee_units": 8,
+        "replay_fee_units": 5,
+        "proofbundle_fee_units": 3,
+        "evidence_docket_fee_units": 3,
+        "skill_publication_fee_units": 2,
+        "skill_import_fee_units": len(target_agent_ids),
+        "unused_budget_refund_units": max(0, utility_budget_units - spent),
+        "settlement_mode": "synthetic_local_json_receipt_only",
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "receipt_note": RECEIPT_NOTE,
+        **BOUNDARIES,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    }

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -12,6 +12,11 @@ RECEIPT_NOTE = (
 
 def build_skill_work_vault_receipt(*, receipt_id: str, skill_id: str, source_job_id: str, source_agent_id: str, target_agent_ids: list[str], utility_budget_units: int = 100) -> dict:
     spent = 42 + 8 + 5 + 3 + 3 + 2 + len(target_agent_ids)
+    if utility_budget_units < spent:
+        raise ValueError(
+            f"utility_budget_units ({utility_budget_units}) is lower than required spend ({spent}); "
+            "refusing to emit underfunded synthetic receipt"
+        )
     return {
         "schema_version": "agialpha.skill_network.work_vault_receipt.v1",
         "receipt_id": receipt_id,
@@ -27,7 +32,7 @@ def build_skill_work_vault_receipt(*, receipt_id: str, skill_id: str, source_job
         "evidence_docket_fee_units": 3,
         "skill_publication_fee_units": 2,
         "skill_import_fee_units": len(target_agent_ids),
-        "unused_budget_refund_units": max(0, utility_budget_units - spent),
+        "unused_budget_refund_units": utility_budget_units - spent,
         "settlement_mode": "synthetic_local_json_receipt_only",
         "wallet_used": False,
         "custody_used": False,


### PR DESCRIPTION
### Motivation
- Provide the missing Engine-003 runtime pieces required by the Networked Skill Compounding flow so runs can produce auditable, utility-only receipts and the public proof surface routes can be rendered. 
- Ensure utility-only accounting and boundary metadata are explicit (no wallet/custody/payment/token claims) and that routes for the new Skill Network pages are available to the generated-data pipeline.

### Description
- Implement `agialpha_engine/work_vault.py` to create deterministic synthetic local work-vault receipts (`agialpha.skill_network.work_vault_receipt.v1`) that explicitly set `wallet_used`, `custody_used`, `payment_executed`, `token_price_used`, and `investment_claim_made` to `False` and include boundary fields plus `human_review_required` and `no_auto_merge` flags.
- Implement `agialpha_engine/settlement.py` to synthesize a minimal synthetic local settlement record aligned with utility-only accounting and without any payment or token semantics.
- Implement `agialpha_engine/render.py` to emit site route metadata for the Skill Network flagship proof surface by adding `/agialpha-skill-network/` and `/experiments/agialpha-engine-003/` with the nav label `Skill Network` for the generated-data renderer.

### Testing
- Ran the full network compounding flow commands and build-data: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`, `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`, and `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network` and they completed successfully.
- Ran the test suite `python -m unittest discover -s tests`, which executed all tests (467 tests) and passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c52028648333b7333fda221c26ef)