### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ SecureRails → Enterprise Pilot → ProofBundles → Evidence Dockets → Work 
 | Home | Evidence Mission Control overview | `/` | `evidence-mission-control-publisher.yml` | partial |
 | SecureRails | governance and policy guardrails | `/secure-rails/` | `secure-rails-compliance-guard.yml` | complete |
 | Enterprise Pilot | pilot evidence and dockets | `/enterprise-pilot/` | `agialpha-enterprise-pilot-001.yml` | partial |
+| Skill Network | ENGINE-003 networked skill compounding evidence | `/agialpha-skill-network/` | `agialpha-engine-003-network-compounding.yml` | local bounded |
 
 ## How to run from GitHub UI
 Actions → choose workflow from [docs/WORKFLOW_LAUNCHPAD.md](docs/WORKFLOW_LAUNCHPAD.md) → **Run workflow**.

--- a/agialpha_engine/agent_registry.py
+++ b/agialpha_engine/agent_registry.py
@@ -1,13 +1,53 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Any, Iterable
+
 from .context import BOUNDARIES
 
+DEFAULT_AGENT_ROLES = ("Reviewer Agent", "Validator Agent", "Operator Agent")
 
-def base_record(extra=None):
-    rec={**BOUNDARIES}
+
+def base_record(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({"human_review_required": True, "autonomous_persistence_allowed": False, "no_auto_merge": True})
     return rec
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def make_agent(agent_id: str, role: str, *, native_skill_ids: Iterable[str] | None = None) -> dict[str, Any]:
+    """Create a deterministic Engine-003 agent registry entry."""
+    if not agent_id or not role:
+        raise ValueError("agent_id and role are required")
+    payload = {
+        "schema_version": "agialpha.agent_registry.agent.v1",
+        "agent_id": agent_id,
+        "role": role,
+        "native_skill_ids": sorted(str(s) for s in (native_skill_ids or []) if str(s)),
+        "network_imports_allowed": True,
+        "production_activation_allowed": False,
+        "imported_skills_inactive_outside_sandbox": True,
+        **base_record(),
+    }
+    payload["agent_hash"] = _hash(payload)
+    return payload
+
+
+def register_default_agents(target_agents: int = 3) -> list[dict[str, Any]]:
+    """Register at least Reviewer, Validator, and Operator target agents deterministically."""
+    count = max(3, int(target_agents))
+    roles = list(DEFAULT_AGENT_ROLES) + [f"Sandbox Target Agent {i}" for i in range(4, count + 1)]
+    return [make_agent(f"target-agent-{i}", role) for i, role in enumerate(roles[:count], start=1)]
+
+
+def make_agent_registry(agents: list[dict[str, Any]]) -> dict[str, Any]:
+    return base_record({"schema_version": "agialpha.agent_registry.v1", "agents": agents, "agent_count": len(agents)})
+
 
 __doc__ = "Agent registry helpers for network-compounding runs."

--- a/agialpha_engine/agent_skill_manifest.py
+++ b/agialpha_engine/agent_skill_manifest.py
@@ -1,13 +1,63 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Any, Iterable
+
 from .context import BOUNDARIES
 
 
-def base_record(extra=None):
-    rec={**BOUNDARIES}
+def base_record(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({"human_review_required": True, "autonomous_persistence_allowed": False, "no_auto_merge": True})
     return rec
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def create_agent_skill_manifest(
+    agent_id: str,
+    *,
+    native_skills: Iterable[str] | None = None,
+    imported_skills: Iterable[str] | None = None,
+    quarantined_skills: Iterable[str] | None = None,
+    rejected_skills: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Create a manifest with imported skills sandbox-inactive by default."""
+    if not agent_id:
+        raise ValueError("agent_id is required")
+    manifest = {
+        "schema_version": "agialpha.agent_skill_manifest.v1",
+        "agent_id": agent_id,
+        "native_skills": sorted(str(s) for s in (native_skills or []) if str(s)),
+        "imported_skills": sorted(str(s) for s in (imported_skills or []) if str(s)),
+        "quarantined_skills": sorted(str(s) for s in (quarantined_skills or []) if str(s)),
+        "rejected_skills": sorted(str(s) for s in (rejected_skills or []) if str(s)),
+        "activation_status": "sandbox_registered_inactive_outside_sandbox",
+        "production_activation_allowed": False,
+        "human_review_status": "pending",
+        **base_record(),
+    }
+    manifest["manifest_hash"] = _hash(manifest)
+    return manifest
+
+
+def add_imported_skill(manifest: dict[str, Any], skill_id: str) -> dict[str, Any]:
+    if not skill_id:
+        raise ValueError("skill_id is required")
+    imported = set(str(s) for s in manifest.get("imported_skills", []) if str(s))
+    imported.add(skill_id)
+    return create_agent_skill_manifest(
+        str(manifest.get("agent_id", "")),
+        native_skills=manifest.get("native_skills", []),
+        imported_skills=imported,
+        quarantined_skills=manifest.get("quarantined_skills", []),
+        rejected_skills=manifest.get("rejected_skills", []),
+    )
+
 
 __doc__ = "Agent skill manifest helpers."

--- a/agialpha_engine/failure_learning.py
+++ b/agialpha_engine/failure_learning.py
@@ -1,16 +1,51 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Any, Iterable
+
 from .context import BOUNDARIES
 
 
-def base_record(extra=None):
-    rec={**BOUNDARIES}
+def base_record(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({"human_review_required": True, "autonomous_persistence_allowed": False, "no_auto_merge": True})
     return rec
 
-__doc__ = "Failure learning package helpers."
 
-def build_failure_learning(job_id:str, reason:str):
-    return {"failure_learning_id":f"fl-{job_id}","source_job_id":job_id,"reason":reason,**base_record()}
+def _hash(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def build_failure_learning(
+    job_id: str,
+    reason: str,
+    *,
+    source_agent_id: str = "agent-1",
+    raw_task_result_ids: Iterable[str] | None = None,
+    failure_category: str = "validator_or_replay_learning",
+) -> dict[str, Any]:
+    """Preserve reusable learning for a job that should not become an active skill."""
+    if not job_id or not reason:
+        raise ValueError("job_id and reason are required")
+    ids = list(raw_task_result_ids or [f"raw-{job_id}"])
+    package = {
+        "schema_version": "agialpha.failure_learning_package.v1",
+        "failure_learning_id": f"fl-{job_id}",
+        "source_job_id": job_id,
+        "source_agent_id": source_agent_id,
+        "failure_category": failure_category,
+        "failure_summary": reason,
+        "reason": reason,
+        "raw_task_result_ids": ids,
+        "reuse_policy": "test_harder_before_activation",
+        "activation_status": "not_active_failure_learning_only",
+        **base_record(),
+    }
+    package["failure_learning_hash"] = _hash(package)
+    return package
+
+
+__doc__ = "Failure learning package helpers."

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -799,9 +799,16 @@ def validate_network_compounding(args):
     rejected=_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[])
     failures=_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[])
     active_imports=[imp for imp in imports if imp.get('import_status') in {'imported', 'imported_inactive_outside_sandbox'}]
-    inactive_outside_sandbox=[imp for imp in active_imports if imp.get('activation_status')=='inactive']
-    if len(inactive_outside_sandbox)!=len(active_imports):
-        raise SystemExit('network-compounding-validate failed: imported skills must remain inactive outside sandbox by default')
+    unsafe_imports=[]
+    for imp in active_imports:
+        if imp.get('activation_status') != 'inactive':
+            unsafe_imports.append(f"{imp.get('import_id', 'unknown')}: activation_status must be inactive")
+        if imp.get('active_outside_sandbox') is not False:
+            unsafe_imports.append(f"{imp.get('import_id', 'unknown')}: active_outside_sandbox must be false")
+        if imp.get('production_activation_allowed') is not False:
+            unsafe_imports.append(f"{imp.get('import_id', 'unknown')}: production_activation_allowed must be false")
+    if unsafe_imports:
+        raise SystemExit(f"network-compounding-validate failed: imported skills must remain inactive outside sandbox by default ({unsafe_imports})")
     imported_skill_ids={imp.get('skill_id') for imp in active_imports if imp.get('skill_id')}
     manifest_import_agent_ids=set()
     for manifest in manifests:

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -356,10 +356,10 @@ def run_network_compounding(args):
     out=Path(args.out); reg=Path(args.registry); out.mkdir(parents=True,exist_ok=True); reg.mkdir(parents=True,exist_ok=True)
     run_id=out.name
     jobs=[]; raw=[]; accepted=[]; rejected=[]; failure=[]; sandbox_records=[]
-    agents=[{"agent_id":f"agent-{i+1}","agent_role":ROLES[i%len(ROLES)],**_base()} for i in range(max(args.target_agents+1,4))]
+    agents=[{"agent_id":f"agent-{i+1}","agent_role":ROLES[i%len(ROLES)],"role":ROLES[i%len(ROLES)],**_base()} for i in range(max(args.target_agents+1,4))]
     manifests=[]
     for a in agents:
-        manifests.append({"schema_version":"agialpha.agent_skill_manifest.v1","agent_id":a['agent_id'],"agent_role":a['agent_role'],"native_skills":[],"imported_skills":[],"quarantined_skills":[],"rejected_skills":[],"skill_import_policy":{"auto_import_allowed":True,"auto_activate_allowed":False,"human_review_required_for_activation":True,"regulated_boundary_block_required":True},"last_updated":f"seed-{args.seed}",**_base()})
+        manifests.append({"schema_version":"agialpha.agent_skill_manifest.v1","agent_id":a['agent_id'],"agent_role":a['agent_role'],"native_skills":[],"imported_skills":[],"quarantined_skills":[],"rejected_skills":[],"activation_status":"sandbox_registered_inactive_outside_sandbox","production_activation_allowed":False,"human_review_status":"pending","skill_import_policy":{"auto_import_allowed":True,"auto_activate_allowed":False,"human_review_required_for_activation":True,"regulated_boundary_block_required":True},"last_updated":f"seed-{args.seed}",**_base()})
     for i in range(args.jobs):
         jid=f"job-{i+1}"; aid=agents[0]["agent_id"]
         score=0.5 + i*0.03 + (rng.random()*0.02)
@@ -422,7 +422,7 @@ def run_network_compounding(args):
     manifest_by_agent={m['agent_id']:m for m in manifests}
     for imported_skill in accepted:
         for t in target_agents:
-            imports.append({"schema_version":"agialpha.skill_import.v1","import_id":f"import-{imported_skill['skill_id']}-{t}","skill_id":imported_skill['skill_id'],"source_agent_id":imported_skill['source_agent_id'],"target_agent_id":t,"import_status":"imported","activation_status":"inactive","reason":"imported_for_sandbox_validation","validators_required":["validator-pass"],"heldout_tests_required":["B6_vs_B5"],**_base()})
+            imports.append({"schema_version":"agialpha.skill_import.v1","import_id":f"import-{imported_skill['skill_id']}-{t}","skill_id":imported_skill['skill_id'],"source_agent_id":imported_skill['source_agent_id'],"target_agent_id":t,"import_status":"imported_inactive_outside_sandbox","activation_status":"inactive","active_outside_sandbox":False,"production_activation_allowed":False,"proofbundle_id":imported_skill["proofbundle_id"],"evidence_docket_id":imported_skill["evidence_docket_id"],"reason":"imported_for_sandbox_validation","validators_required":["validator-pass"],"heldout_tests_required":["B6_vs_B5"],**_base()})
             manifest=manifest_by_agent.get(t)
             if manifest is not None:
                 manifest.setdefault('imported_skills',[])
@@ -798,7 +798,7 @@ def validate_network_compounding(args):
     metrics=_read(run/'07_metrics/network_skill_metrics.json',{})
     rejected=_read(run/'03_skill_extraction/rejected_skill_candidates.json',{}).get('rejected_skill_candidates',[])
     failures=_read(run/'03_skill_extraction/failure_learning_packages.json',{}).get('failure_learning_packages',[])
-    active_imports=[imp for imp in imports if imp.get('import_status')=='imported']
+    active_imports=[imp for imp in imports if imp.get('import_status') in {'imported', 'imported_inactive_outside_sandbox'}]
     inactive_outside_sandbox=[imp for imp in active_imports if imp.get('activation_status')=='inactive']
     if len(inactive_outside_sandbox)!=len(active_imports):
         raise SystemExit('network-compounding-validate failed: imported skills must remain inactive outside sandbox by default')

--- a/agialpha_engine/skill_import.py
+++ b/agialpha_engine/skill_import.py
@@ -1,13 +1,44 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Any
+
 from .context import BOUNDARIES
 
 
-def base_record(extra=None):
-    rec={**BOUNDARIES}
+def base_record(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({"human_review_required": True, "autonomous_persistence_allowed": False, "no_auto_merge": True})
     return rec
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def create_skill_import_event(import_id: str, skill_package: dict[str, Any], target_agent_id: str) -> dict[str, Any]:
+    """Record a sandbox-only import, quarantining incomplete skill evidence."""
+    skill_id = skill_package.get("skill_id")
+    has_evidence = bool(skill_package.get("proofbundle_id") and skill_package.get("evidence_docket_id") and skill_package.get("raw_task_result_ids"))
+    status = "imported_inactive_outside_sandbox" if has_evidence else "quarantined_missing_evidence"
+    event = {
+        "schema_version": "agialpha.skill_import.v1",
+        "import_id": import_id,
+        "skill_id": skill_id,
+        "target_agent_id": target_agent_id,
+        "import_status": status,
+        "active_outside_sandbox": False,
+        "production_activation_allowed": False,
+        "quarantine_reason": "" if has_evidence else "missing ProofBundle, Evidence Docket, or raw task result ids",
+        "proofbundle_id": skill_package.get("proofbundle_id"),
+        "evidence_docket_id": skill_package.get("evidence_docket_id"),
+        **base_record(),
+    }
+    event["skill_import_hash"] = _hash(event)
+    return event
+
 
 __doc__ = "Skill import event helpers."

--- a/agialpha_engine/skill_import.py
+++ b/agialpha_engine/skill_import.py
@@ -24,17 +24,19 @@ def create_skill_import_event(import_id: str, skill_package: dict[str, Any], tar
     skill_id = skill_package.get("skill_id")
     has_evidence = bool(skill_package.get("proofbundle_id") and skill_package.get("evidence_docket_id") and skill_package.get("raw_task_result_ids"))
     status = "imported_inactive_outside_sandbox" if has_evidence else "quarantined_missing_evidence"
+    activation_status = "inactive" if has_evidence else "quarantined"
     event = {
         "schema_version": "agialpha.skill_import.v1",
         "import_id": import_id,
         "skill_id": skill_id,
         "target_agent_id": target_agent_id,
         "import_status": status,
+        "activation_status": activation_status,
         "active_outside_sandbox": False,
         "production_activation_allowed": False,
         "quarantine_reason": "" if has_evidence else "missing ProofBundle, Evidence Docket, or raw task result ids",
-        "proofbundle_id": skill_package.get("proofbundle_id"),
-        "evidence_docket_id": skill_package.get("evidence_docket_id"),
+        "proofbundle_id": skill_package.get("proofbundle_id") or "unavailable",
+        "evidence_docket_id": skill_package.get("evidence_docket_id") or "unavailable",
         **base_record(),
     }
     event["skill_import_hash"] = _hash(event)

--- a/agialpha_engine/skill_vault.py
+++ b/agialpha_engine/skill_vault.py
@@ -1,13 +1,53 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from typing import Any
+
 from .context import BOUNDARIES
 
 
-def base_record(extra=None):
-    rec={**BOUNDARIES}
+def base_record(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    rec = {**BOUNDARIES}
     if extra:
         rec.update(extra)
-    rec.update({"human_review_required":True,"autonomous_persistence_allowed":False,"no_auto_merge":True})
+    rec.update({"human_review_required": True, "autonomous_persistence_allowed": False, "no_auto_merge": True})
     return rec
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def publish_skill_package(skill_package: dict[str, Any]) -> dict[str, Any]:
+    """Create an append-only Network Skill Vault entry for a proof-bound skill."""
+    skill_id = skill_package.get("skill_id")
+    raw_ids = skill_package.get("raw_task_result_ids", [])
+    if not skill_id:
+        raise ValueError("skill package must include skill_id")
+    if not raw_ids:
+        raise ValueError(f"skill package {skill_id} must reference raw_task_result_ids")
+    if not skill_package.get("proofbundle_id") or not skill_package.get("evidence_docket_id"):
+        raise ValueError(f"skill package {skill_id} must include ProofBundle and Evidence Docket ids")
+    entry = {
+        "schema_version": "agialpha.network_skill_vault_entry.v1",
+        "skill_id": skill_id,
+        "skill_package_hash": _hash(skill_package),
+        "published": True,
+        "activation_status": "sandbox_registered_inactive_outside_sandbox",
+        "allowed_import_scope": skill_package.get("allowed_import_scope", "sandbox_only"),
+        "proofbundle_id": skill_package.get("proofbundle_id"),
+        "evidence_docket_id": skill_package.get("evidence_docket_id"),
+        "raw_task_result_ids": list(raw_ids),
+        **base_record(),
+    }
+    entry["vault_entry_hash"] = _hash(entry)
+    return entry
+
+
+def make_vault(skill_packages: list[dict[str, Any]]) -> dict[str, Any]:
+    entries = [publish_skill_package(skill) for skill in skill_packages]
+    return base_record({"schema_version": "agialpha.network_skill_vault.v1", "skill_packages": skill_packages, "vault_entries": entries, "skill_count": len(entries)})
+
 
 __doc__ = "Sandbox vault publication helpers."

--- a/agialpha_skill_network_registry/agent_skill_manifests.json
+++ b/agialpha_skill_network_registry/agent_skill_manifests.json
@@ -4,15 +4,18 @@
   "human_review_required": true,
   "manifests": [
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-1",
       "agent_role": "Reviewer Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [],
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -26,11 +29,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-2",
       "agent_role": "Validator Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -38,6 +43,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -51,11 +57,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-3",
       "agent_role": "Operator Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -63,6 +71,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -76,11 +85,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-4",
       "agent_role": "Documentation Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -88,6 +99,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],

--- a/agialpha_skill_network_registry/agents.json
+++ b/agialpha_skill_network_registry/agents.json
@@ -8,6 +8,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Reviewer Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -18,6 +19,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Validator Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -28,6 +30,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Operator Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -38,6 +41,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Documentation Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }
   ],

--- a/agialpha_skill_network_registry/proofbundles.json
+++ b/agialpha_skill_network_registry/proofbundles.json
@@ -6,10 +6,10 @@
   "proofbundles": [
     {
       "agent_skill_manifest_hashes": [
-        "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-        "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-        "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-        "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+        "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+        "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+        "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+        "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
       ],
       "autonomous_persistence_allowed": false,
       "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -31,7 +31,7 @@
       "missing_raw_task_result_ids": [],
       "network_skill_vault_entry_hash": "33b0689cb2320601fdc2104d4f03750c5e4da2a548a5a3852fe8fa2f71c554b0",
       "no_auto_merge": true,
-      "proofbundle_hash": "2853d49c91cd98dea97e67f9118fef582610f21b4fcdce15f6ab71b59808fe22",
+      "proofbundle_hash": "37d0b32e354ca29687c6ca0b8d5d569503c9b3653db6140200d1198b67252d80",
       "proofbundle_id": "pb-skill-1",
       "raw_evaluator_log_hashes": [
         "0c255240cf2ed179f4695355fcf755c1bc59aa6634c018477c52267f4d60e798"
@@ -50,12 +50,12 @@
       "seed": 123,
       "skill_id": "skill-1",
       "skill_import_event_hashes": [
-        "9e96c646f1e1764c32a74bb3ea9644a6dba802f9f75639786121b6df7e5bcfa1",
-        "6607c12592b621a256341e8a05569eb7f80eda40d19b0668bb941fc5c40afad3",
-        "78a948baff56f62ce650aad18d94c2e854177997509a18841eb7832f5c666127"
+        "2d2809718c44715057c89b415194b32e2c714e0413c520bde6d6e7f2e07280d7",
+        "7852dd2b54c95f5e29786ac81ff0d53e96e77bbe3394162d999d80af8c32627b",
+        "dc1198825afc2aae1490b92674a381f85f2e7bb9cc4b91b0321205bed08a0122"
       ],
       "skill_package_hash": "c09ca3a786ae1e768fca7971086b90966dfcd7bc1fdfb4285291cd22e4064f15",
-      "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+      "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
       "source_agent_id": "agent-1",
       "source_job_hash": "69f6dcda68b6e067c3202854f432c59edc40ac46d12f3e708fff48b5bb2886c1",
       "source_job_id": "job-1",
@@ -66,10 +66,10 @@
     },
     {
       "agent_skill_manifest_hashes": [
-        "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-        "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-        "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-        "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+        "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+        "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+        "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+        "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
       ],
       "autonomous_persistence_allowed": false,
       "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -91,7 +91,7 @@
       "missing_raw_task_result_ids": [],
       "network_skill_vault_entry_hash": "75797dea9ecf172ea893e5c3c58821ea35cbe1b624e9296c71b6f559ca1bb047",
       "no_auto_merge": true,
-      "proofbundle_hash": "aab1ae2a84a865d16ff6c461c13bc3cdc0f9134063097bc87b457d61ca422596",
+      "proofbundle_hash": "6745f89b519867055ef7870ea2967bda6eda260d0da3215e15289d84eeaf99dc",
       "proofbundle_id": "pb-skill-4",
       "raw_evaluator_log_hashes": [
         "d3c1ecec26b76bb614fecb6774c1ccd7e739472e9c8a2f033eda8dd0468a61ec"
@@ -110,12 +110,12 @@
       "seed": 123,
       "skill_id": "skill-4",
       "skill_import_event_hashes": [
-        "4da02c11dbf07746282916fffe70138e3bc2e6cb623fe2aec2f51fe5af8938d7",
-        "d3f98c0e4a6f02578fce32913c1665299a7e95b998a512a5b2fe627fa46acd77",
-        "df58e8b844e9d2919688572928f8ca8e1087b2fa136b3681f3ae9d645540b3ce"
+        "9fabc23780a302286321faaed0acb9b43f77c10419f465711361aece10124ca0",
+        "8e0854b6da1d359ba8a1ed3f97b4dc23051e1d29cf0076a80f471be4843c26bf",
+        "bba82449bd1a92272287d2c36ef542e7d022c0f05ea11116a6d3df2f89b8b407"
       ],
       "skill_package_hash": "d6e383f41f9af31d1b567ab4dfe10ad943ac35fc489aafe20c552e24147f379a",
-      "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+      "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
       "source_agent_id": "agent-1",
       "source_job_hash": "f1b4baffd53e1b0cf4a55d81adf0504d00fb06a98567ddc8e23a069b76b56915",
       "source_job_id": "job-4",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/01_agent_registry.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/01_agent_registry.json
@@ -8,6 +8,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Reviewer Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -18,6 +19,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Validator Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -28,6 +30,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Operator Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -38,6 +41,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Documentation Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }
   ],

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/08_agent_skill_manifests.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/08_agent_skill_manifests.json
@@ -4,15 +4,18 @@
   "human_review_required": true,
   "manifests": [
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-1",
       "agent_role": "Reviewer Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [],
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -26,11 +29,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-2",
       "agent_role": "Validator Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -38,6 +43,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -51,11 +57,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-3",
       "agent_role": "Operator Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -63,6 +71,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -76,11 +85,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-4",
       "agent_role": "Documentation Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -88,6 +99,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/09_skill_import_events.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/09_skill_import_events.json
@@ -7,15 +7,19 @@
   "skill_import_events": [
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -29,15 +33,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -51,15 +59,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -73,15 +85,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -95,15 +111,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -117,15 +137,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/14_proofbundles/index.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/14_proofbundles/index.json
@@ -6,10 +6,10 @@
   "proofbundles": [
     {
       "agent_skill_manifest_hashes": [
-        "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-        "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-        "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-        "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+        "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+        "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+        "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+        "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
       ],
       "autonomous_persistence_allowed": false,
       "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -31,7 +31,7 @@
       "missing_raw_task_result_ids": [],
       "network_skill_vault_entry_hash": "33b0689cb2320601fdc2104d4f03750c5e4da2a548a5a3852fe8fa2f71c554b0",
       "no_auto_merge": true,
-      "proofbundle_hash": "2853d49c91cd98dea97e67f9118fef582610f21b4fcdce15f6ab71b59808fe22",
+      "proofbundle_hash": "37d0b32e354ca29687c6ca0b8d5d569503c9b3653db6140200d1198b67252d80",
       "proofbundle_id": "pb-skill-1",
       "raw_evaluator_log_hashes": [
         "0c255240cf2ed179f4695355fcf755c1bc59aa6634c018477c52267f4d60e798"
@@ -50,12 +50,12 @@
       "seed": 123,
       "skill_id": "skill-1",
       "skill_import_event_hashes": [
-        "9e96c646f1e1764c32a74bb3ea9644a6dba802f9f75639786121b6df7e5bcfa1",
-        "6607c12592b621a256341e8a05569eb7f80eda40d19b0668bb941fc5c40afad3",
-        "78a948baff56f62ce650aad18d94c2e854177997509a18841eb7832f5c666127"
+        "2d2809718c44715057c89b415194b32e2c714e0413c520bde6d6e7f2e07280d7",
+        "7852dd2b54c95f5e29786ac81ff0d53e96e77bbe3394162d999d80af8c32627b",
+        "dc1198825afc2aae1490b92674a381f85f2e7bb9cc4b91b0321205bed08a0122"
       ],
       "skill_package_hash": "c09ca3a786ae1e768fca7971086b90966dfcd7bc1fdfb4285291cd22e4064f15",
-      "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+      "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
       "source_agent_id": "agent-1",
       "source_job_hash": "69f6dcda68b6e067c3202854f432c59edc40ac46d12f3e708fff48b5bb2886c1",
       "source_job_id": "job-1",
@@ -66,10 +66,10 @@
     },
     {
       "agent_skill_manifest_hashes": [
-        "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-        "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-        "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-        "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+        "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+        "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+        "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+        "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
       ],
       "autonomous_persistence_allowed": false,
       "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -91,7 +91,7 @@
       "missing_raw_task_result_ids": [],
       "network_skill_vault_entry_hash": "75797dea9ecf172ea893e5c3c58821ea35cbe1b624e9296c71b6f559ca1bb047",
       "no_auto_merge": true,
-      "proofbundle_hash": "aab1ae2a84a865d16ff6c461c13bc3cdc0f9134063097bc87b457d61ca422596",
+      "proofbundle_hash": "6745f89b519867055ef7870ea2967bda6eda260d0da3215e15289d84eeaf99dc",
       "proofbundle_id": "pb-skill-4",
       "raw_evaluator_log_hashes": [
         "d3c1ecec26b76bb614fecb6774c1ccd7e739472e9c8a2f033eda8dd0468a61ec"
@@ -110,12 +110,12 @@
       "seed": 123,
       "skill_id": "skill-4",
       "skill_import_event_hashes": [
-        "4da02c11dbf07746282916fffe70138e3bc2e6cb623fe2aec2f51fe5af8938d7",
-        "d3f98c0e4a6f02578fce32913c1665299a7e95b998a512a5b2fe627fa46acd77",
-        "df58e8b844e9d2919688572928f8ca8e1087b2fa136b3681f3ae9d645540b3ce"
+        "9fabc23780a302286321faaed0acb9b43f77c10419f465711361aece10124ca0",
+        "8e0854b6da1d359ba8a1ed3f97b4dc23051e1d29cf0076a80f471be4843c26bf",
+        "bba82449bd1a92272287d2c36ef542e7d022c0f05ea11116a6d3df2f89b8b407"
       ],
       "skill_package_hash": "d6e383f41f9af31d1b567ab4dfe10ad943ac35fc489aafe20c552e24147f379a",
-      "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+      "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
       "source_agent_id": "agent-1",
       "source_job_hash": "f1b4baffd53e1b0cf4a55d81adf0504d00fb06a98567ddc8e23a069b76b56915",
       "source_job_id": "job-4",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/14_proofbundles/pb-skill-1.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/14_proofbundles/pb-skill-1.json
@@ -1,9 +1,9 @@
 {
   "agent_skill_manifest_hashes": [
-    "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-    "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-    "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-    "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+    "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+    "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+    "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+    "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
   ],
   "autonomous_persistence_allowed": false,
   "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -25,7 +25,7 @@
   "missing_raw_task_result_ids": [],
   "network_skill_vault_entry_hash": "33b0689cb2320601fdc2104d4f03750c5e4da2a548a5a3852fe8fa2f71c554b0",
   "no_auto_merge": true,
-  "proofbundle_hash": "2853d49c91cd98dea97e67f9118fef582610f21b4fcdce15f6ab71b59808fe22",
+  "proofbundle_hash": "37d0b32e354ca29687c6ca0b8d5d569503c9b3653db6140200d1198b67252d80",
   "proofbundle_id": "pb-skill-1",
   "raw_evaluator_log_hashes": [
     "0c255240cf2ed179f4695355fcf755c1bc59aa6634c018477c52267f4d60e798"
@@ -44,12 +44,12 @@
   "seed": 123,
   "skill_id": "skill-1",
   "skill_import_event_hashes": [
-    "9e96c646f1e1764c32a74bb3ea9644a6dba802f9f75639786121b6df7e5bcfa1",
-    "6607c12592b621a256341e8a05569eb7f80eda40d19b0668bb941fc5c40afad3",
-    "78a948baff56f62ce650aad18d94c2e854177997509a18841eb7832f5c666127"
+    "2d2809718c44715057c89b415194b32e2c714e0413c520bde6d6e7f2e07280d7",
+    "7852dd2b54c95f5e29786ac81ff0d53e96e77bbe3394162d999d80af8c32627b",
+    "dc1198825afc2aae1490b92674a381f85f2e7bb9cc4b91b0321205bed08a0122"
   ],
   "skill_package_hash": "c09ca3a786ae1e768fca7971086b90966dfcd7bc1fdfb4285291cd22e4064f15",
-  "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+  "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
   "source_agent_id": "agent-1",
   "source_job_hash": "69f6dcda68b6e067c3202854f432c59edc40ac46d12f3e708fff48b5bb2886c1",
   "source_job_id": "job-1",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/14_proofbundles/pb-skill-4.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/14_proofbundles/pb-skill-4.json
@@ -1,9 +1,9 @@
 {
   "agent_skill_manifest_hashes": [
-    "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-    "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-    "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-    "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+    "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+    "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+    "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+    "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
   ],
   "autonomous_persistence_allowed": false,
   "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -25,7 +25,7 @@
   "missing_raw_task_result_ids": [],
   "network_skill_vault_entry_hash": "75797dea9ecf172ea893e5c3c58821ea35cbe1b624e9296c71b6f559ca1bb047",
   "no_auto_merge": true,
-  "proofbundle_hash": "aab1ae2a84a865d16ff6c461c13bc3cdc0f9134063097bc87b457d61ca422596",
+  "proofbundle_hash": "6745f89b519867055ef7870ea2967bda6eda260d0da3215e15289d84eeaf99dc",
   "proofbundle_id": "pb-skill-4",
   "raw_evaluator_log_hashes": [
     "d3c1ecec26b76bb614fecb6774c1ccd7e739472e9c8a2f033eda8dd0468a61ec"
@@ -44,12 +44,12 @@
   "seed": 123,
   "skill_id": "skill-4",
   "skill_import_event_hashes": [
-    "4da02c11dbf07746282916fffe70138e3bc2e6cb623fe2aec2f51fe5af8938d7",
-    "d3f98c0e4a6f02578fce32913c1665299a7e95b998a512a5b2fe627fa46acd77",
-    "df58e8b844e9d2919688572928f8ca8e1087b2fa136b3681f3ae9d645540b3ce"
+    "9fabc23780a302286321faaed0acb9b43f77c10419f465711361aece10124ca0",
+    "8e0854b6da1d359ba8a1ed3f97b4dc23051e1d29cf0076a80f471be4843c26bf",
+    "bba82449bd1a92272287d2c36ef542e7d022c0f05ea11116a6d3df2f89b8b407"
   ],
   "skill_package_hash": "d6e383f41f9af31d1b567ab4dfe10ad943ac35fc489aafe20c552e24147f379a",
-  "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+  "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
   "source_agent_id": "agent-1",
   "source_job_hash": "f1b4baffd53e1b0cf4a55d81adf0504d00fb06a98567ddc8e23a069b76b56915",
   "source_job_id": "job-4",

--- a/agialpha_skill_network_registry/skill_imports.json
+++ b/agialpha_skill_network_registry/skill_imports.json
@@ -7,15 +7,19 @@
   "skill_imports": [
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -29,15 +33,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -51,15 +59,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -73,15 +85,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -95,15 +111,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -117,15 +137,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",

--- a/agialpha_skill_network_registry/skill_propagation_events.json
+++ b/agialpha_skill_network_registry/skill_propagation_events.json
@@ -7,15 +7,19 @@
   "skill_propagation_events": [
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -29,15 +33,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -51,15 +59,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -73,15 +85,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -95,15 +111,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -117,15 +137,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",

--- a/docs/EXPERIMENT_INDEX.md
+++ b/docs/EXPERIMENT_INDEX.md
@@ -9,3 +9,7 @@ Canonical experiment families are mapped in [WORKFLOW_CATALOG](WORKFLOW_CATALOG.
 - Gauntlets
 
 - `AGI-ALPHA-ENGINE-002`: Measured Recursive Machine Labor Proof; adjacent-mandate pilot with frozen capability, held-out evaluation, treatment vs shadow control, replay, falsification, ProofBundles, and Evidence Dockets.
+
+## AGI ALPHA Engine 003
+
+`AGI-ALPHA-ENGINE-003` measures local bounded networked skill compounding: source jobs produce reusable learning, accepted Skill Packages publish to the Network Skill Vault, target agents import sandbox-inactive skills, and held-out B6 shared-skill runs are compared against B5 no-shared-skill baselines.

--- a/docs/PUBLIC_ROUTES.md
+++ b/docs/PUBLIC_ROUTES.md
@@ -1,0 +1,11 @@
+# Public Routes
+
+Evidence Mission Control is the central public publisher. Non-publisher workflows must not deploy GitHub Pages directly.
+
+| route | label | backing data | boundary |
+|---|---|---|---|
+| `/` | Evidence Mission Control | `evidence_registry/` | No Evidence Docket, no empirical SOTA claim. |
+| `/agialpha-skill-network/` | Skill Network | `docs/_generated/agialpha-skill-network/` | Local bounded network skill propagation only unless claim gates pass. |
+| `/experiments/agialpha-engine-003/` | AGI ALPHA Engine 003 | `docs/_generated/agialpha-skill-network/` | Instant sharing means sandboxed registration/importability; production activation requires validators and human review. |
+
+Footer doctrine: **No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.**

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -48,3 +48,7 @@ This guide serves three audiences: non-technical operators, technical contributo
 ## Engine 002 proof quick start
 
 For measured recursive machine labor evidence, run the Engine 002 proof commands in `README_AGIALPHA_ENGINE_PROOF.md`. A supported result requires Evidence Dockets, ProofBundles, replay, falsification, treatment/control metrics, and human review before promotion.
+
+## Engine 003 Skill Network quick start
+
+Run the ENGINE-003 network-compounding commands in `README_AGIALPHA_SKILL_NETWORK.md` to produce local bounded network skill propagation evidence. Every job must yield an accepted Skill Package, rejected candidate, or Failure Learning Package. Instant sharing means sandboxed registration/importability; production activation requires validators and human review.

--- a/docs/WORKFLOW_LAUNCHPAD.md
+++ b/docs/WORKFLOW_LAUNCHPAD.md
@@ -44,3 +44,7 @@ Use lifecycle workflow to generate local bounded recursive substrate evidence.
 - AGI ALPHA Docs and Pages UX 001: `.github/workflows/agialpha-docs-pages-ux-001.yml`
 
 - **AGI ALPHA Engine 002 / Measured Recursive Machine Labor Proof** — run `agialpha-engine-002-measured-recursive-proof.yml` for frozen-capability treatment/control proof artifacts. No direct Pages deploy or auto-merge.
+
+## Engine 003 Skill Network
+
+Run `agialpha-engine-003-network-compounding.yml` for the deterministic networked skill compounding loop, then use replay, falsification-audit, and claim-gate workflows. These workflows upload evidence artifacts only; they never auto-merge or deploy Pages directly.

--- a/docs/_generated/agialpha-skill-network/agent_skill_manifests.json
+++ b/docs/_generated/agialpha-skill-network/agent_skill_manifests.json
@@ -4,15 +4,18 @@
   "human_review_required": true,
   "manifests": [
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-1",
       "agent_role": "Reviewer Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [],
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -26,11 +29,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-2",
       "agent_role": "Validator Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -38,6 +43,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -51,11 +57,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-3",
       "agent_role": "Operator Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -63,6 +71,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],
@@ -76,11 +85,13 @@
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
+      "activation_status": "sandbox_registered_inactive_outside_sandbox",
       "agent_id": "agent-4",
       "agent_role": "Documentation Agent",
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
       "human_review_required": true,
+      "human_review_status": "pending",
       "imported_skills": [
         "skill-1",
         "skill-4"
@@ -88,6 +99,7 @@
       "last_updated": "seed-123",
       "native_skills": [],
       "no_auto_merge": true,
+      "production_activation_allowed": false,
       "quarantined_skills": [],
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "rejected_skills": [],

--- a/docs/_generated/agialpha-skill-network/agents.json
+++ b/docs/_generated/agialpha-skill-network/agents.json
@@ -8,6 +8,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Reviewer Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -18,6 +19,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Validator Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -28,6 +30,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Operator Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     },
     {
@@ -38,6 +41,7 @@
       "human_review_required": true,
       "no_auto_merge": true,
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "role": "Documentation Agent",
       "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
     }
   ],

--- a/docs/_generated/agialpha-skill-network/proofbundles.json
+++ b/docs/_generated/agialpha-skill-network/proofbundles.json
@@ -6,10 +6,10 @@
   "proofbundles": [
     {
       "agent_skill_manifest_hashes": [
-        "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-        "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-        "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-        "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+        "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+        "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+        "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+        "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
       ],
       "autonomous_persistence_allowed": false,
       "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -31,7 +31,7 @@
       "missing_raw_task_result_ids": [],
       "network_skill_vault_entry_hash": "33b0689cb2320601fdc2104d4f03750c5e4da2a548a5a3852fe8fa2f71c554b0",
       "no_auto_merge": true,
-      "proofbundle_hash": "2853d49c91cd98dea97e67f9118fef582610f21b4fcdce15f6ab71b59808fe22",
+      "proofbundle_hash": "37d0b32e354ca29687c6ca0b8d5d569503c9b3653db6140200d1198b67252d80",
       "proofbundle_id": "pb-skill-1",
       "raw_evaluator_log_hashes": [
         "0c255240cf2ed179f4695355fcf755c1bc59aa6634c018477c52267f4d60e798"
@@ -50,12 +50,12 @@
       "seed": 123,
       "skill_id": "skill-1",
       "skill_import_event_hashes": [
-        "9e96c646f1e1764c32a74bb3ea9644a6dba802f9f75639786121b6df7e5bcfa1",
-        "6607c12592b621a256341e8a05569eb7f80eda40d19b0668bb941fc5c40afad3",
-        "78a948baff56f62ce650aad18d94c2e854177997509a18841eb7832f5c666127"
+        "2d2809718c44715057c89b415194b32e2c714e0413c520bde6d6e7f2e07280d7",
+        "7852dd2b54c95f5e29786ac81ff0d53e96e77bbe3394162d999d80af8c32627b",
+        "dc1198825afc2aae1490b92674a381f85f2e7bb9cc4b91b0321205bed08a0122"
       ],
       "skill_package_hash": "c09ca3a786ae1e768fca7971086b90966dfcd7bc1fdfb4285291cd22e4064f15",
-      "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+      "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
       "source_agent_id": "agent-1",
       "source_job_hash": "69f6dcda68b6e067c3202854f432c59edc40ac46d12f3e708fff48b5bb2886c1",
       "source_job_id": "job-1",
@@ -66,10 +66,10 @@
     },
     {
       "agent_skill_manifest_hashes": [
-        "86e8f6d4e6075b47d05d0d40b6ea0da669cb6b5f08900c82f8c7e3eb6171bf5f",
-        "e4cb93c592ce20752501caa957e2081a43e408ba08b54a7465a6f24d5b6abb68",
-        "69f30199143bee2d05110630b1c179ea7e059e501d53794e3bbd16d0357075a9",
-        "b1f2bddf7b6bc1a9217c59d6f4ad3beeb052e33844219d832b2e3964a06bbbe5"
+        "b70dacccdb197f946a855b2cca82e7962f6a65b00cf8c1011064a121f54410b7",
+        "5cee32609ca71f4b7b3b9d90eb68d9fde1100555ad5923c336131b30d7093dee",
+        "398bde48276929f175ed2cb7322784a9680fb48867718dcc5f7e97ede3929cfb",
+        "e576248685d06a8699974b27b9d6c52ca35964833839ef2e70227b666bf58088"
       ],
       "autonomous_persistence_allowed": false,
       "b6_vs_b5_comparison_hash": "e7b6534065644344221effa32f67c628e0f4fafc47545238680e7abce82b7f0e",
@@ -91,7 +91,7 @@
       "missing_raw_task_result_ids": [],
       "network_skill_vault_entry_hash": "75797dea9ecf172ea893e5c3c58821ea35cbe1b624e9296c71b6f559ca1bb047",
       "no_auto_merge": true,
-      "proofbundle_hash": "aab1ae2a84a865d16ff6c461c13bc3cdc0f9134063097bc87b457d61ca422596",
+      "proofbundle_hash": "6745f89b519867055ef7870ea2967bda6eda260d0da3215e15289d84eeaf99dc",
       "proofbundle_id": "pb-skill-4",
       "raw_evaluator_log_hashes": [
         "d3c1ecec26b76bb614fecb6774c1ccd7e739472e9c8a2f033eda8dd0468a61ec"
@@ -110,12 +110,12 @@
       "seed": 123,
       "skill_id": "skill-4",
       "skill_import_event_hashes": [
-        "4da02c11dbf07746282916fffe70138e3bc2e6cb623fe2aec2f51fe5af8938d7",
-        "d3f98c0e4a6f02578fce32913c1665299a7e95b998a512a5b2fe627fa46acd77",
-        "df58e8b844e9d2919688572928f8ca8e1087b2fa136b3681f3ae9d645540b3ce"
+        "9fabc23780a302286321faaed0acb9b43f77c10419f465711361aece10124ca0",
+        "8e0854b6da1d359ba8a1ed3f97b4dc23051e1d29cf0076a80f471be4843c26bf",
+        "bba82449bd1a92272287d2c36ef542e7d022c0f05ea11116a6d3df2f89b8b407"
       ],
       "skill_package_hash": "d6e383f41f9af31d1b567ab4dfe10ad943ac35fc489aafe20c552e24147f379a",
-      "source_agent_hash": "d750edec1d55b107c5e1c9f8047d0ea01908e136f23716bfc87641e3200f7b33",
+      "source_agent_hash": "6aeaa877adb3095fb58cc9827b05d70a056ca4c556a31f33d26d60b5c6509493",
       "source_agent_id": "agent-1",
       "source_job_hash": "f1b4baffd53e1b0cf4a55d81adf0504d00fb06a98567ddc8e23a069b76b56915",
       "source_job_id": "job-4",

--- a/docs/_generated/agialpha-skill-network/skill_imports.json
+++ b/docs/_generated/agialpha-skill-network/skill_imports.json
@@ -7,15 +7,19 @@
   "skill_imports": [
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -29,15 +33,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -51,15 +59,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -73,15 +85,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -95,15 +111,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -117,15 +137,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",

--- a/docs/_generated/agialpha-skill-network/skill_propagation_events.json
+++ b/docs/_generated/agialpha-skill-network/skill_propagation_events.json
@@ -7,15 +7,19 @@
   "skill_propagation_events": [
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -29,15 +33,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -51,15 +59,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-1-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-1",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -73,15 +85,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-2",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -95,15 +111,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-3",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",
@@ -117,15 +137,19 @@
     },
     {
       "activation_status": "inactive",
+      "active_outside_sandbox": false,
       "autonomous_persistence_allowed": false,
       "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
       "heldout_tests_required": [
         "B6_vs_B5"
       ],
       "human_review_required": true,
       "import_id": "import-skill-4-agent-4",
-      "import_status": "imported",
+      "import_status": "imported_inactive_outside_sandbox",
       "no_auto_merge": true,
+      "production_activation_allowed": false,
+      "proofbundle_id": "pb-skill-4",
       "reason": "imported_for_sandbox_validation",
       "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
       "schema_version": "agialpha.skill_import.v1",

--- a/schemas/agialpha_agent_registry.schema.json
+++ b/schemas/agialpha_agent_registry.schema.json
@@ -1,1 +1,81 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}
+{
+  "$id": "https://montreal.ai/schemas/agialpha_agent_registry.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "agent_count": {
+      "minimum": 3,
+      "type": "integer"
+    },
+    "agents": {
+      "items": {
+        "properties": {
+          "agent_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "imported_skills_inactive_outside_sandbox": {
+            "const": true,
+            "type": "boolean"
+          },
+          "network_imports_allowed": {
+            "type": "boolean"
+          },
+          "production_activation_allowed": {
+            "const": false,
+            "type": "boolean"
+          },
+          "role": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_id",
+          "role"
+        ],
+        "type": "object"
+      },
+      "minItems": 3,
+      "type": "array"
+    },
+    "autonomous_persistence_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "human_review_required": {
+      "const": true,
+      "type": "boolean"
+    },
+    "no_auto_merge": {
+      "const": true,
+      "type": "boolean"
+    },
+    "regulated_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "token_boundary": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "agents",
+    "claim_boundary",
+    "token_boundary",
+    "regulated_boundary",
+    "human_review_required",
+    "autonomous_persistence_allowed",
+    "no_auto_merge"
+  ],
+  "title": "AGI ALPHA Agent Registry",
+  "type": "object"
+}

--- a/schemas/agialpha_agent_skill_manifest.schema.json
+++ b/schemas/agialpha_agent_skill_manifest.schema.json
@@ -1,1 +1,99 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}
+{
+  "$id": "https://montreal.ai/schemas/agialpha_agent_skill_manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "activation_status": {
+      "enum": [
+        "sandbox_registered_inactive_outside_sandbox",
+        "not_active_failure_learning_only",
+        "quarantined"
+      ],
+      "type": "string"
+    },
+    "agent_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "autonomous_persistence_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "human_review_required": {
+      "const": true,
+      "type": "boolean"
+    },
+    "human_review_status": {
+      "enum": [
+        "pending",
+        "accepted",
+        "needs_changes",
+        "rejected"
+      ],
+      "type": "string"
+    },
+    "imported_skills": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "native_skills": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "no_auto_merge": {
+      "const": true,
+      "type": "boolean"
+    },
+    "production_activation_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "quarantined_skills": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "regulated_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "rejected_skills": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "token_boundary": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "agent_id",
+    "native_skills",
+    "imported_skills",
+    "quarantined_skills",
+    "rejected_skills",
+    "activation_status",
+    "claim_boundary",
+    "token_boundary",
+    "regulated_boundary",
+    "human_review_required",
+    "autonomous_persistence_allowed",
+    "no_auto_merge"
+  ],
+  "title": "AGI ALPHA Agent Skill Manifest",
+  "type": "object"
+}

--- a/schemas/agialpha_network_claim_gate.schema.json
+++ b/schemas/agialpha_network_claim_gate.schema.json
@@ -1,1 +1,72 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}
+{
+  "$id": "https://montreal.ai/schemas/agialpha_network_claim_gate.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "autonomous_persistence_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "checks": {
+      "type": "object"
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "claim_gate_status": {
+      "enum": [
+        "supported_local_bounded",
+        "not_supported"
+      ],
+      "type": "string"
+    },
+    "exponential_compounding_status": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "exponential_compounding_supported": {
+      "type": "boolean"
+    },
+    "failed_reasons": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "human_review_required": {
+      "const": true,
+      "type": "boolean"
+    },
+    "no_auto_merge": {
+      "const": true,
+      "type": "boolean"
+    },
+    "regulated_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "supported_wording": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "token_boundary": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "claim_gate_status",
+    "checks",
+    "supported_wording",
+    "exponential_compounding_status",
+    "claim_boundary",
+    "token_boundary",
+    "regulated_boundary",
+    "human_review_required",
+    "autonomous_persistence_allowed",
+    "no_auto_merge"
+  ],
+  "title": "AGI ALPHA Network Compounding Claim Gate",
+  "type": "object"
+}

--- a/schemas/agialpha_network_skill_metrics.schema.json
+++ b/schemas/agialpha_network_skill_metrics.schema.json
@@ -1,1 +1,185 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}
+{
+  "$id": "https://montreal.ai/schemas/agialpha_network_skill_metrics.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "B6_shared_skill_advantage_delta": {
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "B6_shared_skill_beats_B5_no_shared_skill": {
+      "type": [
+        "boolean",
+        "string"
+      ]
+    },
+    "accepted_skill_packages": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "agent_skill_manifests_created": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "agents_registered": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "autonomous_persistence_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "capability_compounding_rate": {
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "compounding_exponent_proxy": {
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "exponential_compounding_status": {
+      "type": "string"
+    },
+    "exponential_compounding_supported": {
+      "type": "boolean"
+    },
+    "failure_learning_packages": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "fake_zero_metric_count": {
+      "const": 0,
+      "type": "integer"
+    },
+    "falsification_pass": {
+      "type": [
+        "boolean",
+        "string"
+      ]
+    },
+    "hard_coded_metric_count": {
+      "const": 0,
+      "type": "integer"
+    },
+    "heldout_tasks_evaluated": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "human_review_required": {
+      "const": true,
+      "type": "boolean"
+    },
+    "jobs_run": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "jobs_with_skill_extraction": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "network_skill_multiplier": {
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "network_skill_propagation_lift": {
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "no_auto_merge": {
+      "const": true,
+      "type": "boolean"
+    },
+    "raw_task_result_ids": {
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "regulated_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "rejected_skill_candidates": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "replay_pass_rate": {
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "semantic_tests_passed": {
+      "type": [
+        "boolean",
+        "string"
+      ]
+    },
+    "skill_import_events": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "skills_published_to_vault": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "target_agents_improved_on_heldout": {
+      "type": [
+        "integer",
+        "string"
+      ]
+    },
+    "target_agents_with_imported_skill": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "token_boundary": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "jobs_run",
+    "jobs_with_skill_extraction",
+    "accepted_skill_packages",
+    "rejected_skill_candidates",
+    "failure_learning_packages",
+    "skills_published_to_vault",
+    "agents_registered",
+    "agent_skill_manifests_created",
+    "skill_import_events",
+    "target_agents_with_imported_skill",
+    "heldout_tasks_evaluated",
+    "B6_shared_skill_beats_B5_no_shared_skill",
+    "B6_shared_skill_advantage_delta",
+    "network_skill_propagation_lift",
+    "raw_task_result_ids",
+    "hard_coded_metric_count",
+    "fake_zero_metric_count",
+    "claim_boundary",
+    "token_boundary",
+    "regulated_boundary",
+    "human_review_required",
+    "autonomous_persistence_allowed",
+    "no_auto_merge"
+  ],
+  "title": "AGI ALPHA Network Skill Metrics",
+  "type": "object"
+}

--- a/schemas/agialpha_skill_import.schema.json
+++ b/schemas/agialpha_skill_import.schema.json
@@ -85,6 +85,7 @@
     "import_status",
     "activation_status",
     "active_outside_sandbox",
+    "production_activation_allowed",
     "proofbundle_id",
     "evidence_docket_id",
     "claim_boundary",

--- a/schemas/agialpha_skill_import.schema.json
+++ b/schemas/agialpha_skill_import.schema.json
@@ -3,6 +3,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": true,
   "properties": {
+    "activation_status": {
+      "enum": [
+        "inactive",
+        "quarantined"
+      ],
+      "type": "string"
+    },
     "active_outside_sandbox": {
       "const": false,
       "type": "boolean"
@@ -76,6 +83,7 @@
     "skill_id",
     "target_agent_id",
     "import_status",
+    "activation_status",
     "active_outside_sandbox",
     "proofbundle_id",
     "evidence_docket_id",

--- a/schemas/agialpha_skill_import.schema.json
+++ b/schemas/agialpha_skill_import.schema.json
@@ -1,1 +1,91 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}
+{
+  "$id": "https://montreal.ai/schemas/agialpha_skill_import.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "active_outside_sandbox": {
+      "const": false,
+      "type": "boolean"
+    },
+    "autonomous_persistence_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "evidence_docket_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "human_review_required": {
+      "const": true,
+      "type": "boolean"
+    },
+    "import_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "import_status": {
+      "enum": [
+        "imported_inactive_outside_sandbox",
+        "quarantined_missing_evidence",
+        "regulated_boundary_blocked",
+        "documentation_only_human_review_required"
+      ],
+      "type": "string"
+    },
+    "no_auto_merge": {
+      "const": true,
+      "type": "boolean"
+    },
+    "production_activation_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "proofbundle_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "quarantine_reason": {
+      "type": "string"
+    },
+    "regulated_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "skill_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "target_agent_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "token_boundary": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "import_id",
+    "skill_id",
+    "target_agent_id",
+    "import_status",
+    "active_outside_sandbox",
+    "proofbundle_id",
+    "evidence_docket_id",
+    "claim_boundary",
+    "token_boundary",
+    "regulated_boundary",
+    "human_review_required",
+    "autonomous_persistence_allowed",
+    "no_auto_merge"
+  ],
+  "title": "AGI ALPHA Skill Import Event",
+  "type": "object"
+}

--- a/schemas/agialpha_skill_package.schema.json
+++ b/schemas/agialpha_skill_package.schema.json
@@ -1,1 +1,168 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}
+{
+  "$id": "https://montreal.ai/schemas/agialpha_skill_package.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "activation_policy": {
+      "properties": {
+        "auto_activate_allowed": {
+          "const": false,
+          "type": "boolean"
+        },
+        "falsification_required": {
+          "type": "boolean"
+        },
+        "human_review_required": {
+          "const": true,
+          "type": "boolean"
+        },
+        "replay_required": {
+          "type": "boolean"
+        },
+        "validator_required": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "allowed_import_scope": {
+      "enum": [
+        "sandbox_only",
+        "documentation_only_human_review_required"
+      ],
+      "type": "string"
+    },
+    "autonomous_persistence_allowed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "evidence_docket_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "falsification_status": {
+      "enum": [
+        "pending",
+        "pass",
+        "fail"
+      ],
+      "type": "string"
+    },
+    "human_review_required": {
+      "const": true,
+      "type": "boolean"
+    },
+    "no_auto_merge": {
+      "const": true,
+      "type": "boolean"
+    },
+    "proofbundle_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "raw_task_result_ids": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "regulated_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "replay_status": {
+      "enum": [
+        "pending",
+        "pass",
+        "fail"
+      ],
+      "type": "string"
+    },
+    "risk_tier": {
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "quarantined"
+      ],
+      "type": "string"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "skill_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "skill_payload": {
+      "type": "object"
+    },
+    "skill_type": {
+      "enum": [
+        "validator",
+        "workflow_template",
+        "scoring_rubric",
+        "safety_rule",
+        "replay_recipe",
+        "redaction_rule",
+        "claim_boundary_rule",
+        "token_boundary_rule",
+        "regulated_boundary_rule",
+        "test_fixture",
+        "operator_wrapper",
+        "failure_warning",
+        "capability_package"
+      ],
+      "type": "string"
+    },
+    "source_agent_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "source_job_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "token_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "validated_on_task_ids": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": [
+    "skill_id",
+    "source_job_id",
+    "source_agent_id",
+    "skill_type",
+    "skill_payload",
+    "validated_on_task_ids",
+    "raw_task_result_ids",
+    "proofbundle_id",
+    "evidence_docket_id",
+    "replay_status",
+    "falsification_status",
+    "risk_tier",
+    "allowed_import_scope",
+    "activation_policy",
+    "claim_boundary",
+    "token_boundary",
+    "regulated_boundary",
+    "human_review_required",
+    "autonomous_persistence_allowed",
+    "no_auto_merge"
+  ],
+  "title": "AGI ALPHA Skill Package",
+  "type": "object"
+}

--- a/tests/test_agialpha_agent_skill_manifest.py
+++ b/tests/test_agialpha_agent_skill_manifest.py
@@ -18,6 +18,8 @@ def test_agent_manifests_include_required_skill_lists_and_policy():
         for m in manifests:
             for key in ['native_skills','imported_skills','quarantined_skills','rejected_skills']:
                 assert key in m and isinstance(m[key], list)
+            assert m['activation_status'] == 'sandbox_registered_inactive_outside_sandbox'
+            assert m['production_activation_allowed'] is False
             assert m['skill_import_policy']
             assert m['claim_boundary'] and m['token_boundary'] and m['regulated_boundary']
 
@@ -34,4 +36,7 @@ def test_imported_skills_are_inactive_outside_sandbox_by_default():
         imports = json.loads((run / '05_skill_import/skill_import_events.json').read_text())['skill_import_events']
         assert len(imports) >= 3
         assert all(e['activation_status'] == 'inactive' for e in imports)
+        assert all(e['import_status'] == 'imported_inactive_outside_sandbox' for e in imports)
+        assert all(e.get('active_outside_sandbox') is False for e in imports)
+        assert all(e.get('proofbundle_id') and e.get('evidence_docket_id') for e in imports)
         assert all(e.get('autonomous_persistence_allowed') is False for e in imports)

--- a/tests/test_agialpha_skill_import.py
+++ b/tests/test_agialpha_skill_import.py
@@ -29,3 +29,12 @@ def test_create_skill_import_event_quarantines_missing_evidence_without_empty_sc
     assert event["proofbundle_id"] == "unavailable"
     assert event["evidence_docket_id"] == "unavailable"
     assert "missing ProofBundle" in event["quarantine_reason"]
+
+
+def test_skill_import_schema_requires_production_activation_block():
+    import json
+    from pathlib import Path
+
+    schema = json.loads(Path("schemas/agialpha_skill_import.schema.json").read_text())
+    assert "production_activation_allowed" in schema["required"]
+    assert schema["properties"]["production_activation_allowed"] == {"const": False, "type": "boolean"}

--- a/tests/test_agialpha_skill_import.py
+++ b/tests/test_agialpha_skill_import.py
@@ -1,2 +1,31 @@
-def test_placeholder():
-    assert True
+from agialpha_engine.skill_import import create_skill_import_event
+
+
+def test_create_skill_import_event_sets_activation_status_for_proof_bound_import():
+    skill = {
+        "skill_id": "skill-1",
+        "proofbundle_id": "pb-skill-1",
+        "evidence_docket_id": "ed-skill-1",
+        "raw_task_result_ids": ["raw-job-1"],
+    }
+    event = create_skill_import_event("import-1", skill, "agent-2")
+
+    assert event["import_status"] == "imported_inactive_outside_sandbox"
+    assert event["activation_status"] == "inactive"
+    assert event["active_outside_sandbox"] is False
+    assert event["production_activation_allowed"] is False
+    assert event["proofbundle_id"] == "pb-skill-1"
+    assert event["evidence_docket_id"] == "ed-skill-1"
+    assert event["skill_import_hash"]
+
+
+def test_create_skill_import_event_quarantines_missing_evidence_without_empty_schema_fields():
+    event = create_skill_import_event("import-2", {"skill_id": "skill-2"}, "agent-3")
+
+    assert event["import_status"] == "quarantined_missing_evidence"
+    assert event["activation_status"] == "quarantined"
+    assert event["active_outside_sandbox"] is False
+    assert event["production_activation_allowed"] is False
+    assert event["proofbundle_id"] == "unavailable"
+    assert event["evidence_docket_id"] == "unavailable"
+    assert "missing ProofBundle" in event["quarantine_reason"]

--- a/tests/test_agialpha_skill_network_run.py
+++ b/tests/test_agialpha_skill_network_run.py
@@ -14,9 +14,15 @@ def test_network_run_end_to_end():
         assert m['jobs_run']>=3 and m['accepted_skill_packages']>=1
         acc=json.loads((run/'03_skill_extraction/accepted_skill_packages.json').read_text())['accepted_skill_packages'][0]
         assert acc['raw_task_result_ids'] and acc['proofbundle_id'] and acc['evidence_docket_id']
+        agents=json.loads((run/'01_agents/agent_registry.json').read_text())['agents']
+        assert all(a.get('role') == a.get('agent_role') for a in agents)
         imp=json.loads((run/'05_skill_import/skill_import_events.json').read_text())['skill_import_events']
         assert len(imp)>=3 and all(i['activation_status']=='inactive' for i in imp)
+        assert all(i['import_status']=='imported_inactive_outside_sandbox' for i in imp)
+        assert all(i.get('active_outside_sandbox') is False for i in imp)
+        assert all(i.get('proofbundle_id') and i.get('evidence_docket_id') for i in imp)
         manifests=json.loads((run/'05_skill_import/agent_skill_manifests_after_import.json').read_text())['manifests']
+        assert all(mm.get('activation_status') == 'sandbox_registered_inactive_outside_sandbox' for mm in manifests)
         imported_agents=[mm for mm in manifests if mm.get('imported_skills')]
         assert len(imported_agents) >= 3
         assert 'network_skill_propagation_lift' in m

--- a/tests/test_agialpha_skill_network_run.py
+++ b/tests/test_agialpha_skill_network_run.py
@@ -261,3 +261,21 @@ def test_falsification_requires_boolean_replay_status():
         proc=subprocess.run(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)], capture_output=True, text=True)
         assert proc.returncode != 0
         assert 'replay_pass must be boolean' in (proc.stderr + proc.stdout)
+
+
+def test_validate_rejects_import_active_outside_sandbox_or_production_activation():
+    with tempfile.TemporaryDirectory() as td:
+        run=Path(td)/'run'; reg=Path(td)/'reg'
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-run','--repo-root','.','--registry',str(reg),'--out',str(run),'--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        path=run/'05_skill_import/skill_import_events.json'
+        doc=json.loads(path.read_text())
+        doc['skill_import_events'][0]['active_outside_sandbox']=True
+        doc['skill_import_events'][1]['production_activation_allowed']=True
+        path.write_text(json.dumps(doc))
+        proc=subprocess.run(['python','-m','agialpha_engine','network-compounding-validate','--run',str(run)], capture_output=True, text=True)
+        output=proc.stderr + proc.stdout
+        assert proc.returncode != 0
+        assert 'active_outside_sandbox must be false' in output
+        assert 'production_activation_allowed must be false' in output


### PR DESCRIPTION
### Motivation
- Make ENGINE-003 operational and auditable by implementing missing engine helpers, deterministic records, proof bindings, and registry publishing so "Every Job makes an AI Agent smarter" is measurable and replayable. 
- Remove hard-coded claim/metric shortcuts and ensure every job emits reusable learning (Accepted Skill Package, Rejected Skill Candidate, or Failure Learning Package) with ProofBundle/Evidence Docket linkage and human-review gating. 
- Surface measured, bounded network-skill evidence via generated public site data for `/agialpha-skill-network/` while preserving SecureRails boundaries (no autonomous persistence, no token/custody/payment logic, regulated-boundary firewall). 

### Description
- Implemented deterministic engine helpers: `agialpha_engine/agent_registry.py`, `agialpha_engine/agent_skill_manifest.py`, `agialpha_engine/skill_vault.py`, `agialpha_engine/skill_import.py`, and hardened `agialpha_engine/failure_learning.py` to produce hash-bound, append-only, human-review-required records and sandbox-inactive imports. 
- Hardened schemas: added/extended `schemas/agialpha_skill_package.schema.json`, `schemas/agialpha_agent_registry.schema.json`, `schemas/agialpha_agent_skill_manifest.schema.json`, `schemas/agialpha_skill_import.schema.json`, `schemas/agialpha_network_skill_metrics.schema.json`, and `schemas/agialpha_network_claim_gate.schema.json` to require evidence IDs, raw task lineage, and boundary fields. 
- Kept Engine-003 core loop and gates deterministic and evidence-driven: `network_compounding` writes raw logs, accepted/rejected/failure artifacts, publishes to the `agialpha_skill_network_registry`, builds ProofBundles, Evidence Docket sections, Work Vault receipts (utility-only), and evaluates the `NetworkCompoundingClaimGate` from raw logs (no hard-coded B6/vRCI/lift). 
- Public UX and docs: added Skill Network route to `README.md`, `docs/PUBLIC_ROUTES.md`, and updated `docs/START_HERE.md`, `docs/WORKFLOW_LAUNCHPAD.md`, and `docs/EXPERIMENT_INDEX.md`; generator `agialpha_evidence_hub.build` renders `/agialpha-skill-network/` and `/experiments/agialpha-engine-003/` from `docs/_generated/agialpha-skill-network`. 
- CLI bindings preserved: `python -m agialpha_engine network-compounding-run/replay/falsification/validate/build-data` operate deterministically with provided args and registry mirroring. 

### Testing
- Ran an end-to-end ENGINE-003 run: `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` followed by `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`; all steps completed and produced expected registry/evidence artifacts. 
- Unit and integration test suites executed: `python -m unittest discover -s tests` and `pytest -q` passed (project-wide test suite and added semantic checks ran green). 
- Ran SecureRails checks used by workflows: `scripts/secure_rails_claim_boundary_check.py`, `scripts/secure_rails_no_automerge_check.py`, and `scripts/secure_rails_trust_center_check.py` passed; `scripts/secure_rails_human_review_check.py` requires a decision-file argument when run standalone (raises `IndexError` without it) and `scripts/secure_rails_policy_check.py` reported repository-wide policy inventory items that pre-existed and are outside this Engine-003 hardening (no changes weaken SecureRails). 
- All automated validation gates in `network-compounding-validate` returned expected failures/successes under tamper and negative-test scenarios exercised by the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1981dba0a4833393157e11b9a1e33a)