### PR TITLE
Engine-003: require 3+ target agents imported for network-compounding validation

### DIFF
--- a/agialpha_engine/validate.py
+++ b/agialpha_engine/validate.py
@@ -109,9 +109,10 @@ def validate_network_skill_run_minimum(run_dir: Path) -> dict[str, Any]:
     accepted_rows = accepted.get("accepted_skill_packages", [])
     import_rows = imports.get("skill_import_events", [])
     imported_agents = {
-        str(row.get("target_agent_id", "")).strip()
+        target_id.strip()
         for row in import_rows
-        if str(row.get("target_agent_id", "")).strip()
+        for target_id in [row.get("target_agent_id")]
+        if isinstance(target_id, str) and target_id.strip()
     }
     pass_flags = {
         "raw_task_results_present": len(raw_rows) >= 1,

--- a/agialpha_engine/validate.py
+++ b/agialpha_engine/validate.py
@@ -108,10 +108,16 @@ def validate_network_skill_run_minimum(run_dir: Path) -> dict[str, Any]:
     raw_rows = raw.get("raw_task_results", [])
     accepted_rows = accepted.get("accepted_skill_packages", [])
     import_rows = imports.get("skill_import_events", [])
+    imported_agents = {
+        str(row.get("target_agent_id", "")).strip()
+        for row in import_rows
+        if str(row.get("target_agent_id", "")).strip()
+    }
     pass_flags = {
         "raw_task_results_present": len(raw_rows) >= 1,
         "accepted_skills_link_raw_task_results": all(bool(r.get("raw_task_result_ids")) for r in accepted_rows),
         "imports_present": len(import_rows) >= 1,
+        "minimum_target_agents_imported": len(imported_agents) >= 3,
         "metrics_have_lift": "network_skill_propagation_lift" in metrics,
         "no_hardcoded_metrics": metrics.get("hard_coded_metric_count") == 0,
     }


### PR DESCRIPTION
### Motivation
- The Engine-003 claim gate and validation must verify not only that skill imports exist but that skills were imported by a minimum number of distinct target agents to support a network-propagation claim.
- This enforces the product rule that shared skills must propagate across multiple agents before any local-bounded compounding claim is considered supported.

### Description
- Added an imported-agent threshold check to ENGINE-003 lightweight validation in `agialpha_engine/validate.py` by extracting distinct `target_agent_id` values from `05_skill_import/skill_import_events.json` and requiring at least 3 unique importing agents via a new `minimum_target_agents_imported` check. 
- The final `validation_pass` now includes the new check alongside the existing raw-log, accepted-skill, imports-present, lift-metric, and non-hardcoded-metrics checks.

### Testing
- Ran the Engine-003 end-to-end local commands: `network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, all of which completed successfully. 
- Ran the full unit test suite with `python -m unittest discover -s tests` and targeted pytest suites including `tests/test_securerails_promotion_gate.py`, `tests/test_securerails_decision_ledger.py`, and `tests/test_agialpha_network_compounding_metrics.py`, and these passed after the change.
- Committed the change under the message: "Strengthen Engine-003 validation for imported-agent threshold" and recorded the PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e4c718b483338b6ef0d0f6fb4397)