### PR TITLE
Add synthetic work-vault receipt, local settlement, and network routes renderer

### DIFF
--- a/agialpha_engine/render.py
+++ b/agialpha_engine/render.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+from .context import atomic_write_json, BOUNDARIES
+
+
+def render_network_routes(out: Path) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(out / "routes.json", {
+        "routes": ["/agialpha-skill-network/", "/experiments/agialpha-engine-003/"],
+        "nav_label": "Skill Network",
+        **BOUNDARIES,
+    })

--- a/agialpha_engine/settlement.py
+++ b/agialpha_engine/settlement.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .context import BOUNDARIES
+
+
+def synthesize_local_settlement(receipt: dict) -> dict:
+    return {
+        "settlement_id": f"settlement-{receipt.get('receipt_id', 'unknown')}",
+        "mode": "synthetic_local_json_receipt_only",
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "status": "recorded",
+        **BOUNDARIES,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    }

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -11,6 +11,8 @@ RECEIPT_NOTE = (
 
 
 def build_skill_work_vault_receipt(*, receipt_id: str, skill_id: str, source_job_id: str, source_agent_id: str, target_agent_ids: list[str], utility_budget_units: int = 100) -> dict:
+    if not target_agent_ids:
+        raise ValueError("target_agent_ids must include at least one target agent")
     spent = 42 + 8 + 5 + 3 + 3 + 2 + len(target_agent_ids)
     if utility_budget_units < spent:
         raise ValueError(

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from .context import BOUNDARIES
+
+
+RECEIPT_NOTE = (
+    "Synthetic local utility receipt only. No wallet, custody, payment, trading, KYC/AML, "
+    "money transmission, securities functionality, token price, token value, token appreciation, "
+    "or investment return."
+)
+
+
+def build_skill_work_vault_receipt(*, receipt_id: str, skill_id: str, source_job_id: str, source_agent_id: str, target_agent_ids: list[str], utility_budget_units: int = 100) -> dict:
+    spent = 42 + 8 + 5 + 3 + 3 + 2 + len(target_agent_ids)
+    if utility_budget_units < spent:
+        raise ValueError(
+            "utility_budget_units is underfunded for deterministic fees: "
+            f"budget={utility_budget_units}, required={spent}"
+        )
+    return {
+        "schema_version": "agialpha.skill_network.work_vault_receipt.v1",
+        "receipt_id": receipt_id,
+        "skill_id": skill_id,
+        "source_job_id": source_job_id,
+        "source_agent_id": source_agent_id,
+        "target_agent_ids": list(target_agent_ids),
+        "utility_budget_units": utility_budget_units,
+        "alpha_work_units_estimated": 42,
+        "validator_fee_units": 8,
+        "replay_fee_units": 5,
+        "proofbundle_fee_units": 3,
+        "evidence_docket_fee_units": 3,
+        "skill_publication_fee_units": 2,
+        "skill_import_fee_units": len(target_agent_ids),
+        "unused_budget_refund_units": utility_budget_units - spent,
+        "settlement_mode": "synthetic_local_json_receipt_only",
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "receipt_note": RECEIPT_NOTE,
+        **BOUNDARIES,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    }

--- a/tests/test_agialpha_skill_work_vault_receipts.py
+++ b/tests/test_agialpha_skill_work_vault_receipts.py
@@ -1,2 +1,27 @@
-def test_placeholder():
-    assert True
+import pytest
+
+from agialpha_engine.work_vault import build_skill_work_vault_receipt
+
+
+def test_rejects_empty_target_agent_ids():
+    with pytest.raises(ValueError, match="at least one target agent"):
+        build_skill_work_vault_receipt(
+            receipt_id="r-1",
+            skill_id="s-1",
+            source_job_id="j-1",
+            source_agent_id="a-1",
+            target_agent_ids=[],
+        )
+
+
+def test_receipt_has_positive_import_targets_and_fee():
+    receipt = build_skill_work_vault_receipt(
+        receipt_id="r-1",
+        skill_id="s-1",
+        source_job_id="j-1",
+        source_agent_id="a-1",
+        target_agent_ids=["a-2", "a-3"],
+        utility_budget_units=100,
+    )
+    assert len(receipt["target_agent_ids"]) >= 1
+    assert receipt["skill_import_fee_units"] >= 1


### PR DESCRIPTION
### Motivation

- Provide utilities to produce synthetic local receipts and settlements for the skill network and to expose network routes for site navigation, while applying project `BOUNDARIES` and enforcing human review/persistence policies.

### Description

- Add `render_network_routes(out: Path)` in `agialpha_engine/render.py` which writes `routes.json` with `routes`, `nav_label`, and `BOUNDARIES` using `atomic_write_json`.
- Add `synthesize_local_settlement(receipt: dict)` in `agialpha_engine/settlement.py` which returns a deterministic synthetic settlement record populated with `BOUNDARIES` and review/persistence flags.
- Add `build_skill_work_vault_receipt(...)` in `agialpha_engine/work_vault.py` which builds a work-vault receipt with deterministic fee fields, computes `unused_budget_refund_units`, validates `utility_budget_units` against required deterministic fees, and embeds `RECEIPT_NOTE` and `BOUNDARIES` along with review/persistence flags.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c52028648333b7333fda221c26ef)