### PR TITLE
Emit explicit Network Skill Vault registry.json from Engine-003 run writer

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -379,6 +379,28 @@ def run_network_compounding(args):
     atomic_write_json(out/'evidence-run-manifest.json',{"run":str(out),"run_id":run_id,"registry":str(reg),**_base()})
     # registry + generated placeholders
     atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'skill_propagation_events.json',{"skill_propagation_events":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json',{"receipts":[receipt],**_base()}); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()}); atomic_write_json(reg/'proofbundles.json',{"proofbundles":proofbundles,**_base()}); atomic_write_json(reg/'evidence_dockets.json',{"evidence_dockets":dockets,**_base()})
+    atomic_write_json(reg/'registry.json',{
+        "schema_version":"agialpha.skill_network.registry.v1",
+        "latest_run_id":run_id,
+        "runs_path":"runs/",
+        "append_only":True,
+        "records":{
+            "agents":"agents.json",
+            "agent_skill_manifests":"agent_skill_manifests.json",
+            "skill_packages":"skill_packages.json",
+            "rejected_skill_candidates":"rejected_skill_candidates.json",
+            "failure_learning_packages":"failure_learning_packages.json",
+            "skill_imports":"skill_imports.json",
+            "skill_propagation_events":"skill_propagation_events.json",
+            "network_skill_metrics":"network_skill_metrics.json",
+            "claim_gate_decisions":"claim_gate_decisions.json",
+            "work_vault_receipts":"work_vault_receipts.json",
+            "proofbundles":"proofbundles.json",
+            "evidence_dockets":"evidence_dockets.json",
+            "lineage_graph":"lineage_graph.json"
+        },
+        **_base()
+    })
     existing_registry = _read(reg/'registry.json', {})
     atomic_write_json(reg/'registry.json', _next_registry_index(existing_registry, run_id))
     run_registry_dir = reg / "runs" / run_id

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -24,7 +24,13 @@ def _next_registry_index(existing: dict, run_id: str) -> dict:
     runs = [r for r in previous_runs if isinstance(r, str) and r]
     if run_id not in runs:
         runs.append(run_id)
-    return {"latest_run_id": run_id, "runs": runs, **_base()}
+    merged = dict(existing) if isinstance(existing, dict) else {}
+    merged.update({
+        "latest_run_id": run_id,
+        "runs": runs,
+        **_base(),
+    })
+    return merged
 
 
 def _compute_stream_payload(job_id: str, score: float, validator_pass: bool) -> tuple[str, str]:
@@ -379,7 +385,8 @@ def run_network_compounding(args):
     atomic_write_json(out/'evidence-run-manifest.json',{"run":str(out),"run_id":run_id,"registry":str(reg),**_base()})
     # registry + generated placeholders
     atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'skill_propagation_events.json',{"skill_propagation_events":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json',{"receipts":[receipt],**_base()}); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()}); atomic_write_json(reg/'proofbundles.json',{"proofbundles":proofbundles,**_base()}); atomic_write_json(reg/'evidence_dockets.json',{"evidence_dockets":dockets,**_base()})
-    atomic_write_json(reg/'registry.json',{
+    existing_registry = _read(reg/'registry.json', {})
+    registry_contract = {
         "schema_version":"agialpha.skill_network.registry.v1",
         "latest_run_id":run_id,
         "runs_path":"runs/",
@@ -400,9 +407,10 @@ def run_network_compounding(args):
             "lineage_graph":"lineage_graph.json"
         },
         **_base()
-    })
-    existing_registry = _read(reg/'registry.json', {})
-    atomic_write_json(reg/'registry.json', _next_registry_index(existing_registry, run_id))
+    }
+    if isinstance(existing_registry, dict):
+        registry_contract["runs"] = existing_registry.get("runs", [])
+    atomic_write_json(reg/'registry.json', _next_registry_index({**existing_registry, **registry_contract}, run_id))
     run_registry_dir = reg / "runs" / run_id
     atomic_write_json(run_registry_dir / "00_manifest.json", {"run_id": run_id, **_base()})
     atomic_write_json(run_registry_dir / "01_agent_registry.json", {"agents": agents, **_base()})


### PR DESCRIPTION
### Motivation
- Make the Network Skill Vault contract explicit and machine-readable by emitting a top-level append-only `registry.json` that points generated-data/UI at the run index and named registry files.

### Description
- Updated `agialpha_engine/network_compounding.py` to write `agialpha_skill_network_registry/registry.json` with `schema_version`, `latest_run_id`, `runs_path`, `append_only`, and a `records` map listing the registry files before updating the rolling `registry.json` index.
- The change preserves existing per-run mirror artifacts and run-level index emission while adding a deterministic registry pointer for downstream build/data and UI consumers.

### Testing
- Ran the Engine-003 workflow commands which completed without error: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` (succeeded).  
- Ran replay, falsification, validate, and build-data commands which completed: `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data` (all succeeded).  
- Ran the test suite with `python -m unittest discover -s tests` (467 tests executed, all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17716389c483338f2451a122fb8eea)