### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/proofbundle.py
+++ b/agialpha_engine/proofbundle.py
@@ -1,4 +1,7 @@
-"""ProofBundle creation and replay hash verification for Engine-002."""
+"""ProofBundle creation and replay hash verification helpers.
+
+Supports legacy ENGINE-002 proof artifacts and ENGINE-003 network-skill bundles.
+"""
 from __future__ import annotations
 
 from pathlib import Path
@@ -39,3 +42,36 @@ def verify_proofbundle_hash(bundle: dict[str, Any]) -> bool:
     expected = bundle.get("proofbundle_hash")
     body = {k: v for k, v in bundle.items() if k != "proofbundle_hash"}
     return expected == artifact_hash(body)
+
+
+def make_network_skill_proofbundle(bundle_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Build deterministic Engine-003 network skill proofbundle payload."""
+    keys = [
+        "source_job_hash",
+        "source_agent_hash",
+        "raw_evaluator_log_hashes",
+        "validator_result_hashes",
+        "skill_package_hash",
+        "network_skill_vault_entry_hash",
+        "agent_skill_manifest_hashes",
+        "skill_import_event_hashes",
+        "heldout_test_hashes",
+        "b6_vs_b5_comparison_hash",
+        "replay_report_hash",
+        "falsification_audit_hash",
+        "claim_gate_hash",
+    ]
+    sections = {k: payload.get(k, "") for k in keys}
+    bundle = {
+        "schema_version": "agialpha.network_skill.proofbundle.v1",
+        "proofbundle_id": bundle_id,
+        "seed": payload.get("seed"),
+        "environment_info": payload.get("environment_info", {}),
+        "replay_command": payload.get("replay_command", ""),
+        "human_review_status": payload.get("human_review_status", "pending"),
+        **sections,
+        **BOUNDARIES,
+    }
+    bundle["complete"] = all(bool(bundle.get(k)) for k in keys)
+    bundle["proofbundle_hash"] = artifact_hash({k: v for k, v in bundle.items() if k != "proofbundle_hash"})
+    return bundle

--- a/agialpha_engine/validate.py
+++ b/agialpha_engine/validate.py
@@ -86,20 +86,22 @@ def validate_run(run_dir: Path) -> dict[str, Any]:
 
 def validate_network_skill_run_minimum(run_dir: Path) -> dict[str, Any]:
     """Lightweight semantic validation for ENGINE-003 run directories."""
+    # Keep this aligned with ENGINE-003 run writer paths in
+    # agialpha_engine/network_compounding.py.
     required = [
         "00_manifest.json",
-        "02_job_results/raw_task_results.json",
+        "02_jobs/raw_task_results.json",
         "03_skill_extraction/accepted_skill_packages.json",
-        "04_skill_vault/network_skill_vault.json",
+        "04_network_skill_vault/network_skill_vault.json",
         "05_skill_import/skill_import_events.json",
-        "06_heldout_reuse/b6_vs_b5_network_comparison.json",
+        "06_heldout_reuse_tests/comparison.json",
         "07_metrics/network_skill_metrics.json",
         "13_claim_gate/network_compounding_claim_gate.json",
     ]
     missing = [p for p in required if not (run_dir / p).exists()]
     if missing:
         return {"validation_pass": False, "missing_required_files": missing}
-    raw = read_json(run_dir / "02_job_results" / "raw_task_results.json")
+    raw = read_json(run_dir / "02_jobs" / "raw_task_results.json")
     accepted = read_json(run_dir / "03_skill_extraction" / "accepted_skill_packages.json")
     imports = read_json(run_dir / "05_skill_import" / "skill_import_events.json")
     metrics = read_json(run_dir / "07_metrics" / "network_skill_metrics.json")

--- a/agialpha_engine/validate.py
+++ b/agialpha_engine/validate.py
@@ -1,4 +1,7 @@
-"""Validation gates for AGI ALPHA ENGINE-002 proof runs."""
+"""Validation gates for AGI ALPHA ENGINE proof runs.
+
+Includes legacy ENGINE-002 validation and focused ENGINE-003 helpers.
+"""
 from __future__ import annotations
 
 import json
@@ -79,3 +82,39 @@ def validate_run(run_dir: Path) -> dict[str, Any]:
     }
     result["validation_pass"] = all(v is True for k, v in result.items() if k.endswith("_pass")) and support_consistent
     return result
+
+
+def validate_network_skill_run_minimum(run_dir: Path) -> dict[str, Any]:
+    """Lightweight semantic validation for ENGINE-003 run directories."""
+    required = [
+        "00_manifest.json",
+        "02_job_results/raw_task_results.json",
+        "03_skill_extraction/accepted_skill_packages.json",
+        "04_skill_vault/network_skill_vault.json",
+        "05_skill_import/skill_import_events.json",
+        "06_heldout_reuse/b6_vs_b5_network_comparison.json",
+        "07_metrics/network_skill_metrics.json",
+        "13_claim_gate/network_compounding_claim_gate.json",
+    ]
+    missing = [p for p in required if not (run_dir / p).exists()]
+    if missing:
+        return {"validation_pass": False, "missing_required_files": missing}
+    raw = read_json(run_dir / "02_job_results" / "raw_task_results.json")
+    accepted = read_json(run_dir / "03_skill_extraction" / "accepted_skill_packages.json")
+    imports = read_json(run_dir / "05_skill_import" / "skill_import_events.json")
+    metrics = read_json(run_dir / "07_metrics" / "network_skill_metrics.json")
+    raw_rows = raw.get("raw_task_results", [])
+    accepted_rows = accepted.get("accepted_skill_packages", [])
+    import_rows = imports.get("skill_import_events", [])
+    pass_flags = {
+        "raw_task_results_present": len(raw_rows) >= 1,
+        "accepted_skills_link_raw_task_results": all(bool(r.get("raw_task_result_ids")) for r in accepted_rows),
+        "imports_present": len(import_rows) >= 1,
+        "metrics_have_lift": "network_skill_propagation_lift" in metrics,
+        "no_hardcoded_metrics": metrics.get("hard_coded_metric_count") == 0,
+    }
+    return {
+        "validation_pass": all(pass_flags.values()),
+        "checks": pass_flags,
+        "missing_required_files": [],
+    }


### PR DESCRIPTION
### Motivation
- Make ENGINE-003 evidence artifacts and semantic validation operational so networked skill propagation is measurable and replayable for local bounded claims.

### Description
- Add `make_network_skill_proofbundle` to `agialpha_engine/proofbundle.py` to build deterministic Engine-003 proofbundles that enumerate required evidence hashes, compute a completeness flag, and emit a reproducible bundle hash while preserving legacy ENGINE-002 helpers. 
- Add `validate_network_skill_run_minimum` to `agialpha_engine/validate.py` to perform lightweight ENGINE-003 run-level semantic checks for required artifacts, verify accepted skills link to raw task results, assert presence of `network_skill_propagation_lift`, and enforce `hard_coded_metric_count == 0`.
- Update module docstrings and keep legacy validation/proofbundle functions intact so existing workflows remain compatible.

### Testing
- Executed the full local network compounding flow with: `python -m agialpha_engine network-compounding-run --repo-root . --registry /tmp/agialpha-reg --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`, and then replay/falsification/validate with `network-compounding-replay`, `network-compounding-falsification-audit`, and `network-compounding-validate`; all commands completed successfully. 
- Built generated public data with `python -m agialpha_engine network-compounding-build-data --registry /tmp/agialpha-reg --out docs/_generated/agialpha-skill-network` which succeeded. 
- Ran the test suite with `python -m unittest discover -s tests` and all tests passed (467 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f6e406908333b8fde71c9f1bccf5)