### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/README_AGIALPHA_SKILL_NETWORK.md
+++ b/README_AGIALPHA_SKILL_NETWORK.md
@@ -12,6 +12,8 @@ One Agent learns, all Agents level up.
 
 “Instant sharing” means **sandboxed registration and importability** through the Network Skill Vault. It does **not** mean production activation without validators and human review.
 
+Instant sharing means sandboxed registration and importability. Production activation requires validators and human review. Exponential compounding is a strategic target unless the exponential claim gate passes.
+
 ## Canonical doctrine
 
 No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.
@@ -25,6 +27,8 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 ## What this does not claim
 
 This experiment does **not** claim achieved AGI, ASI, superintelligence, empirical SOTA, official benchmark victory, certification, legal exemption, safe autonomy, token value, token appreciation, or investment return.
+
+$AGIALPHA remains utility-only. Work Vault records are synthetic local utility-accounting receipts only; no wallet, custody, payment, trading, KYC/AML, token price, token value, ROI, yield, or investment return is implemented or claimed.
 
 ## Quickstart
 

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -893,7 +893,7 @@ def validate_network_compounding(args):
 
 def build_network_data(args):
     reg=Path(args.registry); out=Path(args.out); out.mkdir(parents=True,exist_ok=True)
-    mp={'latest':'latest.json','agents':'agents.json','skill_packages':'skill_packages.json','rejected_skill_candidates':'rejected_skill_candidates.json','failure_learning_packages':'failure_learning_packages.json','skill_imports':'skill_imports.json','skill_propagation_events':'skill_propagation_events.json','network_skill_metrics':'network_skill_metrics.json','claim_gate':'claim_gate_decisions.json','lineage_graph':'lineage_graph.json','work_vault_receipts':'work_vault_receipts.json','proofbundles':'proofbundles.json','evidence_dockets':'evidence_dockets.json','summary':'network_skill_metrics.json'}
+    mp={'latest':'latest.json','agents':'agents.json','agent_skill_manifests':'agent_skill_manifests.json','skill_packages':'skill_packages.json','rejected_skill_candidates':'rejected_skill_candidates.json','failure_learning_packages':'failure_learning_packages.json','skill_imports':'skill_imports.json','skill_propagation_events':'skill_propagation_events.json','network_skill_metrics':'network_skill_metrics.json','claim_gate':'claim_gate_decisions.json','lineage_graph':'lineage_graph.json','work_vault_receipts':'work_vault_receipts.json','proofbundles':'proofbundles.json','evidence_dockets':'evidence_dockets.json','summary':'network_skill_metrics.json'}
     for k,v in mp.items(): atomic_write_json(out/f'{k}.json',_read(reg/v,{"status":"not_reported",**_base()}))
     # alias
     atomic_write_json(out/'b6_vs_b5.json',_read(reg/'network_skill_metrics.json',{}))

--- a/agialpha_evidence_hub/build.py
+++ b/agialpha_evidence_hub/build.py
@@ -18,15 +18,174 @@ def _load(base):
         wfs = catalog_workflows
     return runs,exps,wfs
 
+
+def _json_file(path: Path, default):
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return default
+
+
+def _as_list(doc, *keys):
+    if isinstance(doc, list):
+        return doc
+    if not isinstance(doc, dict):
+        return []
+    for key in keys:
+        value = doc.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _metric_card(label, value):
+    return f"<div class='metric'><div class='label'>{html.escape(label)}</div><div class='value'>{html.escape(str(value))}</div></div>"
+
+
+def _render_skill_network_page(repo_root: Path, out_root: Path):
+    data_root = repo_root / 'docs' / '_generated' / 'agialpha-skill-network'
+    metrics = _json_file(data_root / 'network_skill_metrics.json', {})
+    claim_gate = _json_file(data_root / 'claim_gate.json', {})
+    skills_doc = _json_file(data_root / 'skill_packages.json', {})
+    agents_doc = _json_file(data_root / 'agents.json', {})
+    imports_doc = _json_file(data_root / 'skill_imports.json', {})
+    manifests_doc = _json_file(data_root / 'agents.json', {})
+    failures_doc = _json_file(data_root / 'failure_learning_packages.json', {})
+    rejected_doc = _json_file(data_root / 'rejected_skill_candidates.json', {})
+    receipts_doc = _json_file(data_root / 'work_vault_receipts.json', {})
+    b6_doc = _json_file(data_root / 'b6_vs_b5.json', {})
+    lineage_doc = _json_file(data_root / 'lineage_graph.json', {})
+
+    skills = _as_list(skills_doc, 'skill_packages', 'accepted_skill_packages')
+    agents = _as_list(agents_doc, 'agents')
+    imports = _as_list(imports_doc, 'skill_imports', 'skill_import_events')
+    manifests = _as_list(_json_file(data_root / 'agent_skill_manifests.json', {}), 'manifests', 'agent_skill_manifests')
+    failures = _as_list(failures_doc, 'failure_learning_packages')
+    rejected = _as_list(rejected_doc, 'rejected_skill_candidates')
+    receipts = _as_list(receipts_doc, 'receipts')
+    skill_imports_by_skill = {}
+    for item in imports:
+        skill_imports_by_skill.setdefault(item.get('skill_id', 'unknown'), []).append(item.get('target_agent_id', 'not_reported'))
+
+    status_fields = [
+        ('jobs run', metrics.get('jobs_run', 'not_reported')),
+        ('accepted Skill Packages', metrics.get('accepted_skill_packages', 'not_reported')),
+        ('rejected Skill Candidates', metrics.get('rejected_skill_candidates', 'not_reported')),
+        ('Failure Learning Packages', metrics.get('failure_learning_packages', 'not_reported')),
+        ('skills published', metrics.get('skills_published_to_vault', 'not_reported')),
+        ('agents registered', metrics.get('agents_registered', len(agents) if agents else 'not_reported')),
+        ('skill imports', metrics.get('skill_import_events', len(imports) if imports else 'not_reported')),
+        ('target agents improved', metrics.get('target_agents_improved_on_heldout', 'not_reported')),
+        ('held-out tasks evaluated', metrics.get('heldout_tasks_evaluated', 'not_reported')),
+        ('B6 beats B5', metrics.get('B6_shared_skill_beats_B5_no_shared_skill', 'not_reported')),
+        ('NetworkSkillPropagationLift', metrics.get('network_skill_propagation_lift', 'not_reported')),
+        ('CompoundingExponentProxy', metrics.get('compounding_exponent_proxy', 'not_supported')),
+        ('exponential compounding supported', metrics.get('exponential_compounding_supported', False)),
+        ('replay status', metrics.get('replay_pass_rate', 'not_reported')),
+        ('falsification status', metrics.get('falsification_pass', 'not_reported')),
+        ('hard safety counters', metrics.get('critical_safety_incidents', 'not_reported')),
+    ]
+    cards = ''.join(_metric_card(label, value) for label, value in status_fields)
+
+    skill_rows = ''.join(
+        '<tr>'
+        f"<td>{html.escape(str(skill.get('skill_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(skill.get('source_job_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(skill.get('source_agent_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(skill.get('skill_type', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(skill.get('proofbundle_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(skill.get('evidence_docket_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(', '.join(str(x) for x in skill_imports_by_skill.get(skill.get('skill_id'), [])) or 'not_reported')}</td>"
+        f"<td>{html.escape(str(metrics.get('network_skill_propagation_lift', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(skill.get('allowed_import_scope', 'sandbox_only')))}</td>"
+        f"<td>{html.escape(str(skill.get('human_review_status', 'pending')))}</td>"
+        '</tr>'
+        for skill in skills
+    ) or "<tr><td colspan='10'>No accepted Skill Packages reported.</td></tr>"
+
+    manifest_rows = ''.join(
+        '<tr>'
+        f"<td>{html.escape(str(m.get('agent_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(m.get('agent_role', 'not_reported')))}</td>"
+        f"<td>{html.escape(', '.join(str(x) for x in m.get('imported_skills', [])) or 'none')}</td>"
+        f"<td>{html.escape(str(m.get('skill_import_policy', {}).get('auto_activate_allowed', False)))}</td>"
+        '</tr>'
+        for m in manifests
+    ) or "<tr><td colspan='4'>No Agent Skill Manifests reported.</td></tr>"
+
+    failure_items = ''.join(f"<li>{html.escape(str(f.get('failure_learning_id', f.get('candidate_id', 'not_reported'))))}: {html.escape(str(f.get('failure_summary', f.get('rejection_reason', 'preserved for review'))))}</li>" for f in failures + rejected)
+    receipt_rows = ''.join(
+        '<tr>'
+        f"<td>{html.escape(str(r.get('receipt_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(r.get('skill_id', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(r.get('wallet_used', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(r.get('custody_used', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(r.get('payment_executed', 'not_reported')))}</td>"
+        f"<td>{html.escape(str(r.get('token_price_used', 'not_reported')))}</td>"
+        '</tr>'
+        for r in receipts
+    ) or "<tr><td colspan='6'>No utility receipts reported.</td></tr>"
+
+    raw_links = ''.join(
+        f"<li><a href='/agialpha-first-real-loop/data/agialpha-skill-network/{name}'>{name}</a></li>"
+        for name in [
+            'latest.json','agents.json','skill_packages.json','rejected_skill_candidates.json',
+            'failure_learning_packages.json','skill_imports.json','network_skill_metrics.json',
+            'b6_vs_b5.json','claim_gate.json','lineage_graph.json','work_vault_receipts.json','summary.json'
+        ]
+    )
+    proof_chain = 'AGI Job → Skill Package / Rejected Skill / Failure Learning → ProofBundle → Evidence Docket → Network Skill Vault → Agent Skill Manifest → Held-out Reuse Test → B6 vs B5 → NetworkSkillPropagationLift → Claim Gate → Human Review'
+    workflow_buttons = """
+      <p class='actions'>
+        <a class='btn' href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/agialpha-engine-003-network-compounding.yml'>Run Network Compounding</a>
+        <a class='btn secondary' href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/agialpha-engine-003-network-replay.yml'>Replay</a>
+        <a class='btn secondary' href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/agialpha-engine-003-network-falsification-audit.yml'>Falsification Audit</a>
+        <a class='btn secondary' href='https://github.com/MontrealAI/agialpha-first-real-loop/actions/workflows/agialpha-engine-003-network-claim-gate.yml'>Claim Gate</a>
+      </p>
+    """
+    body = f"""
+      <p class='kicker'>AGI ALPHA Skill Network</p>
+      <h2>Operating thesis</h2>
+      <p><strong>Every Job makes an AI Agent smarter.</strong><br />Every new skill can be instantly shared across the network.<br />One Agent learns, all Agents level up.</p>
+      <p class='warning'>Instant sharing means sandboxed registration/importability. Production activation requires validators and human review. Exponential compounding is a strategic target unless the exponential claim gate passes.</p>
+      <h2>Proof chain</h2><p>{html.escape(proof_chain)}</p>
+      <h2>Claim gate</h2><p><strong>Claim gate status:</strong> {html.escape(str(claim_gate.get('claim_gate_status', 'not_supported')))}</p><p>{html.escape(str(claim_gate.get('supported_wording', 'Networked skill compounding claim not yet supported.')))}</p>
+      <h2>Exponential compounding status</h2><p>{html.escape(str(claim_gate.get('exponential_compounding_status', 'Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.')))}</p>
+      <h2>Status cards</h2><div class='metric-grid'>{cards}</div>
+      <h2>Skill propagation graph</h2><pre>{html.escape(json.dumps(lineage_doc.get('edges', []), indent=2))}</pre>
+      <h2>Skill table</h2><table><tr><th>skill</th><th>source job</th><th>source agent</th><th>skill type</th><th>ProofBundle</th><th>Evidence Docket</th><th>imported by</th><th>held-out lift</th><th>activation status</th><th>human review</th></tr>{skill_rows}</table>
+      <h2>Agent Skill Manifest panel</h2><table><tr><th>agent</th><th>role</th><th>imported skills</th><th>auto activate</th></tr>{manifest_rows}</table>
+      <h2>B6 vs B5 comparison</h2><pre>{html.escape(json.dumps({'D_no_shared_skill': b6_doc.get('D_no_shared_skill', metrics.get('D_no_shared_skill_B5', 'not_reported')), 'D_shared_skill_network': b6_doc.get('D_shared_skill_network', metrics.get('D_shared_skill_network_B6', 'not_reported')), 'NetworkSkillPropagationLift': b6_doc.get('NetworkSkillPropagationLift', metrics.get('network_skill_propagation_lift', 'not_reported'))}, indent=2))}</pre>
+      <h2>Failure learning panel</h2><ul>{failure_items or '<li>No rejected or failure-learning packages reported.</li>'}</ul>
+      <h2>Work Vault / $AGIALPHA utility accounting</h2><p>$AGIALPHA remains utility-only accounting.</p><table><tr><th>receipt</th><th>skill</th><th>wallet</th><th>custody</th><th>payment</th><th>token price</th></tr>{receipt_rows}</table>
+      <h2>Safety and boundaries</h2><p><strong>claim boundary:</strong> {html.escape(str(metrics.get('claim_boundary', CLAIM_BOUNDARY)))}</p><p><strong>token boundary:</strong> {html.escape(str(metrics.get('token_boundary', 'Utility-only; no wallet, custody, payment, trading, KYC/AML, token price, token value, token appreciation, ROI, yield, or investment return.')))}</p><p><strong>regulated boundary:</strong> {html.escape(str(metrics.get('regulated_boundary', 'Regulated-domain decisioning is blocked and requires documentation-only human review.')))}</p>
+      <h2>Workflows</h2>{workflow_buttons}
+      <h2>Raw JSON links</h2><p>Raw JSON is secondary to the proof-chain UI.</p><ul>{raw_links}</ul><p><a href='/agialpha-first-real-loop/'>Back to hub</a></p>
+    """
+    page_html = page('AGI ALPHA Skill Network', body)
+    route = out_root / 'agialpha-skill-network'
+    route.mkdir(parents=True, exist_ok=True)
+    route.joinpath('index.html').write_text(page_html, encoding='utf-8')
+    exp_route = out_root / 'experiments' / 'agialpha-engine-003'
+    exp_route.mkdir(parents=True, exist_ok=True)
+    exp_route.joinpath('index.html').write_text(page_html, encoding='utf-8')
+    data_out = out_root / 'data' / 'agialpha-skill-network'
+    data_out.mkdir(parents=True, exist_ok=True)
+    if data_root.exists():
+        for src in data_root.glob('*.json'):
+            (data_out / src.name).write_text(src.read_text(encoding='utf-8'), encoding='utf-8')
+
 def build_site(registry='evidence_registry', out='_site'):
     runs,exps,wfs=_load(registry)
     repo_root = Path(__file__).resolve().parent.parent
     o=Path(out); o.mkdir(parents=True,exist_ok=True)
-    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets','strong-rsi','secure-rails']:
+    for d in ['data','experiments','workflows','runs','artifacts','legacy','external-review','safety','launchpad','falsification','assets','strong-rsi','secure-rails','agialpha-skill-network']:
         (o/d).mkdir(exist_ok=True)
 
     o.joinpath('.nojekyll').write_text('')
-    o.joinpath('assets/app.css').write_text(':root{--bg:#f7f9fc;--panel:#fff;--panel-2:#f1f5f9;--text:#0f172a;--muted:#475569;--line:#dbe3ef;--accent:#2563eb;--success:#059669;--warning:#d97706;--danger:#dc2626;--info:#0284c7;--shadow:0 8px 30px rgba(15,23,42,.07);--radius:16px}*{box-sizing:border-box}body{margin:0;font-family:Inter,Arial,sans-serif;background:var(--bg);color:var(--text)}.topnav{display:flex;justify-content:space-between;align-items:center;padding:1rem 2rem;border-bottom:1px solid var(--line);background:var(--panel)}.topnav nav a,.brand{margin-right:1rem;color:var(--accent);text-decoration:none}.container{max-width:1200px;margin:2rem auto;padding:0 1rem}.panel{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem 1.25rem}.hero h1{margin-top:0}table{width:100%;border-collapse:collapse}td,th{border:1px solid var(--line);padding:.45rem;text-align:left}.footer{padding:1rem 2rem;color:var(--muted)}')
+    o.joinpath('assets/app.css').write_text(':root{--bg:#f7f9fc;--panel:#fff;--panel-2:#f1f5f9;--text:#0f172a;--muted:#475569;--line:#dbe3ef;--accent:#2563eb;--success:#059669;--warning:#d97706;--danger:#dc2626;--info:#0284c7;--shadow:0 8px 30px rgba(15,23,42,.07);--radius:16px}*{box-sizing:border-box}body{margin:0;font-family:Inter,Arial,sans-serif;background:var(--bg);color:var(--text)}.topnav{display:flex;justify-content:space-between;align-items:center;padding:1rem 2rem;border-bottom:1px solid var(--line);background:var(--panel)}.topnav nav a,.brand{margin-right:1rem;color:var(--accent);text-decoration:none}.container{max-width:1200px;margin:2rem auto;padding:0 1rem}.panel{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem 1.25rem}.hero h1{margin-top:0}table{width:100%;border-collapse:collapse}td,th{border:1px solid var(--line);padding:.45rem;text-align:left}.footer{padding:1rem 2rem;color:var(--muted)}.metric-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;margin:1rem 0}.metric{background:var(--panel-2);border:1px solid var(--line);border-radius:12px;padding:.8rem}.metric .label{text-transform:uppercase;color:var(--muted);font-size:.72rem;letter-spacing:.06em}.metric .value{font-size:1.35rem;font-weight:800;margin-top:.25rem}.warning{border-left:4px solid var(--warning);background:#fff7ed;padding:.75rem 1rem}.actions{display:flex;flex-wrap:wrap;gap:.75rem}.btn{display:inline-block;background:var(--accent);color:#fff;text-decoration:none;border-radius:999px;padding:.65rem .9rem;font-weight:700}.btn.secondary{background:#fff;color:var(--accent);border:1px solid var(--line)}pre{white-space:pre-wrap;background:#0f172a;color:#e2e8f0;padding:1rem;border-radius:12px;overflow:auto}')
     o.joinpath('assets/app.js').write_text('document.querySelectorAll("[data-copy]").forEach(b=>b.onclick=()=>navigator.clipboard?.writeText(b.dataset.copy));')
 
     by_exp={}
@@ -64,6 +223,9 @@ def build_site(registry='evidence_registry', out='_site'):
             extra = "<p><a href='/agialpha-first-real-loop/strong-rsi/'>Open Strong RSI control room</a></p>"
         ep.joinpath('index.html').write_text(page(exp,f"<div>claim boundary: {html.escape(latest.get('claim_boundary','missing'))}</div><div>latest status: {latest.get('status')}</div><div>safety incidents: {latest.get('metrics',{}).get('safety_incidents','not_reported')}</div><table>{run_rows}</table>{extra}<a href='/agialpha-first-real-loop/'>Back to hub</a>"))
     custom_experiment_source = repo_root / 'experiments' / 'rsi-governor-001' / 'index.html'
+
+    _render_skill_network_page(repo_root, o)
+
     if custom_experiment_source.exists() and 'rsi-governor-001' not in by_exp:
         exp_dir = o / 'experiments' / 'rsi-governor-001'
         exp_dir.mkdir(parents=True, exist_ok=True)

--- a/agialpha_evidence_hub/render.py
+++ b/agialpha_evidence_hub/render.py
@@ -19,6 +19,7 @@ def page(title,body):
       <a href="/agialpha-first-real-loop/runs/">Runs</a>
       <a href="/agialpha-first-real-loop/launchpad/">Launchpad</a>
       <a href="/agialpha-first-real-loop/strong-rsi/">Strong RSI</a>
+      <a href="/agialpha-first-real-loop/agialpha-skill-network/">Skill Network</a>
     </nav>
   </header>
   <main class="container">

--- a/docs/_generated/agialpha-skill-network/agent_skill_manifests.json
+++ b/docs/_generated/agialpha-skill-network/agent_skill_manifests.json
@@ -1,0 +1,107 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "human_review_required": true,
+  "manifests": [
+    {
+      "agent_id": "agent-1",
+      "agent_role": "Reviewer Agent",
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "human_review_required": true,
+      "imported_skills": [],
+      "last_updated": "seed-123",
+      "native_skills": [],
+      "no_auto_merge": true,
+      "quarantined_skills": [],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejected_skills": [],
+      "schema_version": "agialpha.agent_skill_manifest.v1",
+      "skill_import_policy": {
+        "auto_activate_allowed": false,
+        "auto_import_allowed": true,
+        "human_review_required_for_activation": true,
+        "regulated_boundary_block_required": true
+      },
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "agent_id": "agent-2",
+      "agent_role": "Validator Agent",
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "human_review_required": true,
+      "imported_skills": [
+        "skill-1",
+        "skill-4"
+      ],
+      "last_updated": "seed-123",
+      "native_skills": [],
+      "no_auto_merge": true,
+      "quarantined_skills": [],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejected_skills": [],
+      "schema_version": "agialpha.agent_skill_manifest.v1",
+      "skill_import_policy": {
+        "auto_activate_allowed": false,
+        "auto_import_allowed": true,
+        "human_review_required_for_activation": true,
+        "regulated_boundary_block_required": true
+      },
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "agent_id": "agent-3",
+      "agent_role": "Operator Agent",
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "human_review_required": true,
+      "imported_skills": [
+        "skill-1",
+        "skill-4"
+      ],
+      "last_updated": "seed-123",
+      "native_skills": [],
+      "no_auto_merge": true,
+      "quarantined_skills": [],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejected_skills": [],
+      "schema_version": "agialpha.agent_skill_manifest.v1",
+      "skill_import_policy": {
+        "auto_activate_allowed": false,
+        "auto_import_allowed": true,
+        "human_review_required_for_activation": true,
+        "regulated_boundary_block_required": true
+      },
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "agent_id": "agent-4",
+      "agent_role": "Documentation Agent",
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "human_review_required": true,
+      "imported_skills": [
+        "skill-1",
+        "skill-4"
+      ],
+      "last_updated": "seed-123",
+      "native_skills": [],
+      "no_auto_merge": true,
+      "quarantined_skills": [],
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "rejected_skills": [],
+      "schema_version": "agialpha.agent_skill_manifest.v1",
+      "skill_import_policy": {
+        "auto_activate_allowed": false,
+        "auto_import_allowed": true,
+        "human_review_required_for_activation": true,
+        "regulated_boundary_block_required": true
+      },
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    }
+  ],
+  "no_auto_merge": true,
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/tests/test_agialpha_skill_network_docs.py
+++ b/tests/test_agialpha_skill_network_docs.py
@@ -1,2 +1,46 @@
-def test_placeholder():
-    assert True
+import unittest
+from pathlib import Path
+
+REQUIRED_DOCS = [
+    "README_AGIALPHA_SKILL_NETWORK.md",
+    "docs/agialpha-skill-network/README.md",
+    "docs/agialpha-skill-network/every-job-teaches.md",
+    "docs/agialpha-skill-network/network-skill-vault.md",
+    "docs/agialpha-skill-network/agent-skill-manifests.md",
+    "docs/agialpha-skill-network/skill-packages.md",
+    "docs/agialpha-skill-network/failure-learning-packages.md",
+    "docs/agialpha-skill-network/b6-vs-b5-shared-skill.md",
+    "docs/agialpha-skill-network/network-skill-propagation-lift.md",
+    "docs/agialpha-skill-network/compounding-claim-gate.md",
+    "docs/agialpha-skill-network/exponential-compounding-boundary.md",
+    "docs/agialpha-skill-network/work-vaults-and-agialpha.md",
+    "docs/agialpha-skill-network/replay-and-falsification.md",
+    "docs/agialpha-skill-network/human-review-gate.md",
+    "docs/agialpha-skill-network/claim-boundary.md",
+    "docs/agialpha-skill-network/token-boundary.md",
+    "docs/agialpha-skill-network/regulated-boundary.md",
+    "docs/agialpha-skill-network/operator-guide.md",
+    "docs/agialpha-skill-network/reviewer-guide.md",
+]
+
+
+class TestAgialphaSkillNetworkDocs(unittest.TestCase):
+    def test_skill_network_docs_exist_and_state_boundaries(self):
+        for doc in REQUIRED_DOCS:
+            self.assertTrue(Path(doc).exists(), doc)
+
+        readme = Path("README_AGIALPHA_SKILL_NETWORK.md").read_text(encoding="utf-8")
+        self.assertIn("Every Job makes an AI Agent smarter", readme)
+        self.assertIn("Instant sharing means sandboxed registration", readme)
+        self.assertIn("Production activation requires validators and human review", readme)
+        self.assertIn("Exponential compounding is a strategic target", readme)
+        self.assertIn("$AGIALPHA remains utility-only", readme)
+
+    def test_workflow_catalog_mentions_engine_003(self):
+        catalog = Path("docs/WORKFLOW_CATALOG.md").read_text(encoding="utf-8")
+        self.assertIn("AGI ALPHA Engine 003 / Networked Skill Compounding", catalog)
+        self.assertIn("agialpha-engine-003-network-compounding.yml", catalog)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agialpha_skill_network_public_page.py
+++ b/tests/test_agialpha_skill_network_public_page.py
@@ -1,2 +1,50 @@
-def test_placeholder():
-    assert True
+import unittest
+from pathlib import Path
+
+from agialpha_evidence_hub.build import build_site
+
+
+class TestAgialphaSkillNetworkPublicPage(unittest.TestCase):
+    def test_skill_network_public_page_is_polished_and_route_backed(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "site"
+            build_site("evidence_registry", out)
+
+            skill_page = out / "agialpha-skill-network" / "index.html"
+            experiment_page = out / "experiments" / "agialpha-engine-003" / "index.html"
+            raw_data = out / "data" / "agialpha-skill-network" / "network_skill_metrics.json"
+
+            self.assertTrue(skill_page.exists())
+            self.assertTrue(experiment_page.exists())
+            self.assertTrue(raw_data.exists())
+
+            html = skill_page.read_text(encoding="utf-8")
+            for expected in [
+                "AGI ALPHA Skill Network",
+                "Every Job makes an AI Agent smarter",
+                "Every new skill can be instantly shared across the network",
+                "One Agent learns, all Agents level up",
+                "Instant sharing means sandboxed registration/importability",
+                "Proof chain",
+                "Claim gate",
+                "Exponential compounding is a strategic target",
+                "Skill propagation graph",
+                "Work Vault / $AGIALPHA utility accounting",
+                "Raw JSON is secondary",
+                "No Evidence Docket, no empirical SOTA claim",
+            ]:
+                self.assertIn(expected, html)
+
+    def test_mission_control_nav_links_skill_network(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "site"
+            build_site("evidence_registry", out)
+            index = (out / "index.html").read_text(encoding="utf-8")
+            self.assertIn("Skill Network", index)
+            self.assertIn("/agialpha-first-real-loop/agialpha-skill-network/", index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agialpha_skill_network_workflows.py
+++ b/tests/test_agialpha_skill_network_workflows.py
@@ -1,2 +1,37 @@
-def test_placeholder():
-    assert True
+import unittest
+from pathlib import Path
+
+WORKFLOWS = [
+    ".github/workflows/agialpha-engine-003-network-compounding.yml",
+    ".github/workflows/agialpha-engine-003-network-replay.yml",
+    ".github/workflows/agialpha-engine-003-network-falsification-audit.yml",
+    ".github/workflows/agialpha-engine-003-network-claim-gate.yml",
+]
+
+
+class TestAgialphaSkillNetworkWorkflows(unittest.TestCase):
+    def test_engine_003_workflows_have_safe_permissions_and_no_pages_deploy(self):
+        for workflow in WORKFLOWS:
+            text = Path(workflow).read_text(encoding="utf-8")
+            self.assertIn("workflow_dispatch", text)
+            self.assertIn("schedule:", text)
+            self.assertIn("contents: read", text)
+            self.assertIn("actions: read", text)
+            self.assertNotIn("pages: write", text)
+            self.assertNotIn("deploy-pages", text)
+            self.assertNotIn("auto-merge", text.lower())
+
+    def test_lifecycle_workflow_runs_full_network_chain(self):
+        text = Path(".github/workflows/agialpha-engine-003-network-compounding.yml").read_text(encoding="utf-8")
+        for command in [
+            "network-compounding-run",
+            "network-compounding-replay",
+            "network-compounding-falsification-audit",
+            "network-compounding-validate",
+            "network-compounding-build-data",
+        ]:
+            self.assertIn(command, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make the ENGINE-003 skill-network thesis operational, measurable, falsifiable, and visible in the public Evidence Mission Control UI while preserving safety boundaries and human-review-only promotion.
- Close implementation gaps in empty/placeholder modules and remove hard-coded evaluation artefacts so metrics are computed strictly from raw task results and replay/falsification artifacts.
- Provide a deterministic local loop that converts every AGI Job into reusable learning artifacts (Accepted Skill Package, Rejected Skill Candidate, or Failure Learning Package) and publishes evidence into an append-only Network Skill Vault.

### Description
- Implemented non-empty engine modules: `agialpha_engine/metrics.py`, `sandbox.py`, `proofbundle.py`, `validate.py` plus helpers for agent manifests, skill packages, skill vault, imports, propagation, failure-learning, work-vault receipts, settlement, redaction, and human-review gating; extended `network_compounding.py`, `network_skill_metrics.py`, `network_claim_gate.py`, and `render.py` to produce run artifacts, proofbundles, evidence dockets, and registry mirrors.
- Removed hard-coded evaluation flags and constants (no fixed B6 win, no fixed `vRCI`, no fixed lift) and instead compute `NetworkSkillPropagationLift` and related metrics deterministically from raw held-out logs and replay/falsification artifacts.
- Implemented a safe local sandbox that copies fixtures, blocks network/external targets, records before/after hashes, stdout/stderr hashes, deterministic seed, and never mutates repo sources; proofbundle builders now include required hashes and completeness checks for ENGINE-003 artifacts.
- Added CLI commands and public-data generators for the lifecycle: `network-compounding-run/replay/falsification-audit/validate/build-data` and integrated a rendered public page at `/agialpha-skill-network/` plus an experiments page `/experiments/agialpha-engine-003/`, and added workflow entries that run the local loop but never auto-deploy Pages (publisher-only flow preserved).

### Testing
- Ran full test suites: `python -m unittest discover -s tests` and `pytest -q`, both completed successfully (all tests passed); unit and semantic tests for ENGINE-003 were added and exercised.
- Executed the ENGINE-003 lifecycle commands end-to-end locally: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123`, then ran `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and verified generated docs in `docs/_generated/agialpha-skill-network` and Evidence Mission Control build via `python -m agialpha_evidence_hub build`; these flows completed and replay/falsification/validate gates behaved as designed.
- Ran SecureRails script checks used by workflows and they passed locally; proofbundle, replay, falsification, claim-gate recomputation and registry synchronization checks were validated by automated tests and replay steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190b2fc9bc83339238256ff78a5aaa)