### PR TITLE
Harden atomic JSON writes for Engine-003 runs

### DIFF
--- a/agialpha_engine/context.py
+++ b/agialpha_engine/context.py
@@ -13,8 +13,9 @@ BOUNDARIES={
 
 def atomic_write_json(path: Path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + '.tmp')
-    with tmp.open('w', encoding='utf-8') as f:
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', dir=str(path.parent), prefix=path.name + '.', suffix='.tmp', delete=False) as f:
+        tmp = Path(f.name)
         json.dump(data, f, indent=2, sort_keys=True)
         f.write('\n')
     tmp.replace(path)


### PR DESCRIPTION
### Motivation
- Prevent temp-file collision and JSON corruption when concurrent Engine-003 processes or tests write the same artifact paths by making atomic JSON writes robust and directory-local.

### Description
- Replace the previous `atomic_write_json` tmp-file logic with `tempfile.NamedTemporaryFile` created inside the destination directory and then `replace()` the target to ensure unique per-write temp files and reliable atomic replace semantics.

### Testing
- Ran the full Engine-003 happy-path commands: `python -m agialpha_engine network-compounding-run ...`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, all of which completed successfully.
- Ran the test suites: `python -m unittest discover -s tests` and `pytest -q`, and verified the test runs completed (unittests passed and `pytest` reported `683 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d7f2c1108333bd9753cfe6ae5ba4)