### PR TITLE
Fix YAML heredoc indentation in Engine 003 network workflows

### DIFF
--- a/.github/workflows/agialpha-engine-003-network-claim-gate.yml
+++ b/.github/workflows/agialpha-engine-003-network-claim-gate.yml
@@ -37,26 +37,26 @@ jobs:
           fi
 
           RESOLVED_PATH=$(python - <<'PY'
-import json
-from pathlib import Path
-latest_path = Path('agialpha_skill_network_registry/latest.json')
-if not latest_path.exists():
-    print("")
-    raise SystemExit(0)
-latest = json.loads(latest_path.read_text())
-run_id = latest.get('run_id')
-if not run_id:
-    print("")
-    raise SystemExit(0)
-candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
-for path in candidates:
-    if path.exists() and path.is_dir():
-        print(path)
-        break
-else:
-    print("")
-PY
-)
+          import json
+          from pathlib import Path
+          latest_path = Path('agialpha_skill_network_registry/latest.json')
+          if not latest_path.exists():
+              print("")
+              raise SystemExit(0)
+          latest = json.loads(latest_path.read_text())
+          run_id = latest.get('run_id')
+          if not run_id:
+              print("")
+              raise SystemExit(0)
+          candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+          for path in candidates:
+              if path.exists() and path.is_dir():
+                  print(path)
+                  break
+          else:
+              print("")
+          PY
+          )
 
           if [ -z "$RESOLVED_PATH" ]; then
             echo "No runnable registry run found; creating deterministic local run for claim-gate validation."

--- a/.github/workflows/agialpha-engine-003-network-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-003-network-falsification-audit.yml
@@ -37,26 +37,26 @@ jobs:
           fi
 
           RESOLVED_PATH=$(python - <<'PY'
-import json
-from pathlib import Path
-latest_path = Path('agialpha_skill_network_registry/latest.json')
-if not latest_path.exists():
-    print("")
-    raise SystemExit(0)
-latest = json.loads(latest_path.read_text())
-run_id = latest.get('run_id')
-if not run_id:
-    print("")
-    raise SystemExit(0)
-candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
-for path in candidates:
-    if path.exists() and path.is_dir():
-        print(path)
-        break
-else:
-    print("")
-PY
-)
+          import json
+          from pathlib import Path
+          latest_path = Path('agialpha_skill_network_registry/latest.json')
+          if not latest_path.exists():
+              print("")
+              raise SystemExit(0)
+          latest = json.loads(latest_path.read_text())
+          run_id = latest.get('run_id')
+          if not run_id:
+              print("")
+              raise SystemExit(0)
+          candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+          for path in candidates:
+              if path.exists() and path.is_dir():
+                  print(path)
+                  break
+          else:
+              print("")
+          PY
+          )
 
           if [ -z "$RESOLVED_PATH" ]; then
             echo "No runnable registry run found; creating deterministic local run for falsification audit."


### PR DESCRIPTION
### Motivation
- Fix YAML parsing errors in two GitHub workflow files where the inline Python heredoc was not indented under `run: |`, which caused the YAML parser to treat `import json` as a top-level key and fail.

### Description
- Properly indented the inline Python heredoc block so it is nested inside the `run: |` multiline scalar in `.github/workflows/agialpha-engine-003-network-falsification-audit.yml` and `.github/workflows/agialpha-engine-003-network-claim-gate.yml`.

### Testing
- Parsed all workflow YAML files with Ruby/Psych using `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each{|f| YAML.load_file(f)}; puts "all workflow yaml parsed"'`, and the parse completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1514b816f883338e0cc051452d084f)