### PR TITLE
Refine Engine-003: emit schema-aligned rejected and failure packages in network compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -170,9 +170,30 @@ def run_network_compounding(args):
             sid=f"skill-{i+1}"
             accepted.append({"schema_version":"agialpha.skill_package.v1","skill_id":sid,"source_job_id":jid,"source_agent_id":aid,"skill_type":"workflow_template","skill_payload":{"template":"safe_replay_template"},"validated_on_task_ids":[jid],"raw_task_result_ids":[f"raw-{jid}"],"proofbundle_id":f"pb-{sid}","evidence_docket_id":f"ed-{sid}","replay_status":"pending","falsification_status":"pending","risk_tier":"low","allowed_import_scope":"sandbox_only","activation_policy":{"auto_activate_allowed":False,"human_review_required":True,"validator_required":True,"replay_required":True,"falsification_required":True},**_base()})
         elif i%3==1:
-            rejected.append({"candidate_id":f"cand-{jid}","source_job_id":jid,"reason":"low_validator_confidence",**_base()})
+            rejected.append({
+                "schema_version": "agialpha.rejected_skill_candidate.v1",
+                "candidate_id": f"cand-{jid}",
+                "source_job_id": jid,
+                "source_agent_id": aid,
+                "rejection_reason": "low_validator_confidence",
+                "quarantine_required": True,
+                "raw_task_result_ids": [f"raw-{jid}"],
+                **_base(),
+            })
         else:
-            failure.append({"failure_learning_id":f"fl-{jid}","source_job_id":jid,"reason":"replay_mismatch_warning",**_base()})
+            failure.append({
+                "schema_version": "agialpha.failure_learning_package.v1",
+                "failure_learning_id": f"fl-{jid}",
+                "source_job_id": jid,
+                "source_agent_id": aid,
+                "failure_type": "replay_mismatch_warning",
+                "failure_summary": "Candidate did not satisfy replay confidence threshold for promotion.",
+                "reusable_warning": "Re-run with tightened validator and sandbox replay tracing.",
+                "recommended_future_validator": "replay_consistency_validator",
+                "quarantine_required": True,
+                "raw_task_result_ids": [f"raw-{jid}"],
+                **_base(),
+            })
     if not accepted:
         raise SystemExit("at least one accepted skill required")
     skill=accepted[0]

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -186,6 +186,7 @@ def run_network_compounding(args):
                 "failure_learning_id": f"fl-{jid}",
                 "source_job_id": jid,
                 "source_agent_id": aid,
+                "failure_category": "replay_mismatch",
                 "failure_type": "replay_mismatch_warning",
                 "failure_summary": "Candidate did not satisfy replay confidence threshold for promotion.",
                 "reusable_warning": "Re-run with tightened validator and sandbox replay tracing.",


### PR DESCRIPTION
### Motivation
- Ensure non-accepted outcomes from the Networked Skill Compounding run are preserved as full, schema-aligned artifacts (rejected skill candidates and failure learning packages) so the registry and evidence chain can record quarantine, raw-task linkage, and remediation guidance instead of minimal placeholders.

### Description
- Update `agialpha_engine/network_compounding.py` so rejected candidates and failure learning packages are emitted with explicit `schema_version`, `source_agent_id`, `raw_task_result_ids`, `quarantine_required`, and richer fields such as `rejection_reason` for rejected candidates and `failure_type`, `failure_summary`, `reusable_warning`, and `recommended_future_validator` for failures, while preserving existing accepted-skill behavior and boundary metadata.

### Testing
- Executed the end-to-end run and downstream steps with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, `network-compounding-build-data`, and ran the full unit test suite via `python -m unittest discover -s tests`, all of which completed successfully (467 tests ran, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14eae5545083339d7af4af9aa552d3)