### PR TITLE
Add integration tests for skill import, claim gating, and failure learning

### DIFF
--- a/tests/test_agialpha_agent_skill_manifest.py
+++ b/tests/test_agialpha_agent_skill_manifest.py
@@ -1,2 +1,37 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_agent_manifests_include_required_skill_lists_and_policy():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        subprocess.check_call([
+            'python','-m','agialpha_engine','network-compounding-run',
+            '--repo-root','.','--registry',str(reg),'--out',str(run),
+            '--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'
+        ])
+        manifests = json.loads((run / '05_skill_import/agent_skill_manifests_after_import.json').read_text())['manifests']
+        assert len(manifests) >= 3
+        for m in manifests:
+            for key in ['native_skills','imported_skills','quarantined_skills','rejected_skills']:
+                assert key in m and isinstance(m[key], list)
+            assert m['skill_import_policy']
+            assert m['claim_boundary'] and m['token_boundary'] and m['regulated_boundary']
+
+
+def test_imported_skills_are_inactive_outside_sandbox_by_default():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        subprocess.check_call([
+            'python','-m','agialpha_engine','network-compounding-run',
+            '--repo-root','.','--registry',str(reg),'--out',str(run),
+            '--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'
+        ])
+        imports = json.loads((run / '05_skill_import/skill_import_events.json').read_text())['skill_import_events']
+        assert len(imports) >= 3
+        assert all(e['activation_status'] == 'inactive' for e in imports)
+        assert all(e.get('autonomous_persistence_allowed') is False for e in imports)

--- a/tests/test_agialpha_exponential_claim_gate.py
+++ b/tests/test_agialpha_exponential_claim_gate.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 
-def test_exponential_compounding_defaults_to_strategic_target_without_multi_cycle_evidence():
+def test_exponential_claim_defaults_to_strategic_target_without_multicycle_evidence():
     with tempfile.TemporaryDirectory() as td:
         run = Path(td) / 'run'
         reg = Path(td) / 'reg'
@@ -16,3 +16,19 @@ def test_exponential_compounding_defaults_to_strategic_target_without_multi_cycl
         metrics = json.loads((run / '07_metrics/network_skill_metrics.json').read_text())
         assert metrics['exponential_compounding_supported'] is False
         assert 'strategic target' in metrics['exponential_compounding_status']
+
+
+def test_exponential_claim_remains_blocked_even_after_replay_and_falsification():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        subprocess.check_call([
+            'python','-m','agialpha_engine','network-compounding-run',
+            '--repo-root','.','--registry',str(reg),'--out',str(run),
+            '--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'
+        ])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        metrics = json.loads((run / '07_metrics/network_skill_metrics.json').read_text())
+        assert metrics['exponential_compounding_supported'] is False
+        assert metrics['compounding_exponent_proxy'] in {'not_supported', 'pending', 'not_reported', 'unavailable', 'skipped_with_reason'}

--- a/tests/test_agialpha_failure_learning.py
+++ b/tests/test_agialpha_failure_learning.py
@@ -1,2 +1,41 @@
-def test_placeholder():
-    assert True
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_each_job_produces_reusable_learning_bucket():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        subprocess.check_call([
+            'python','-m','agialpha_engine','network-compounding-run',
+            '--repo-root','.','--registry',str(reg),'--out',str(run),
+            '--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'
+        ])
+        accepted = json.loads((run / '03_skill_extraction/accepted_skill_packages.json').read_text())['accepted_skill_packages']
+        rejected = json.loads((run / '03_skill_extraction/rejected_skill_candidates.json').read_text())['rejected_skill_candidates']
+        failures = json.loads((run / '03_skill_extraction/failure_learning_packages.json').read_text())['failure_learning_packages']
+        raw = json.loads((run / '02_jobs/raw_task_results.json').read_text())['raw_task_results']
+        produced = {p['source_job_id'] for p in accepted + rejected + failures}
+        expected = {r['task_id'] for r in raw}
+        assert expected <= produced
+        assert failures or rejected or accepted
+
+
+def test_failure_learning_package_has_boundary_fields_and_raw_ids():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        subprocess.check_call([
+            'python','-m','agialpha_engine','network-compounding-run',
+            '--repo-root','.','--registry',str(reg),'--out',str(run),
+            '--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'
+        ])
+        failures = json.loads((run / '03_skill_extraction/failure_learning_packages.json').read_text())['failure_learning_packages']
+        if failures:
+            row = failures[0]
+            assert row['raw_task_result_ids']
+            assert row['claim_boundary']
+            assert row['token_boundary']
+            assert row['regulated_boundary']


### PR DESCRIPTION
### Motivation

- Provide integration-level tests that validate skill import manifests, default activation/persistence behavior, claim-gating behavior for exponential compounding, and the production of failure-learning buckets.

### Description

- Replace placeholders with tests that run the end-to-end pipeline via `python -m agialpha_engine network-compounding-run` and inspect produced JSON outputs for expected fields and invariants.
- Add checks that agent skill manifests include `native_skills`, `imported_skills`, `quarantined_skills`, `rejected_skills`, `skill_import_policy`, and the `claim_boundary`, `token_boundary`, and `regulated_boundary` fields.
- Add tests asserting imported skills are `inactive` outside the sandbox by default and that `autonomous_persistence_allowed` is `False` on imports.
- Add tests for exponential-claim gating that assert default status (`strategic target`) when multicycle evidence is missing and that claims remain blocked after running `network-compounding-replay` and `network-compounding-falsification-audit` with expected `compounding_exponent_proxy` statuses.
- Add failure-learning tests that verify each job produces a reusable learning bucket by comparing `raw_task_results` to produced accepted/rejected/failure packages and that failure packages include `raw_task_result_ids`, `claim_boundary`, `token_boundary`, and `regulated_boundary` when present.

### Testing

- Ran the new integration tests with `pytest tests/test_agialpha_agent_skill_manifest.py tests/test_agialpha_exponential_claim_gate.py tests/test_agialpha_failure_learning.py` which invoke `python -m agialpha_engine network-compounding-run` and related replay/falsification commands, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15cb2bead083338a55da64e768e667)