### PR TITLE
Fix heredoc indentation in Engine 003 network replay workflow

### DIFF
--- a/.github/workflows/agialpha-engine-003-network-replay.yml
+++ b/.github/workflows/agialpha-engine-003-network-replay.yml
@@ -37,26 +37,26 @@ jobs:
           fi
 
           RESOLVED_PATH=$(python - <<'PY'
-import json
-from pathlib import Path
-latest_path = Path('agialpha_skill_network_registry/latest.json')
-if not latest_path.exists():
-    print("")
-    raise SystemExit(0)
-latest = json.loads(latest_path.read_text())
-run_id = latest.get('run_id')
-if not run_id:
-    print("")
-    raise SystemExit(0)
-candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
-for path in candidates:
-    if path.exists() and path.is_dir():
-        print(path)
-        break
-else:
-    print("")
-PY
-)
+          import json
+          from pathlib import Path
+          latest_path = Path('agialpha_skill_network_registry/latest.json')
+          if not latest_path.exists():
+              print("")
+              raise SystemExit(0)
+          latest = json.loads(latest_path.read_text())
+          run_id = latest.get('run_id')
+          if not run_id:
+              print("")
+              raise SystemExit(0)
+          candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+          for path in candidates:
+              if path.exists() and path.is_dir():
+                  print(path)
+                  break
+          else:
+              print("")
+          PY
+          )
 
           if [ -z "$RESOLVED_PATH" ]; then
             echo "No runnable registry run found; creating deterministic local run for replay."


### PR DESCRIPTION
### Motivation
- The inline Python heredoc in ` .github/workflows/agialpha-engine-003-network-replay.yml` was mis-indented causing the workflow file to be invalid for the GitHub Actions parser, so the YAML needed a small formatting correction while preserving existing behavior.

### Description
- Corrected indentation of the `RESOLVED_PATH=$(python - <<'PY' ... PY )` heredoc block in ` .github/workflows/agialpha-engine-003-network-replay.yml` so the inline Python runs cleanly under the workflow `run` step without changing runtime logic.

### Testing
- Ran `python -m unittest discover -s tests`, which executed the test suite (467 tests) and completed with `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1511acdda0833389b9778fcc12d2ad)