### PR TITLE
Keep skill audit statuses pending by default

### DIFF
--- a/agialpha_engine/skill_package.py
+++ b/agialpha_engine/skill_package.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import Any
+
 from .context import BOUNDARIES
+
+_PENDING_STATUS = "pending"
+_ALLOWED_AUDIT_STATUSES = {_PENDING_STATUS, "pass", "fail"}
+_PLACEHOLDER_EVIDENCE_IDS = {"", "pending", "placeholder", "none", "null", "n/a", "na"}
 
 
 def base_record(extra=None):
@@ -9,5 +16,81 @@ def base_record(extra=None):
         rec.update(extra)
     rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
     return rec
+
+
+def evidence_id_present(evidence_id: str | None) -> bool:
+    """Return whether an evidence identifier is a non-placeholder value."""
+    if evidence_id is None:
+        return False
+    return str(evidence_id).strip().lower() not in _PLACEHOLDER_EVIDENCE_IDS
+
+
+def _list(value: Iterable[str] | None) -> list[str]:
+    if value is None:
+        return []
+    return list(value)
+
+
+def _audit_status(name: str, value: str) -> str:
+    if value not in _ALLOWED_AUDIT_STATUSES:
+        allowed = ", ".join(sorted(_ALLOWED_AUDIT_STATUSES))
+        raise ValueError(f"{name} must be one of: {allowed}")
+    return value
+
+
+def create_skill_package(
+    *,
+    skill_id: str,
+    source_job_id: str,
+    source_agent_id: str,
+    skill_type: str = "workflow_template",
+    skill_payload: dict[str, Any] | None = None,
+    validated_on_task_ids: Iterable[str] | None = None,
+    raw_task_result_ids: Iterable[str] | None = None,
+    proofbundle_id: str | None = None,
+    evidence_docket_id: str | None = None,
+    replay_status: str = _PENDING_STATUS,
+    falsification_status: str = _PENDING_STATUS,
+    risk_tier: str = "low",
+    allowed_import_scope: str = "sandbox_only",
+    activation_policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a skill package without converting evidence IDs into audit pass states.
+
+    ProofBundle and Evidence Docket identifiers only prove that artifacts were assigned.
+    Replay and falsification must remain pending until the dedicated audit workflows
+    write explicit pass/fail statuses.
+    """
+    if activation_policy is None:
+        activation_policy = {
+            "auto_activate_allowed": False,
+            "human_review_required": True,
+            "validator_required": True,
+            "replay_required": True,
+            "falsification_required": True,
+        }
+
+    return base_record(
+        {
+            "schema_version": "agialpha.skill_package.v1",
+            "skill_id": skill_id,
+            "source_job_id": source_job_id,
+            "source_agent_id": source_agent_id,
+            "skill_type": skill_type,
+            "skill_payload": skill_payload or {},
+            "validated_on_task_ids": _list(validated_on_task_ids),
+            "raw_task_result_ids": _list(raw_task_result_ids),
+            "proofbundle_id": proofbundle_id,
+            "proofbundle_id_present": evidence_id_present(proofbundle_id),
+            "evidence_docket_id": evidence_docket_id,
+            "evidence_docket_id_present": evidence_id_present(evidence_docket_id),
+            "replay_status": _audit_status("replay_status", replay_status),
+            "falsification_status": _audit_status("falsification_status", falsification_status),
+            "risk_tier": risk_tier,
+            "allowed_import_scope": allowed_import_scope,
+            "activation_policy": activation_policy,
+        }
+    )
+
 
 __doc__ = "Skill package creation helpers."

--- a/tests/test_agialpha_skill_package_schema.py
+++ b/tests/test_agialpha_skill_package_schema.py
@@ -1,2 +1,56 @@
-def test_placeholder():
-    assert True
+import unittest
+
+from agialpha_engine.skill_package import create_skill_package, evidence_id_present
+
+
+class SkillPackageSchemaTests(unittest.TestCase):
+    def test_create_skill_package_keeps_audit_status_pending_with_real_evidence_ids(self):
+        package = create_skill_package(
+            skill_id="skill-1",
+            source_job_id="job-1",
+            source_agent_id="agent-1",
+            skill_payload={"template": "safe_replay_template"},
+            validated_on_task_ids=["job-1"],
+            raw_task_result_ids=["raw-job-1"],
+            proofbundle_id="pb-skill-1",
+            evidence_docket_id="ed-skill-1",
+        )
+
+        self.assertIs(package["proofbundle_id_present"], True)
+        self.assertIs(package["evidence_docket_id_present"], True)
+        self.assertEqual(package["replay_status"], "pending")
+        self.assertEqual(package["falsification_status"], "pending")
+        self.assertIs(package["activation_policy"]["replay_required"], True)
+        self.assertIs(package["activation_policy"]["falsification_required"], True)
+
+    def test_create_skill_package_allows_explicit_post_audit_pass_statuses(self):
+        package = create_skill_package(
+            skill_id="skill-1",
+            source_job_id="job-1",
+            source_agent_id="agent-1",
+            proofbundle_id="pb-skill-1",
+            evidence_docket_id="ed-skill-1",
+            replay_status="pass",
+            falsification_status="pass",
+        )
+
+        self.assertEqual(package["replay_status"], "pass")
+        self.assertEqual(package["falsification_status"], "pass")
+
+    def test_create_skill_package_rejects_unknown_audit_status(self):
+        with self.assertRaisesRegex(ValueError, "replay_status must be one of"):
+            create_skill_package(
+                skill_id="skill-1",
+                source_job_id="job-1",
+                source_agent_id="agent-1",
+                replay_status="passed_by_id",
+            )
+
+    def test_evidence_id_present_treats_placeholders_as_absent(self):
+        self.assertIs(evidence_id_present("pb-skill-1"), True)
+        self.assertIs(evidence_id_present(" pending "), False)
+        self.assertIs(evidence_id_present(None), False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent proofbundle/evidence docket identifiers from implying replay/falsification audit passes before the dedicated audit workflows run, avoiding premature promotion of skill packages.

### Description
- Introduce `create_skill_package(...)` to build skill package records that keep `replay_status` and `falsification_status` separate from evidence ID presence and default them to `pending`.
- Add helper functions and constants: `evidence_id_present`, `_list`, `_audit_status`, `_PENDING_STATUS`, `_ALLOWED_AUDIT_STATUSES`, and `_PLACEHOLDER_EVIDENCE_IDS` to validate statuses and treat placeholder IDs as absent.
- Record boolean presence fields `proofbundle_id_present` and `evidence_docket_id_present` instead of inferring audit success from ID strings.
- Add unit tests (`tests/test_agialpha_skill_package_schema.py`) covering default pending behavior, explicit post-audit `pass` acceptance, invalid status rejection, and placeholder ID handling.

### Testing
- Ran `pytest -q tests/test_agialpha_skill_package_schema.py` and the new test module passed (4 tests, all passed).
- Ran `python -m unittest discover -s tests` for the full suite and observed successful completion (all tests passed; full test run OK).
- Executed SecureRails checks (`scripts/secure_rails_*.py`) to validate policy hooks; claim-boundary and no-auto-merge checks passed while some scripts exited non-zero due to expected missing CLI arguments, which is documented and expected for those usage-only scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185929619c8333b2dc2509f6b389d6)