### PR TITLE
Add deterministic registry/manifest/skill package helpers, import/vault logic, and unit tests

### DIFF
--- a/agialpha_engine/agent_registry.py
+++ b/agialpha_engine/agent_registry.py
@@ -1,13 +1,52 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Iterable
+
 from .context import BOUNDARIES
+
+DEFAULT_AGENT_ROLES = ("Reviewer Agent", "Validator Agent", "Operator Agent")
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    })
     return rec
 
-__doc__ = "Agent registry helpers for network-compounding runs."
+
+def stable_agent_id(role: str, seed: int) -> str:
+    digest = hashlib.sha256(f"{seed}:{role}".encode("utf-8")).hexdigest()[:10]
+    slug = role.lower().replace(" ", "-")
+    return f"agent-{slug}-{digest}"
+
+
+def build_agent_registry(target_agents: int, seed: int, roles: Iterable[str] | None = None) -> list[dict]:
+    """Build deterministic sandbox-only target agents for skill import tests."""
+    selected_roles = list(roles or DEFAULT_AGENT_ROLES)
+    if target_agents > len(selected_roles):
+        selected_roles.extend(f"Auxiliary Agent {idx}" for idx in range(len(selected_roles) + 1, target_agents + 1))
+    agents: list[dict] = []
+    for idx, role in enumerate(selected_roles[:target_agents], start=1):
+        agent = base_record({
+            "schema_version": "agialpha.engine.agent_registry.v1",
+            "agent_id": stable_agent_id(role, seed),
+            "agent_name": role,
+            "role": role,
+            "ordinal": idx,
+            "sandbox_only": True,
+            "production_activation_allowed": False,
+            "network_calls_allowed": False,
+        })
+        agent["agent_hash"] = hashlib.sha256(json.dumps(agent, sort_keys=True).encode("utf-8")).hexdigest()
+        agents.append(agent)
+    return agents
+
+
+__all__ = ["DEFAULT_AGENT_ROLES", "base_record", "stable_agent_id", "build_agent_registry"]

--- a/agialpha_engine/agent_skill_manifest.py
+++ b/agialpha_engine/agent_skill_manifest.py
@@ -1,13 +1,59 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Iterable
+
 from .context import BOUNDARIES
+from .skill_package import evidence_id_present
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    })
     return rec
 
-__doc__ = "Agent skill manifest helpers."
+
+def build_manifest(agent: dict, native_skills: Iterable[str] | None = None) -> dict:
+    manifest = base_record({
+        "schema_version": "agialpha.engine.agent_skill_manifest.v1",
+        "agent_id": agent["agent_id"],
+        "agent_name": agent.get("agent_name", agent.get("role", "unknown")),
+        "native_skills": sorted(set(native_skills or [])),
+        "imported_skills": [],
+        "quarantined_skills": [],
+        "rejected_skills": [],
+        "skill_import_policy": {
+            "default_activation_status": "inactive",
+            "outside_sandbox_activation_requires_human_review": True,
+            "proofbundle_required": True,
+            "evidence_docket_required": True,
+            "regulated_domain_import_policy": "quarantine",
+        },
+        "activation_status": "sandbox_importable_only",
+        "production_activation_allowed": False,
+    })
+    manifest["manifest_hash"] = hashlib.sha256(json.dumps(manifest, sort_keys=True).encode("utf-8")).hexdigest()
+    return manifest
+
+
+def import_skill_into_manifest(manifest: dict, skill_id: str, *, proofbundle_id: str | None, evidence_docket_id: str | None) -> dict:
+    updated = json.loads(json.dumps(manifest, sort_keys=True))
+    if not evidence_id_present(proofbundle_id) or not evidence_id_present(evidence_docket_id):
+        updated.setdefault("quarantined_skills", []).append(skill_id)
+    elif skill_id not in updated.setdefault("imported_skills", []):
+        updated["imported_skills"].append(skill_id)
+        updated["imported_skills"].sort()
+    updated["activation_status"] = "sandbox_importable_only"
+    updated["production_activation_allowed"] = False
+    updated["manifest_hash"] = hashlib.sha256(json.dumps({k: v for k, v in updated.items() if k != "manifest_hash"}, sort_keys=True).encode("utf-8")).hexdigest()
+    return updated
+
+
+__all__ = ["base_record", "build_manifest", "import_skill_into_manifest"]

--- a/agialpha_engine/failure_learning.py
+++ b/agialpha_engine/failure_learning.py
@@ -1,16 +1,52 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 from .context import BOUNDARIES
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    })
     return rec
 
-__doc__ = "Failure learning package helpers."
 
-def build_failure_learning(job_id:str, reason:str):
-    return {"failure_learning_id":f"fl-{job_id}","source_job_id":job_id,"reason":reason,**base_record()}
+def build_failure_learning(job_id: str, reason: str, *, raw_task_result_ids: list[str] | None = None) -> dict:
+    package = base_record({
+        "schema_version": "agialpha.engine.failure_learning_package.v1",
+        "failure_learning_id": f"fl-{hashlib.sha256(job_id.encode()).hexdigest()[:12]}",
+        "source_job_id": job_id,
+        "raw_task_result_ids": raw_task_result_ids or [],
+        "reason": reason,
+        "learning_type": "failure_warning",
+        "reusable_learning": "Preserve the failure mode for future tests, quarantine, or harder validation.",
+        "activation_status": "inactive",
+        "production_activation_allowed": False,
+    })
+    package["failure_learning_hash"] = hashlib.sha256(json.dumps(package, sort_keys=True).encode("utf-8")).hexdigest()
+    return package
+
+
+def build_rejected_skill_candidate(job_id: str, reason: str, *, raw_task_result_ids: list[str] | None = None) -> dict:
+    candidate = base_record({
+        "schema_version": "agialpha.engine.rejected_skill_candidate.v1",
+        "rejected_skill_candidate_id": f"rsc-{hashlib.sha256((job_id + reason).encode()).hexdigest()[:12]}",
+        "source_job_id": job_id,
+        "raw_task_result_ids": raw_task_result_ids or [],
+        "rejected_reason": reason,
+        "quarantined": True,
+        "activation_status": "inactive",
+        "production_activation_allowed": False,
+    })
+    candidate["rejected_skill_candidate_hash"] = hashlib.sha256(json.dumps(candidate, sort_keys=True).encode("utf-8")).hexdigest()
+    return candidate
+
+
+__all__ = ["base_record", "build_failure_learning", "build_rejected_skill_candidate"]

--- a/agialpha_engine/skill_extractor.py
+++ b/agialpha_engine/skill_extractor.py
@@ -1,16 +1,38 @@
 from __future__ import annotations
 
 from .context import BOUNDARIES
+from .failure_learning import build_failure_learning, build_rejected_skill_candidate
+from .skill_package import build_skill_package
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({"human_review_required": True, "autonomous_persistence_allowed": False, "no_auto_merge": True})
     return rec
 
-__doc__ = "Deterministic skill extraction routing."
 
-def classify_job(job_index:int)->str:
-    return ["accepted","rejected","failure"][job_index%3]
+def classify_job(job_index: int) -> str:
+    return ["accepted", "rejected", "failure"][job_index % 3]
+
+
+def extract_learning_from_job(job: dict, raw_result: dict, job_index: int) -> dict:
+    """Deterministically route each job into reusable accepted/rejected/failure learning."""
+    outcome = classify_job(job_index)
+    job_id = job["job_id"]
+    raw_ids = [raw_result["task_result_id"]]
+    if outcome == "accepted" and raw_result.get("passed") is True:
+        return {"outcome": outcome, "record": build_skill_package(
+            source_job_id=job_id,
+            source_agent_id=job.get("agent_id", raw_result.get("agent_id", "source-agent")),
+            skill_type="capability_package",
+            skill_payload={"portable_capability": job.get("task_family", "local evidence repair"), "sandbox_only": True},
+            raw_task_result_ids=raw_ids,
+        )}
+    if outcome == "rejected":
+        return {"outcome": outcome, "record": build_rejected_skill_candidate(job_id, "validator margin insufficient for publication", raw_task_result_ids=raw_ids)}
+    return {"outcome": "failure", "record": build_failure_learning(job_id, raw_result.get("failure_reason") or "held for harder regression testing", raw_task_result_ids=raw_ids)}
+
+
+__all__ = ["base_record", "classify_job", "extract_learning_from_job"]

--- a/agialpha_engine/skill_import.py
+++ b/agialpha_engine/skill_import.py
@@ -1,13 +1,43 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 from .context import BOUNDARIES
+from .skill_package import evidence_id_present
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    })
     return rec
 
-__doc__ = "Skill import event helpers."
+
+def build_skill_import_event(*, skill_id: str, source_agent_id: str, target_agent_id: str, proofbundle_id: str | None, evidence_docket_id: str | None, seed: int) -> dict:
+    has_evidence = evidence_id_present(proofbundle_id) and evidence_id_present(evidence_docket_id)
+    status = "imported" if has_evidence else "quarantined_missing_evidence"
+    event = base_record({
+        "schema_version": "agialpha.engine.skill_import.v1",
+        "skill_import_id": f"import-{hashlib.sha256(f'{seed}:{skill_id}:{target_agent_id}'.encode()).hexdigest()[:12]}",
+        "skill_id": skill_id,
+        "source_agent_id": source_agent_id,
+        "target_agent_id": target_agent_id,
+        "proofbundle_id": proofbundle_id,
+        "evidence_docket_id": evidence_docket_id,
+        "import_status": status,
+        "activation_status": "inactive",
+        "allowed_import_scope": "sandbox_only",
+        "production_activation_allowed": False,
+        "poisoned_skill_quarantined": not has_evidence,
+    })
+    event["skill_import_hash"] = hashlib.sha256(json.dumps(event, sort_keys=True).encode("utf-8")).hexdigest()
+    return event
+
+
+__all__ = ["base_record", "build_skill_import_event"]

--- a/agialpha_engine/skill_package.py
+++ b/agialpha_engine/skill_package.py
@@ -1,13 +1,85 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Any
+
 from .context import BOUNDARIES
+
+SKILL_TYPES = {
+    "validator", "workflow_template", "scoring_rubric", "safety_rule", "replay_recipe",
+    "redaction_rule", "claim_boundary_rule", "token_boundary_rule", "regulated_boundary_rule",
+    "test_fixture", "operator_wrapper", "failure_warning", "capability_package",
+}
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    })
     return rec
 
-__doc__ = "Skill package creation helpers."
+
+def stable_skill_id(source_job_id: str, source_agent_id: str, skill_type: str) -> str:
+    digest = hashlib.sha256(f"{source_job_id}:{source_agent_id}:{skill_type}".encode("utf-8")).hexdigest()[:12]
+    return f"skill-{digest}"
+
+
+def evidence_id_present(value: Any) -> bool:
+    if value is None:
+        return False
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip().lower()
+    return normalized not in ("", "pending", "not_reported", "unavailable", "skipped_with_reason")
+
+
+def build_skill_package(*, source_job_id: str, source_agent_id: str, skill_type: str, skill_payload: dict[str, Any], raw_task_result_ids: list[str], proofbundle_id: str | None = "pending", evidence_docket_id: str | None = "pending") -> dict[str, Any]:
+    if skill_type not in SKILL_TYPES:
+        raise ValueError(f"unsupported skill_type: {skill_type}")
+    if not raw_task_result_ids:
+        raise ValueError("accepted skill packages require raw_task_result_ids")
+    skill_id = stable_skill_id(source_job_id, source_agent_id, skill_type)
+    package = base_record({
+        "schema_version": "agialpha.engine.skill_package.v1",
+        "skill_id": skill_id,
+        "source_job_id": source_job_id,
+        "source_agent_id": source_agent_id,
+        "skill_type": skill_type,
+        "skill_payload": skill_payload,
+        "validated_on_task_ids": list(raw_task_result_ids),
+        "raw_task_result_ids": list(raw_task_result_ids),
+        "proofbundle_id": proofbundle_id,
+        "evidence_docket_id": evidence_docket_id,
+        "replay_status": "pass" if evidence_id_present(proofbundle_id) else "pending",
+        "falsification_status": "pass" if evidence_id_present(evidence_docket_id) else "pending",
+        "risk_tier": "low",
+        "allowed_import_scope": "sandbox_only",
+        "activation_policy": "inactive_outside_sandbox_until_human_review",
+        "production_activation_allowed": False,
+    })
+    package["skill_hash"] = hashlib.sha256(json.dumps(package, sort_keys=True).encode("utf-8")).hexdigest()
+    return package
+
+
+def has_required_evidence(package: dict[str, Any]) -> bool:
+    return (
+        bool(package.get("raw_task_result_ids"))
+        and evidence_id_present(package.get("proofbundle_id"))
+        and evidence_id_present(package.get("evidence_docket_id"))
+    )
+
+
+__all__ = [
+    "SKILL_TYPES",
+    "base_record",
+    "stable_skill_id",
+    "evidence_id_present",
+    "build_skill_package",
+    "has_required_evidence",
+]

--- a/agialpha_engine/skill_vault.py
+++ b/agialpha_engine/skill_vault.py
@@ -1,13 +1,57 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Iterable
+
 from .context import BOUNDARIES
+from .skill_package import has_required_evidence
 
 
 def base_record(extra=None):
-    rec={**BOUNDARIES}
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({
+        "human_review_required": True,
+        "autonomous_persistence_allowed": False,
+        "no_auto_merge": True,
+    })
     return rec
 
-__doc__ = "Sandbox vault publication helpers."
+
+def publish_to_vault(skill_packages: Iterable[dict]) -> dict:
+    """Create an append-only vault view that refuses evidence-free accepted skills."""
+    entries = []
+    rejected = []
+    for package in skill_packages:
+        if has_required_evidence(package):
+            entry = base_record({
+                "schema_version": "agialpha.engine.network_skill_vault_entry.v1",
+                "skill_id": package["skill_id"],
+                "source_job_id": package.get("source_job_id"),
+                "source_agent_id": package.get("source_agent_id"),
+                "proofbundle_id": package.get("proofbundle_id"),
+                "evidence_docket_id": package.get("evidence_docket_id"),
+                "publication_status": "published_sandbox_importable",
+                "activation_status": "inactive",
+                "production_activation_allowed": False,
+            })
+            entry["vault_entry_hash"] = hashlib.sha256(json.dumps(entry, sort_keys=True).encode("utf-8")).hexdigest()
+            entries.append(entry)
+        else:
+            rejected.append(base_record({
+                "skill_id": package.get("skill_id", "unknown"),
+                "publication_status": "rejected_missing_proofbundle_or_evidence_docket",
+                "quarantined": True,
+            }))
+    return base_record({
+        "schema_version": "agialpha.engine.network_skill_vault.v1",
+        "skill_packages": entries,
+        "rejected_publications": rejected,
+        "append_only": True,
+        "skills_published_to_vault": len(entries),
+    })
+
+
+__all__ = ["base_record", "publish_to_vault"]

--- a/tests/test_agialpha_skill_extractor.py
+++ b/tests/test_agialpha_skill_extractor.py
@@ -1,2 +1,18 @@
-def test_placeholder():
-    assert True
+import unittest
+
+from agialpha_engine.skill_extractor import classify_job, extract_learning_from_job
+
+
+class TestSkillExtractor(unittest.TestCase):
+    def test_skill_extractor_routes_every_job_to_reusable_learning(self):
+        job = {"job_id": "job-001", "agent_id": "agent-source", "task_family": "ProofBundle completeness repair"}
+        raw = {"task_result_id": "raw-001", "agent_id": "agent-source", "passed": True, "failure_reason": ""}
+        accepted = extract_learning_from_job(job, raw, 0)
+        rejected = extract_learning_from_job({**job, "job_id": "job-002"}, {**raw, "task_result_id": "raw-002"}, 1)
+        failure = extract_learning_from_job({**job, "job_id": "job-003"}, {**raw, "task_result_id": "raw-003", "passed": False, "failure_reason": "validator failed"}, 2)
+
+        self.assertEqual([classify_job(i) for i in range(3)], ["accepted", "rejected", "failure"])
+        self.assertEqual(accepted["record"]["raw_task_result_ids"], ["raw-001"])
+        self.assertIs(rejected["record"]["quarantined"], True)
+        self.assertEqual(failure["record"]["learning_type"], "failure_warning")
+        self.assertTrue(all(item["record"]["autonomous_persistence_allowed"] is False for item in [accepted, rejected, failure]))

--- a/tests/test_agialpha_skill_import.py
+++ b/tests/test_agialpha_skill_import.py
@@ -1,2 +1,40 @@
-def test_placeholder():
-    assert True
+import unittest
+
+from agialpha_engine.agent_registry import build_agent_registry
+from agialpha_engine.agent_skill_manifest import build_manifest, import_skill_into_manifest
+from agialpha_engine.skill_import import build_skill_import_event
+
+
+class TestSkillImport(unittest.TestCase):
+    def test_skill_import_event_and_manifest_keep_skill_inactive(self):
+        agent = build_agent_registry(1, seed=123)[0]
+        event = build_skill_import_event(
+            skill_id="skill-001", source_agent_id="agent-source", target_agent_id=agent["agent_id"],
+            proofbundle_id="pb-001", evidence_docket_id="ed-001", seed=123
+        )
+        manifest = import_skill_into_manifest(build_manifest(agent), event["skill_id"], proofbundle_id=event["proofbundle_id"], evidence_docket_id=event["evidence_docket_id"])
+        self.assertEqual(event["import_status"], "imported")
+        self.assertEqual(event["activation_status"], "inactive")
+        self.assertIs(event["production_activation_allowed"], False)
+        self.assertEqual(manifest["imported_skills"], ["skill-001"])
+        self.assertIs(manifest["production_activation_allowed"], False)
+
+    def test_skill_import_without_evidence_is_quarantined(self):
+        event = build_skill_import_event(skill_id="skill-002", source_agent_id="agent-source", target_agent_id="agent-target", proofbundle_id="", evidence_docket_id="", seed=1)
+        self.assertEqual(event["import_status"], "quarantined_missing_evidence")
+        self.assertIs(event["poisoned_skill_quarantined"], True)
+
+    def test_pending_evidence_ids_are_quarantined_not_imported(self):
+        agent = build_agent_registry(1, seed=123)[0]
+        event = build_skill_import_event(
+            skill_id="skill-003", source_agent_id="agent-source", target_agent_id=agent["agent_id"],
+            proofbundle_id="pending", evidence_docket_id="pending", seed=123
+        )
+        manifest = import_skill_into_manifest(
+            build_manifest(agent), event["skill_id"],
+            proofbundle_id=event["proofbundle_id"], evidence_docket_id=event["evidence_docket_id"]
+        )
+        self.assertEqual(event["import_status"], "quarantined_missing_evidence")
+        self.assertIs(event["poisoned_skill_quarantined"], True)
+        self.assertEqual(manifest["imported_skills"], [])
+        self.assertEqual(manifest["quarantined_skills"], ["skill-003"])

--- a/tests/test_agialpha_skill_package_schema.py
+++ b/tests/test_agialpha_skill_package_schema.py
@@ -1,2 +1,43 @@
-def test_placeholder():
-    assert True
+import unittest
+
+from agialpha_engine.skill_package import SKILL_TYPES, build_skill_package, evidence_id_present, has_required_evidence
+
+
+class TestSkillPackageSchema(unittest.TestCase):
+    def test_skill_package_requires_raw_logs_and_allowed_type(self):
+        self.assertIn("capability_package", SKILL_TYPES)
+        package = build_skill_package(
+            source_job_id="job-001",
+            source_agent_id="agent-source",
+            skill_type="capability_package",
+            skill_payload={"sandbox_only": True},
+            raw_task_result_ids=["raw-001"],
+            proofbundle_id="pb-001",
+            evidence_docket_id="ed-001",
+        )
+        self.assertEqual(package["schema_version"], "agialpha.engine.skill_package.v1")
+        self.assertEqual(package["allowed_import_scope"], "sandbox_only")
+        self.assertEqual(package["activation_policy"], "inactive_outside_sandbox_until_human_review")
+        self.assertIs(has_required_evidence(package), True)
+
+        with self.assertRaises(ValueError):
+            build_skill_package(source_job_id="job", source_agent_id="agent", skill_type="bad", skill_payload={}, raw_task_result_ids=["raw"])
+        with self.assertRaises(ValueError):
+            build_skill_package(source_job_id="job", source_agent_id="agent", skill_type="capability_package", skill_payload={}, raw_task_result_ids=[])
+
+    def test_blank_none_and_pending_evidence_ids_do_not_mark_replay_or_falsification_pass(self):
+        for missing_value in (None, "", "  ", "pending", "not_reported", "unavailable"):
+            with self.subTest(missing_value=missing_value):
+                package = build_skill_package(
+                    source_job_id="job-missing",
+                    source_agent_id="agent-source",
+                    skill_type="capability_package",
+                    skill_payload={"sandbox_only": True},
+                    raw_task_result_ids=["raw-missing"],
+                    proofbundle_id=missing_value,
+                    evidence_docket_id=missing_value,
+                )
+                self.assertFalse(evidence_id_present(missing_value))
+                self.assertEqual(package["replay_status"], "pending")
+                self.assertEqual(package["falsification_status"], "pending")
+                self.assertFalse(has_required_evidence(package))

--- a/tests/test_agialpha_skill_vault.py
+++ b/tests/test_agialpha_skill_vault.py
@@ -1,2 +1,21 @@
-def test_placeholder():
-    assert True
+import unittest
+
+from agialpha_engine.skill_package import build_skill_package
+from agialpha_engine.skill_vault import publish_to_vault
+
+
+class TestSkillVault(unittest.TestCase):
+    def test_skill_vault_publishes_only_proof_bound_skills(self):
+        good = build_skill_package(
+            source_job_id="job-001", source_agent_id="agent-source", skill_type="capability_package",
+            skill_payload={"sandbox_only": True}, raw_task_result_ids=["raw-001"], proofbundle_id="pb-001", evidence_docket_id="ed-001"
+        )
+        missing = build_skill_package(
+            source_job_id="job-002", source_agent_id="agent-source", skill_type="capability_package",
+            skill_payload={"sandbox_only": True}, raw_task_result_ids=["raw-002"]
+        )
+        vault = publish_to_vault([good, missing])
+        self.assertIs(vault["append_only"], True)
+        self.assertEqual(vault["skills_published_to_vault"], 1)
+        self.assertEqual(vault["skill_packages"][0]["activation_status"], "inactive")
+        self.assertEqual(vault["rejected_publications"][0]["publication_status"], "rejected_missing_proofbundle_or_evidence_docket")


### PR DESCRIPTION
### Motivation

- Provide deterministic helper utilities for creating agent registries, skill packages, import events, manifests, failure learning, and vault publications to support sandbox-only testing and deterministic skill import workflows.

### Description

- Consolidate and normalize `base_record` behavior and introduce deterministic ID generation and content hashing across `agent_registry`, `agent_skill_manifest`, `skill_package`, `skill_import`, `skill_vault`, `failure_learning`, and `skill_extractor` modules.
- Add `build_agent_registry`, `stable_agent_id`, `build_manifest`, and `import_skill_into_manifest` to manage agent metadata and skill import manifests with quarantine rules based on evidence presence.
- Implement `SKILL_TYPES`, `stable_skill_id`, `evidence_id_present`, `build_skill_package`, and `has_required_evidence` to validate skill payloads, require raw task logs, and compute package hashes.
- Add `build_skill_import_event`, `publish_to_vault`, `build_failure_learning`, `build_rejected_skill_candidate`, and `extract_learning_from_job` to model import events, append-only vault views that reject evidence-free packages, and deterministic routing of job outcomes.

### Testing

- Added unit tests `tests/test_agialpha_skill_extractor.py`, `tests/test_agialpha_skill_import.py`, `tests/test_agialpha_skill_package_schema.py`, and `tests/test_agialpha_skill_vault.py` which exercise routing, manifest/import behavior, skill package validation, evidence handling, and vault publication rules.
- Ran the test suite with `pytest -q` and all added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184784cc2883339b2af1df68f832ec)