### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_claim_gate.py
+++ b/agialpha_engine/network_claim_gate.py
@@ -32,6 +32,7 @@ def evaluate_network_compounding_claim(*, jobs_run:int, exact_one_outcome_per_jo
     ok = all(checks.values())
     return base_record({
         "claim_gate_status": supported_status(ok),
+        "exponential_compounding_status": "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.",
         "supported_wording": (
             "We have demonstrated local bounded networked skill compounding: one agent’s proof-bound job produced a validated Skill Package that other agents imported and used to improve held-out adjacent work against no-shared-skill baselines."
             if ok else

--- a/agialpha_engine/network_skill_metrics.py
+++ b/agialpha_engine/network_skill_metrics.py
@@ -13,5 +13,6 @@ def base_record(extra=None):
 __doc__ = "Network skill metrics computation from raw logs."
 
 def compute_d_metric(rows):
-    if not rows: return None
+    if not rows:
+        return "not_reported"
     return sum(r["success_score"]*r["validator_pass"]*r["replay_pass"]*r["proofbundle"]*r["docket"]/max(1,r["cost_risk_proxy"]) for r in rows)/len(rows)

--- a/agialpha_skill_network_registry/claim_gate_decisions.json
+++ b/agialpha_skill_network_registry/claim_gate_decisions.json
@@ -14,6 +14,7 @@
   },
   "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
   "claim_gate_status": "supported_local_bounded",
+  "exponential_compounding_status": "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.",
   "failed_reasons": [],
   "human_review_required": true,
   "no_auto_merge": true,

--- a/docs/_generated/agialpha-skill-network/claim_gate.json
+++ b/docs/_generated/agialpha-skill-network/claim_gate.json
@@ -14,6 +14,7 @@
   },
   "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
   "claim_gate_status": "supported_local_bounded",
+  "exponential_compounding_status": "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.",
   "failed_reasons": [],
   "human_review_required": true,
   "no_auto_merge": true,


### PR DESCRIPTION
### Motivation

- Make Engine-003 outputs deterministic and honest about missing metrics and ensure the public claim gate always includes the required exponential-compounding caveat text so public artifacts do not overclaim.

### Description

- Change `compute_d_metric` in `agialpha_engine/network_skill_metrics.py` to return the explicit sentinel string `"not_reported"` when held-out rows are absent instead of `None`, preserving honest missing-metric semantics.
- Add `exponential_compounding_status` to the claim payload emitted by `evaluate_network_compounding_claim` in `agialpha_engine/network_claim_gate.py` with the required caveat: `"Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only."`.
- Regenerated and updated the registry and generated-data claim gate artifacts so `agialpha_skill_network_registry/claim_gate_decisions.json` and `docs/_generated/agialpha-skill-network/claim_gate.json` reflect the new field and wording, then committed the changes.

### Testing

- Ran the full Engine-003 local flow with `python -m agialpha_engine network-compounding-run ...`, followed by `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and those commands completed successfully.
- Ran the full test suite with `python -m unittest discover -s tests` and all tests passed.
- Committed changes in a single patch with message `Refine Engine-003 network claim/metric reporting` and prepared this PR for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d32386808333a9b097aa117a2120)