### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_skill_network_registry/failure_learning_packages.json
+++ b/agialpha_skill_network_registry/failure_learning_packages.json
@@ -5,11 +5,21 @@
     {
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "failure_category": "replay_mismatch",
       "failure_learning_id": "fl-job-3",
+      "failure_summary": "Candidate did not satisfy replay confidence threshold for promotion.",
+      "failure_type": "replay_mismatch_warning",
       "human_review_required": true,
       "no_auto_merge": true,
-      "reason": "replay_mismatch_warning",
+      "quarantine_required": true,
+      "raw_task_result_ids": [
+        "raw-job-3"
+      ],
+      "recommended_future_validator": "replay_consistency_validator",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "reusable_warning": "Re-run with tightened validator and sandbox replay tracing.",
+      "schema_version": "agialpha.failure_learning_package.v1",
+      "source_agent_id": "agent-1",
       "source_job_id": "job-3",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }

--- a/agialpha_skill_network_registry/rejected_skill_candidates.json
+++ b/agialpha_skill_network_registry/rejected_skill_candidates.json
@@ -11,8 +11,14 @@
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
       "no_auto_merge": true,
-      "reason": "low_validator_confidence",
+      "quarantine_required": true,
+      "raw_task_result_ids": [
+        "raw-job-2"
+      ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejection_reason": "low_validator_confidence",
+      "schema_version": "agialpha.rejected_skill_candidate.v1",
+      "source_agent_id": "agent-1",
       "source_job_id": "job-2",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
@@ -22,8 +28,14 @@
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
       "no_auto_merge": true,
-      "reason": "low_validator_confidence",
+      "quarantine_required": true,
+      "raw_task_result_ids": [
+        "raw-job-5"
+      ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejection_reason": "low_validator_confidence",
+      "schema_version": "agialpha.rejected_skill_candidate.v1",
+      "source_agent_id": "agent-1",
       "source_job_id": "job-5",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }

--- a/docs/_generated/agialpha-skill-network/failure_learning_packages.json
+++ b/docs/_generated/agialpha-skill-network/failure_learning_packages.json
@@ -5,11 +5,21 @@
     {
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "failure_category": "replay_mismatch",
       "failure_learning_id": "fl-job-3",
+      "failure_summary": "Candidate did not satisfy replay confidence threshold for promotion.",
+      "failure_type": "replay_mismatch_warning",
       "human_review_required": true,
       "no_auto_merge": true,
-      "reason": "replay_mismatch_warning",
+      "quarantine_required": true,
+      "raw_task_result_ids": [
+        "raw-job-3"
+      ],
+      "recommended_future_validator": "replay_consistency_validator",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "reusable_warning": "Re-run with tightened validator and sandbox replay tracing.",
+      "schema_version": "agialpha.failure_learning_package.v1",
+      "source_agent_id": "agent-1",
       "source_job_id": "job-3",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }

--- a/docs/_generated/agialpha-skill-network/rejected_skill_candidates.json
+++ b/docs/_generated/agialpha-skill-network/rejected_skill_candidates.json
@@ -11,8 +11,14 @@
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
       "no_auto_merge": true,
-      "reason": "low_validator_confidence",
+      "quarantine_required": true,
+      "raw_task_result_ids": [
+        "raw-job-2"
+      ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejection_reason": "low_validator_confidence",
+      "schema_version": "agialpha.rejected_skill_candidate.v1",
+      "source_agent_id": "agent-1",
       "source_job_id": "job-2",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
@@ -22,8 +28,14 @@
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
       "no_auto_merge": true,
-      "reason": "low_validator_confidence",
+      "quarantine_required": true,
+      "raw_task_result_ids": [
+        "raw-job-5"
+      ],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejection_reason": "low_validator_confidence",
+      "schema_version": "agialpha.rejected_skill_candidate.v1",
+      "source_agent_id": "agent-1",
       "source_job_id": "job-5",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }


### PR DESCRIPTION
### Motivation

- Ensure the Network Skill Vault and public generated-data preserve actionable evidence for rejected skill candidates and failure-learning packages so every job's learning is observable, quarantinable, and traceable to raw task results.
- Close gaps required by the Engine-003 proof surface by adding required metadata fields and boundary flags to registry and generated-data artifacts used by the claim gate, replay and falsification tooling.

### Description

- Added richer records to the network registry and generated-data surface by updating `agialpha_skill_network_registry/rejected_skill_candidates.json` and `agialpha_skill_network_registry/failure_learning_packages.json` (and the mirrored `docs/_generated/agialpha-skill-network/*`) to include `raw_task_result_ids`, `quarantine_required`, `schema_version`, `source_agent_id`, `rejection_reason`/`failure_type`, and human-review / boundary fields required by Engine-003.
- Preserved required boundaries and anti-autopersist flags (`human_review_required`, `no_auto_merge`, `autonomous_persistence_allowed`, `claim_boundary`, `token_boundary`, `regulated_boundary`) in both registry and generated-data outputs, and committed the updated artifacts.

### Testing

- Executed the Engine-003 pipeline end-to-end with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` and then replay, falsification, validate, and build-data using `python -m agialpha_engine network-compounding-replay`, `python -m agialpha_engine network-compounding-falsification-audit`, `python -m agialpha_engine network-compounding-validate`, and `python -m agialpha_engine network-compounding-build-data`, all of which completed successfully.
- Ran the full test suite with `python -m unittest discover -s tests`, which completed successfully (467 tests run, all OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f2fe9b648333943125f945a6a971)