### PR TITLE
Normalize `validator_results` (list form) and add `schema_version` to raw task results

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -87,8 +87,25 @@ def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: lis
             errors=errors,
             sandbox_id=sandbox_id or "unknown-sandbox",
         )
+        validator_results = row.get("validator_results")
+        if isinstance(validator_results, list):
+            validator_pass_entries: list[bool] = []
+            for v in validator_results:
+                if not isinstance(v, dict):
+                    errors.append(f"validator_results entries must be objects for {sandbox_id}")
+                    continue
+                pass_value = v.get("pass")
+                if not isinstance(pass_value, bool):
+                    errors.append(f"validator_results pass values must be boolean for {sandbox_id}")
+                    continue
+                validator_pass_entries.append(pass_value)
+            validator_pass_value = bool(validator_pass_entries) and all(validator_pass_entries)
+        elif isinstance(validator_results, dict):
+            validator_pass_value = validator_results.get("validator_pass", False)
+        else:
+            validator_pass_value = False
         row_validator_pass = _coerce_bool_strict(
-            row.get("validator_pass", row.get("validator_results", {}).get("validator_pass", False)),
+            row.get("validator_pass", validator_pass_value),
             field_name="validator_pass",
             errors=errors,
             sandbox_id=sandbox_id or "unknown-sandbox",
@@ -190,7 +207,7 @@ def run_network_compounding(args):
         jid=f"job-{i+1}"; aid=agents[0]["agent_id"]
         score=0.5 + i*0.03 + (rng.random()*0.02)
         rec={"job_id":jid,"source_agent_id":aid,"validator_pass":True,"task_success":True,"score":round(score,3),"cost_risk_proxy":1,**_base()}
-        jobs.append(rec); raw.append({"task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":{"validator_pass":True},"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
+        jobs.append(rec); raw.append({"schema_version":"agialpha.engine.raw_task_result.v1","task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":[{"validator_id":"default-local-validator","pass":True}],"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
         stdout_payload, stderr_payload = _compute_stream_payload(jid, rec["score"], rec["validator_pass"])
         sandbox_records.append({
             "schema_version": "agialpha.engine.sandbox_record.v1",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/02_job_results.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/02_job_results.json
@@ -99,6 +99,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-1",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.501,
       "seed": 123,
       "skill_id": null,
@@ -111,9 +112,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -138,6 +142,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-2",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.532,
       "seed": 123,
       "skill_id": null,
@@ -150,9 +155,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -177,6 +185,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-3",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.568,
       "seed": 123,
       "skill_id": null,
@@ -189,9 +198,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -216,6 +228,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-4",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.592,
       "seed": 123,
       "skill_id": null,
@@ -228,9 +241,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     },
     {
       "agent_id": "agent-1",
@@ -255,6 +271,7 @@
         "critical_safety_incidents": 0
       },
       "sandbox_id": "sandbox-job-5",
+      "schema_version": "agialpha.engine.raw_task_result.v1",
       "score": 0.638,
       "seed": 123,
       "skill_id": null,
@@ -267,9 +284,12 @@
       "task_success": true,
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading",
       "validator_pass": true,
-      "validator_results": {
-        "validator_pass": true
-      }
+      "validator_results": [
+        {
+          "pass": true,
+          "validator_id": "default-local-validator"
+        }
+      ]
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",


### PR DESCRIPTION
### Motivation
- Make sandbox record validation robust to a new `validator_results` shape that can be a list of per-validator entries instead of a single dict.  
- Ensure generated raw task results include an explicit `schema_version` and use a consistent `validator_results` list format in the synthetic run generator and registry fixtures.

### Description
- Updated `_validate_sandbox_records` to accept `validator_results` as either a list of `{validator_id, pass}` objects or the legacy dict form and to compute `validator_pass` accordingly using strict boolean coercion.  
- Changed `run_network_compounding` to emit `schema_version: "agialpha.engine.raw_task_result.v1"` and to produce `validator_results` as a list of validator objects (`{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1725ea2f848333ada80b481b81cc69)