### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/docs/agialpha-skill-network/README.md
+++ b/docs/agialpha-skill-network/README.md
@@ -6,6 +6,8 @@ One Agent learns, all Agents level up.
 
 > Instant sharing means sandboxed registration and importability. Production activation requires validators and human review.
 
+> Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.
+
 This section documents ENGINE-003 networked skill compounding artifacts, gates, and boundaries.
 
 ## Guides


### PR DESCRIPTION
### Motivation
- Make the public ENGINE-003 landing explicit about claim boundaries by ensuring the exponential-compounding thesis is presented as a strategic target unless the claim gate passes.

### Description
- Add an explicit caveat line to the Skill Network landing page by updating `docs/agialpha-skill-network/README.md` to include: `> Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.`

### Testing
- Ran the full local proof pipeline and unit tests including `python -m agialpha_engine network-compounding-run ...`, `python -m agialpha_engine network-compounding-replay ...`, `python -m agialpha_engine network-compounding-falsification-audit ...`, `python -m agialpha_engine network-compounding-validate ...`, `python -m agialpha_engine network-compounding-build-data ...`, `python -m unittest discover -s tests`, and `pytest -q tests/test_agialpha_skill_network_docs.py`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14ff42c5a0833397dadec1f8a322a9)