### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/00_manifest.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/00_manifest.json
@@ -1,6 +1,7 @@
 {
   "autonomous_persistence_allowed": false,
   "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "experiment_id": "AGI-ALPHA-ENGINE-003",
   "human_review_required": true,
   "no_auto_merge": true,
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/evidence-run-manifest.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/evidence-run-manifest.json
@@ -5,6 +5,7 @@
   "no_auto_merge": true,
   "registry": "agialpha_skill_network_registry",
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "run": "/tmp/agialpha-skill-network-test",
   "run_id": "agialpha-skill-network-test",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }


### PR DESCRIPTION
### Motivation
- Make Engine-003 run artifacts explicit and discoverable so replay, falsification, validation, and generated-data steps can reliably locate the evidence and bind it to the Engine-003 experiment.

### Description
- Add `"experiment_id": "AGI-ALPHA-ENGINE-003"` to `agialpha_skill_network_registry/runs/agialpha-skill-network-test/00_manifest.json` to tag the run with the Engine-003 experiment identifier. 
- Add `"run": "/tmp/agialpha-skill-network-test"` to `agialpha_skill_network_registry/runs/agialpha-skill-network-test/evidence-run-manifest.json` to record the runtime output path used for replay and evidence linkage.

### Testing
- Executed the networked skill compounding local flow with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` and then ran `python -m agialpha_engine network-compounding-replay --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-falsification-audit --run /tmp/agialpha-skill-network-test`, `python -m agialpha_engine network-compounding-validate --run /tmp/agialpha-skill-network-test`, and `python -m agialpha_engine network-compounding-build-data --registry agialpha_skill_network_registry --out docs/_generated/agialpha-skill-network`; these completed without error. 
- Ran the unit test suite with `python -m unittest discover -s tests` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e0fa9ae88333bd08e4a13215341b)