### PR TITLE
Add minimum_target_agents_imported check to network run validation

### DIFF
--- a/agialpha_engine/validate.py
+++ b/agialpha_engine/validate.py
@@ -108,12 +108,13 @@ def validate_network_skill_run_minimum(run_dir: Path) -> dict[str, Any]:
     raw_rows = raw.get("raw_task_results", [])
     accepted_rows = accepted.get("accepted_skill_packages", [])
     import_rows = imports.get("skill_import_events", [])
-    imported_agents = {
-        target_id.strip()
-        for row in import_rows
-        for target_id in [row.get("target_agent_id")]
-        if isinstance(target_id, str) and target_id.strip()
-    }
+    imported_agents = set()
+    for row in import_rows:
+        if not isinstance(row, dict):
+            continue
+        target_id = row.get("target_agent_id")
+        if isinstance(target_id, str) and target_id.strip():
+            imported_agents.add(target_id.strip())
     pass_flags = {
         "raw_task_results_present": len(raw_rows) >= 1,
         "accepted_skills_link_raw_task_results": all(bool(r.get("raw_task_result_ids")) for r in accepted_rows),

--- a/agialpha_engine/validate.py
+++ b/agialpha_engine/validate.py
@@ -108,10 +108,17 @@ def validate_network_skill_run_minimum(run_dir: Path) -> dict[str, Any]:
     raw_rows = raw.get("raw_task_results", [])
     accepted_rows = accepted.get("accepted_skill_packages", [])
     import_rows = imports.get("skill_import_events", [])
+    imported_agents = {
+        target_id.strip()
+        for row in import_rows
+        for target_id in [row.get("target_agent_id")]
+        if isinstance(target_id, str) and target_id.strip()
+    }
     pass_flags = {
         "raw_task_results_present": len(raw_rows) >= 1,
         "accepted_skills_link_raw_task_results": all(bool(r.get("raw_task_result_ids")) for r in accepted_rows),
         "imports_present": len(import_rows) >= 1,
+        "minimum_target_agents_imported": len(imported_agents) >= 3,
         "metrics_have_lift": "network_skill_propagation_lift" in metrics,
         "no_hardcoded_metrics": metrics.get("hard_coded_metric_count") == 0,
     }


### PR DESCRIPTION
### Motivation
- Ensure `validate_network_skill_run_minimum` identifies runs that do not import a sufficient number of distinct target agents so runs with too few imports are flagged.

### Description
- Compute a set of distinct, non-empty `target_agent_id` values from `05_skill_import/skill_import_events.json` and add a `minimum_target_agents_imported` check that requires at least 3 agents in the returned `checks` map.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e4c718b483338b6ef0d0f6fb4397)