### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -89,7 +89,14 @@ def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: lis
         )
         validator_results = row.get("validator_results")
         if isinstance(validator_results, list):
-            validator_pass_value = any(bool(v.get("pass")) for v in validator_results if isinstance(v, dict))
+            list_pass_values: list[bool] = []
+            for validator_row in validator_results:
+                if not isinstance(validator_row, dict):
+                    continue
+                pass_value = validator_row.get("pass")
+                if isinstance(pass_value, bool):
+                    list_pass_values.append(pass_value)
+            validator_pass_value = bool(list_pass_values) and all(list_pass_values)
         elif isinstance(validator_results, dict):
             validator_pass_value = validator_results.get("validator_pass", False)
         else:

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -87,8 +87,15 @@ def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: lis
             errors=errors,
             sandbox_id=sandbox_id or "unknown-sandbox",
         )
+        validator_results = row.get("validator_results")
+        if isinstance(validator_results, list):
+            validator_pass_value = any(bool(v.get("pass")) for v in validator_results if isinstance(v, dict))
+        elif isinstance(validator_results, dict):
+            validator_pass_value = validator_results.get("validator_pass", False)
+        else:
+            validator_pass_value = False
         row_validator_pass = _coerce_bool_strict(
-            row.get("validator_pass", row.get("validator_results", {}).get("validator_pass", False)),
+            row.get("validator_pass", validator_pass_value),
             field_name="validator_pass",
             errors=errors,
             sandbox_id=sandbox_id or "unknown-sandbox",
@@ -190,7 +197,7 @@ def run_network_compounding(args):
         jid=f"job-{i+1}"; aid=agents[0]["agent_id"]
         score=0.5 + i*0.03 + (rng.random()*0.02)
         rec={"job_id":jid,"source_agent_id":aid,"validator_pass":True,"task_success":True,"score":round(score,3),"cost_risk_proxy":1,**_base()}
-        jobs.append(rec); raw.append({"task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":{"validator_pass":True},"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
+        jobs.append(rec); raw.append({"schema_version":"agialpha.engine.raw_task_result.v1","task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":[{"validator_id":"default-local-validator","pass":True}],"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
         stdout_payload, stderr_payload = _compute_stream_payload(jid, rec["score"], rec["validator_pass"])
         sandbox_records.append({
             "schema_version": "agialpha.engine.sandbox_record.v1",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/02_job_results.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/02_job_results.json
@@ -99,6 +99,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-1",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.501,
       "seed": 123,
       "skill_id": null,
@@ -111,9 +112,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -138,6 +142,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-2",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.532,
       "seed": 123,
       "skill_id": null,
@@ -150,9 +155,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -177,6 +185,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-3",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.568,
       "seed": 123,
       "skill_id": null,
@@ -189,9 +198,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -216,6 +228,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-4",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.592,
       "seed": 123,
       "skill_id": null,
@@ -228,9 +241,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -255,6 +271,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-5",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.638,
       "seed": 123,
       "skill_id": null,
@@ -267,9 +284,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",

--- a/tests/test_agialpha_skill_network_run.py
+++ b/tests/test_agialpha_skill_network_run.py
@@ -1,5 +1,6 @@
 import json, subprocess, tempfile
 from pathlib import Path
+from agialpha_engine.network_compounding import _compute_stream_payload, _h, _validate_sandbox_records
 
 
 def test_network_run_end_to_end():
@@ -234,6 +235,31 @@ def test_seed_changes_outputs():
         m1=json.loads((run1/'07_metrics/network_skill_metrics.json').read_text())
         m2=json.loads((run2/'07_metrics/network_skill_metrics.json').read_text())
         assert m1['network_skill_propagation_lift'] != m2['network_skill_propagation_lift']
+
+
+def test_sandbox_validation_requires_all_listed_validators_to_pass():
+    raw_row = {
+        "sandbox_id": "sandbox-job-1",
+        "task_id": "job-1",
+        "raw_scores": {"score": 0.75},
+        "validator_results": [
+            {"validator_id": "v1", "pass": True},
+            {"validator_id": "v2", "pass": False},
+        ],
+    }
+    stdout, stderr = _compute_stream_payload("job-1", 0.75, False)
+    sandbox_record = {
+        "sandbox_id": "sandbox-job-1",
+        "allowed_root": ".",
+        "stdout_hash": _h(stdout),
+        "stderr_hash": _h(stderr),
+        "network_disabled": True,
+        "repo_mutation_allowed": False,
+        "production_actuation_allowed": False,
+    }
+    ok, errors = _validate_sandbox_records([raw_row], [sandbox_record])
+    assert ok is True
+    assert errors == []
 
 
 def test_registry_skill_packages_synced_after_audits():


### PR DESCRIPTION
### Motivation
- Prevent replay/validation crashes caused by mismatched raw evaluator `validator_results` schema and ensure raw task results conform to the Engine-003 spec. 
- Make sandbox integrity checks robust to both list- and dict-shaped validator results so replay and falsification can deterministically verify stdout/stderr hashes.

### Description
- Normalize emitted raw evaluator rows in `agialpha_engine/network_compounding.py` to include `schema_version: agialpha.engine.raw_task_result.v1` and to emit `validator_results` as a list of `{validator_id, pass}` entries. 
- Update `_validate_sandbox_records` in `agialpha_engine/network_compounding.py` to accept either a list or dict for `validator_results` and compute `validator_pass` deterministically for replay integrity checks. 
- Regenerated the Engine-003 run artifact `agialpha_skill_network_registry/runs/agialpha-skill-network-test/02_job_results.json` to reflect the corrected raw evaluator payload shape so registry and generated-data consumers see consistent schema.

### Testing
- Executed the full Engine-003 local flow with: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` and it completed successfully. 
- Replayed, ran falsification audit, validated the run, and built generated data with `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data` and those steps completed successfully after the fix. 
- Ran the repository unit test suite with `python -m unittest discover -s tests` and all tests passed (existing test suite: 467 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1725ea2f848333ada80b481b81cc69)