### PR TITLE
Add work_vault receipt builder, settlement synthesizer, route renderer, and unit test

### DIFF
--- a/agialpha_engine/render.py
+++ b/agialpha_engine/render.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+from .context import atomic_write_json, BOUNDARIES
+
+
+def render_network_routes(out: Path) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(out / "routes.json", {
+        "routes": ["/agialpha-skill-network/", "/experiments/agialpha-engine-003/"],
+        "nav_label": "Skill Network",
+        **BOUNDARIES,
+    })

--- a/agialpha_engine/settlement.py
+++ b/agialpha_engine/settlement.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .context import BOUNDARIES
+
+
+def synthesize_local_settlement(receipt: dict) -> dict:
+    return {
+        "settlement_id": f"settlement-{receipt.get('receipt_id', 'unknown')}",
+        "mode": "synthetic_local_json_receipt_only",
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "status": "recorded",
+        **BOUNDARIES,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    }

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from .context import BOUNDARIES
+
+
+RECEIPT_NOTE = (
+    "Synthetic local utility receipt only. No wallet, custody, payment, trading, KYC/AML, "
+    "money transmission, securities functionality, token price, token value, token appreciation, "
+    "or investment return."
+)
+
+
+def build_skill_work_vault_receipt(*, receipt_id: str, skill_id: str, source_job_id: str, source_agent_id: str, target_agent_ids: list[str], utility_budget_units: int = 100) -> dict:
+    if not target_agent_ids:
+        raise ValueError("target_agent_ids must include at least one target agent")
+    spent = 42 + 8 + 5 + 3 + 3 + 2 + len(target_agent_ids)
+    if utility_budget_units < spent:
+        raise ValueError(
+            "utility_budget_units is underfunded for deterministic fees: "
+            f"budget={utility_budget_units}, required={spent}"
+        )
+    return {
+        "schema_version": "agialpha.skill_network.work_vault_receipt.v1",
+        "receipt_id": receipt_id,
+        "skill_id": skill_id,
+        "source_job_id": source_job_id,
+        "source_agent_id": source_agent_id,
+        "target_agent_ids": list(target_agent_ids),
+        "utility_budget_units": utility_budget_units,
+        "alpha_work_units_estimated": 42,
+        "validator_fee_units": 8,
+        "replay_fee_units": 5,
+        "proofbundle_fee_units": 3,
+        "evidence_docket_fee_units": 3,
+        "skill_publication_fee_units": 2,
+        "skill_import_fee_units": len(target_agent_ids),
+        "unused_budget_refund_units": utility_budget_units - spent,
+        "settlement_mode": "synthetic_local_json_receipt_only",
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "receipt_note": RECEIPT_NOTE,
+        **BOUNDARIES,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    }

--- a/tests/test_agialpha_skill_work_vault_receipt_targets.py
+++ b/tests/test_agialpha_skill_work_vault_receipt_targets.py
@@ -1,0 +1,15 @@
+import pytest
+
+from agialpha_engine.work_vault import build_skill_work_vault_receipt
+
+
+def test_receipt_requires_at_least_one_target_agent():
+    with pytest.raises(ValueError, match="target_agent_ids"):
+        build_skill_work_vault_receipt(
+            receipt_id="r1",
+            skill_id="s1",
+            source_job_id="j1",
+            source_agent_id="a1",
+            target_agent_ids=[],
+            utility_budget_units=100,
+        )


### PR DESCRIPTION
### Motivation

- Introduce utilities to create synthetic local receipts and network route metadata for the skill network site. 
- Provide a deterministic builder for work-vault receipts with explicit fee accounting and safety checks to prevent accidental on-chain or autonomous persistence. 
- Add a unit test to enforce that receipts must include at least one target agent.

### Description

- Add `render_network_routes` in `agialpha_engine/render.py` to emit `routes.json` with site routes and injected `BOUNDARIES` via `atomic_write_json`. 
- Add `synthesize_local_settlement` in `agialpha_engine/settlement.py` to produce a synthetic settlement record with explicit flags disabling wallet/custody/payment functionality and including `BOUNDARIES`. 
- Add `build_skill_work_vault_receipt` in `agialpha_engine/work_vault.py` that constructs a detailed receipt schema, computes deterministic fee components, validates `target_agent_ids` is non-empty, validates `utility_budget_units` covers required fees, and annotates the receipt with safety flags and `RECEIPT_NOTE`. 
- Add `tests/test_agialpha_skill_work_vault_receipt_targets.py` which verifies that `build_skill_work_vault_receipt` raises a `ValueError` when `target_agent_ids` is empty.

### Testing

- Ran `pytest tests/test_agialpha_skill_work_vault_receipt_targets.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c52028648333b7333fda221c26ef)