### PR TITLE
Harden human-review promotion default to pending

### DIFF
--- a/secure_rails/human_review.py
+++ b/secure_rails/human_review.py
@@ -19,7 +19,7 @@ def validate_promotion_gate(record: dict) -> list[str]:
     if cond.get("human_review_decision_present") is not True: errs.append("human_review_decision_present must be true")
     if cond.get("hard_safety_counters_zero") is not True: errs.append("hard_safety_counters_zero must be true")
     if cond.get("auto_merge_allowed") is not False: errs.append("auto_merge_allowed must be false")
-    review_status = str(record.get("human_review_status", "accepted")).strip().lower()
+    review_status = str(record.get("human_review_status", "pending")).strip().lower()
     if review_status not in {"accepted", "rejected", "needs_changes", "pending"}:
         errs.append("human_review_status invalid")
     if review_status == "pending":

--- a/tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json
+++ b/tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json
@@ -14,5 +14,6 @@
   },
   "gate_status": "pass",
   "failure_reasons": [],
-  "claim_boundary": "Promotion gates enforce human-governed SecureRails promotion. Passing a gate is not a security certification."
+  "claim_boundary": "Promotion gates enforce human-governed SecureRails promotion. Passing a gate is not a security certification.",
+  "human_review_status": "accepted"
 }

--- a/tests/test_securerails_promotion_gate.py
+++ b/tests/test_securerails_promotion_gate.py
@@ -30,3 +30,9 @@ class T(unittest.TestCase):
     gate["required_conditions"]=[]
     errs=validate_promotion_gate(gate)
     self.assertTrue(any("required_conditions must be an object" in e for e in errs))
+
+  def test_missing_human_review_status_defaults_pending_and_blocks(self):
+    gate=json.loads(Path("tests/fixtures/securerails_human_review/valid_promotion_gate_pass.json").read_text())
+    gate.pop("human_review_status", None)
+    errs=validate_promotion_gate(gate)
+    self.assertTrue(any("promotion pending human review" in e for e in errs))


### PR DESCRIPTION
### Motivation

- Prevent implicit acceptance of promotion gates when `human_review_status` is omitted so promotions cannot bypass explicit human acceptance. 

### Description

- Change default human review handling in `secure_rails/human_review.py` so `human_review_status` defaults to `pending` instead of `accepted`. 
- Add an explicit `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d7f2c1108333bd9753cfe6ae5ba4)