### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/render.py
+++ b/agialpha_engine/render.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_skill_network_summary(metrics: dict[str, Any], claim_gate: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# AGI ALPHA Skill Network",
+            "",
+            "Every Job makes an AI Agent smarter.",
+            "Every new skill can be instantly shared across the network.",
+            "One Agent learns, all Agents level up.",
+            "",
+            f"- jobs run: {metrics.get('jobs_run', 'not_reported')}",
+            f"- accepted Skill Packages: {metrics.get('accepted_skill_packages', 'not_reported')}",
+            f"- rejected Skill Candidates: {metrics.get('rejected_skill_candidates', 'not_reported')}",
+            f"- Failure Learning Packages: {metrics.get('failure_learning_packages', 'not_reported')}",
+            f"- NetworkSkillPropagationLift: {metrics.get('network_skill_propagation_lift', 'not_reported')}",
+            f"- Claim gate status: {claim_gate.get('claim_gate_status', 'not_supported')}",
+            "",
+            "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.",
+        ]
+    )

--- a/agialpha_engine/settlement.py
+++ b/agialpha_engine/settlement.py
@@ -8,12 +8,25 @@ from .work_vault import make_skill_publication_receipt
 def settle_skill_publication(*, run_id: str, accepted_skill_packages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     receipts: list[dict[str, Any]] = []
     for skill in accepted_skill_packages:
+        skill_id = skill.get("skill_id")
+        source_job_id = skill.get("source_job_id")
+        source_agent_id = skill.get("source_agent_id")
+        target_agent_ids = skill.get("target_agent_ids")
+        if not isinstance(skill_id, str) or not skill_id:
+            raise ValueError("skill package missing required non-empty skill_id")
+        if not isinstance(source_job_id, str) or not source_job_id:
+            raise ValueError(f"skill package {skill_id} missing required non-empty source_job_id")
+        if not isinstance(source_agent_id, str) or not source_agent_id:
+            raise ValueError(f"skill package {skill_id} missing required non-empty source_agent_id")
+        if not isinstance(target_agent_ids, list) or not target_agent_ids:
+            raise ValueError(f"skill package {skill_id} missing required non-empty target_agent_ids")
         receipts.append(
             make_skill_publication_receipt(
                 run_id=run_id,
-                skill_id=str(skill.get("skill_id", "unknown-skill")),
-                source_job_id=str(skill.get("source_job_id", "unknown-job")),
-                units=1,
+                skill_id=skill_id,
+                source_job_id=source_job_id,
+                source_agent_id=source_agent_id,
+                target_agent_ids=[str(t) for t in target_agent_ids],
             )
         )
     return receipts

--- a/agialpha_engine/settlement.py
+++ b/agialpha_engine/settlement.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .work_vault import make_skill_publication_receipt
+
+
+def settle_skill_publication(*, run_id: str, accepted_skill_packages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    receipts: list[dict[str, Any]] = []
+    for skill in accepted_skill_packages:
+        receipts.append(
+            make_skill_publication_receipt(
+                run_id=run_id,
+                skill_id=str(skill.get("skill_id", "unknown-skill")),
+                source_job_id=str(skill.get("source_job_id", "unknown-job")),
+                units=1,
+            )
+        )
+    return receipts

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -17,20 +17,63 @@ def _hash_payload(payload: dict[str, Any]) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
-def make_skill_publication_receipt(*, run_id: str, skill_id: str, source_job_id: str, units: int = 1) -> dict[str, Any]:
+def make_skill_publication_receipt(
+    *,
+    run_id: str,
+    skill_id: str,
+    source_job_id: str,
+    source_agent_id: str,
+    target_agent_ids: list[str],
+    utility_budget_units: float = 100.0,
+    alpha_work_units_estimated: float = 42.0,
+    validator_fee_units: float = 8.0,
+    replay_fee_units: float = 5.0,
+    proofbundle_fee_units: float = 3.0,
+    evidence_docket_fee_units: float = 3.0,
+    skill_publication_fee_units: float = 2.0,
+    skill_import_fee_units: float | None = None,
+) -> dict[str, Any]:
+    if not run_id or not skill_id or not source_job_id or not source_agent_id:
+        raise ValueError("run_id, skill_id, source_job_id, and source_agent_id are required")
+    if not target_agent_ids or any(not agent_id for agent_id in target_agent_ids):
+        raise ValueError("target_agent_ids must contain at least one non-empty agent id")
+
+    import_fee_units = float(skill_import_fee_units if skill_import_fee_units is not None else len(target_agent_ids))
+    used_units = (
+        float(alpha_work_units_estimated)
+        + float(validator_fee_units)
+        + float(replay_fee_units)
+        + float(proofbundle_fee_units)
+        + float(evidence_docket_fee_units)
+        + float(skill_publication_fee_units)
+        + import_fee_units
+    )
+    refund_units = max(0.0, float(utility_budget_units) - used_units)
+
     base = {
         "schema_version": "agialpha.skill_work_vault_receipt.v1",
         "receipt_id": f"receipt-{run_id}-{skill_id}",
         "run_id": run_id,
         "skill_id": skill_id,
         "source_job_id": source_job_id,
-        "utility_units": int(units),
+        "source_agent_id": source_agent_id,
+        "target_agent_ids": target_agent_ids,
+        "utility_budget_units": float(utility_budget_units),
+        "alpha_work_units_estimated": float(alpha_work_units_estimated),
+        "validator_fee_units": float(validator_fee_units),
+        "replay_fee_units": float(replay_fee_units),
+        "proofbundle_fee_units": float(proofbundle_fee_units),
+        "evidence_docket_fee_units": float(evidence_docket_fee_units),
+        "skill_publication_fee_units": float(skill_publication_fee_units),
+        "skill_import_fee_units": import_fee_units,
+        "unused_budget_refund_units": refund_units,
+        "settlement_mode": "synthetic_local_json_receipt_only",
         "wallet_used": False,
         "custody_used": False,
         "payment_executed": False,
         "token_price_used": False,
         "investment_claim_made": False,
-        "receipt_text": RECEIPT_TEXT,
+        "receipt_note": RECEIPT_TEXT,
         "human_review_required": True,
         "autonomous_persistence_allowed": False,
         "no_auto_merge": True,

--- a/agialpha_engine/work_vault.py
+++ b/agialpha_engine/work_vault.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from .context import BOUNDARIES
+
+RECEIPT_TEXT = (
+    "Synthetic local utility receipt only. No wallet, custody, payment, trading, "
+    "KYC/AML, money transmission, securities functionality, token price, token value, "
+    "token appreciation, or investment return."
+)
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def make_skill_publication_receipt(*, run_id: str, skill_id: str, source_job_id: str, units: int = 1) -> dict[str, Any]:
+    base = {
+        "schema_version": "agialpha.skill_work_vault_receipt.v1",
+        "receipt_id": f"receipt-{run_id}-{skill_id}",
+        "run_id": run_id,
+        "skill_id": skill_id,
+        "source_job_id": source_job_id,
+        "utility_units": int(units),
+        "wallet_used": False,
+        "custody_used": False,
+        "payment_executed": False,
+        "token_price_used": False,
+        "investment_claim_made": False,
+        "receipt_text": RECEIPT_TEXT,
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+        **BOUNDARIES,
+    }
+    base["receipt_hash"] = _hash_payload(base)
+    return base


### PR DESCRIPTION
### Motivation
- Provide concrete, non-empty Engine-003 pieces required for measurable networked skill compounding: Work Vault receipts, settlement wiring, and a public-facing render summary that embed required utility-only boundaries and the exponential-compounding caveat. 

### Description
- Add deterministic utility Work Vault receipt builder `make_skill_publication_receipt` in `agialpha_engine/work_vault.py` that includes schema, stable hashing, and explicit flags forbidding wallet/custody/payment/token claims and requiring human review/autonomous_persistence=false. 
- Implement `settle_skill_publication` in `agialpha_engine/settlement.py` to convert accepted skill packages into per-skill Work Vault receipts using the new receipt builder. 
- Implement `render_skill_network_summary` in `agialpha_engine/render.py` to produce a concise, deterministic textual summary for the AGI ALPHA Skill Network hero/panel that includes core counters, claim-gate status, the operating thesis, and the required caveat: "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only." 
- All changes preserve repository boundary fields from `BOUNDARIES`, avoid external network or secret exposure, and follow the specification that no wallet/payment/token logic or overclaims are introduced.

### Testing
- Ran targeted discovery for network-run tests with `python -m unittest discover -s tests -p 'test_agialpha_skill_network*.py'`, which discovered 0 tests (pattern-specific discovery returned no matches). 
- Ran the full test suite with `python -m unittest discover -s tests`, which executed 467 tests and completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14cd2471fc8333b166b7c6c142c512)