### PR TITLE
Verify claim-gate artifacts in Engine-003 workflow

### DIFF
--- a/.github/workflows/agialpha-engine-003-network-compounding.yml
+++ b/.github/workflows/agialpha-engine-003-network-compounding.yml
@@ -60,6 +60,10 @@ jobs:
       - run: python -m agialpha_engine network-compounding-replay --run "$RUN_PATH"
       - run: python -m agialpha_engine network-compounding-falsification-audit --run "$RUN_PATH"
       - run: python -m agialpha_engine network-compounding-validate --run "$RUN_PATH"
+      - name: Verify claim gate + manifest outputs
+        run: |
+          test -f "$RUN_PATH/13_claim_gate/network_compounding_claim_gate.json"
+          test -f "$RUN_PATH/evidence-run-manifest.json"
       - name: Build generated data
         if: ${{ inputs.publish_skill_network_tab != 'false' }}
         run: python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network


### PR DESCRIPTION
### Motivation
- Ensure lifecycle evidence integrity by failing CI early if the network-compounding run did not emit the required claim-gate decision and evidence manifest artifacts before generated-data build/upload.

### Description
- Add a verification step to `.github/workflows/agialpha-engine-003-network-compounding.yml` that checks for `13_claim_gate/network_compounding_claim_gate.json` and `evidence-run-manifest.json` in the run output immediately after `network-compounding-validate` and before the generated-data build.

### Testing
- Executed the full test suite with `python -m unittest discover -s tests`, which completed successfully (467 tests run, OK). 
- Ran the network compounding pipeline locally with the sequence `network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, which completed without error. 
- Ran `pytest -q tests/test_agialpha_skill_network_workflows.py`, which passed (1 test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15db5fb0948333849057bdea60a7c8)