### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_skill_metrics.py
+++ b/agialpha_engine/network_skill_metrics.py
@@ -14,8 +14,22 @@ def base_record(extra=None):
 
 __doc__ = "Network skill metrics computation from raw logs."
 
+REQUIRED_D_FIELDS = (
+    "success_score",
+    "validator_pass",
+    "replay_pass",
+    "proofbundle",
+    "docket",
+    "cost_risk_proxy",
+)
+
+
 def compute_d_metric(rows):
     if not rows:
+        return "not_reported"
+    if any(not isinstance(row, dict) for row in rows):
+        return "not_reported"
+    if any(any(field not in row for field in REQUIRED_D_FIELDS) for row in rows):
         return "not_reported"
     return sum(_row_factor(r) for r in rows)/len(rows)
 

--- a/tests/test_agialpha_agent_skill_manifest.py
+++ b/tests/test_agialpha_agent_skill_manifest.py
@@ -3,6 +3,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from agialpha_engine.network_skill_metrics import compute_d_metric
+
 
 def test_agent_manifests_include_required_skill_lists_and_policy():
     with tempfile.TemporaryDirectory() as td:
@@ -40,3 +42,39 @@ def test_imported_skills_are_inactive_outside_sandbox_by_default():
         assert all(e.get('active_outside_sandbox') is False for e in imports)
         assert all(e.get('proofbundle_id') and e.get('evidence_docket_id') for e in imports)
         assert all(e.get('autonomous_persistence_allowed') is False for e in imports)
+
+
+def test_target_agent_manifests_keep_imports_sandbox_inactive_and_human_review_pending():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        subprocess.check_call([
+            'python', '-m', 'agialpha_engine', 'network-compounding-run',
+            '--repo-root', '.', '--registry', str(reg), '--out', str(run),
+            '--jobs', '5', '--target-agents', '3', '--heldout-tasks', '5', '--seed', '123'
+        ])
+        manifests = json.loads((run / '05_skill_import/agent_skill_manifests_after_import.json').read_text())['manifests']
+        target_manifests = [m for m in manifests if m['imported_skills']]
+
+        assert len(target_manifests) == 3
+        assert all(m['production_activation_allowed'] is False for m in target_manifests)
+        assert all(m['human_review_status'] == 'pending' for m in target_manifests)
+        assert all(m['activation_status'] == 'sandbox_registered_inactive_outside_sandbox' for m in target_manifests)
+        assert all(m['imported_skills'] for m in target_manifests)
+
+
+def test_network_d_metric_does_not_render_missing_values_as_zero():
+    assert compute_d_metric([]) == 'not_reported'
+    assert compute_d_metric([{'validator_pass': 1, 'replay_pass': 1, 'proofbundle': 1, 'docket': 1, 'cost_risk_proxy': 1}]) == 'not_reported'
+
+    measured_zero = compute_d_metric([
+        {
+            'success_score': 0,
+            'validator_pass': 1,
+            'replay_pass': 1,
+            'proofbundle': 1,
+            'docket': 1,
+            'cost_risk_proxy': 1,
+        }
+    ])
+    assert measured_zero == 0


### PR DESCRIPTION
### Motivation
- Harden D-network metric handling so missing or malformed held-out rows are explicitly `not_reported` instead of being treated as measured zero. 
- Ensure imported skills remain sandbox-registered and inactive outside sandbox by default with human review pending. 
- Improve semantic test coverage to prevent silent overclaiming or accidental metric-fixing in the network compounding flow. 

### Description
- `agialpha_engine/network_skill_metrics.py` now defines `REQUIRED_D_FIELDS` and returns `"not_reported"` if held-out rows are missing required fields or malformed, preserving explicit measured-zero values when fields are present. 
- Added/updated `tests/test_agialpha_agent_skill_manifest.py` to assert target-agent manifests show sandbox registration, `inactive` activation status outside sandbox, `production_activation_allowed=False`, `human_review_status=='pending'`, and to cover `compute_d_metric` semantics for missing vs explicit-zero inputs. 
- Kept all Engine-003 public-facing wording and safety boundaries unchanged (no new claim language, activation remains blocked pending human review). 
- No wallet/custody/payment/trading/KYC/AML or regulated decisioning code was added or modified. 

### Testing
- Ran the network compounding flow end-to-end with `python -m agialpha_engine network-compounding-run ...`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data` and those commands completed successfully. 
- Ran the full test suite with `python -m unittest discover -s tests` and `pytest -q`, and unit/integration tests passed (test suite run reported 705 passed). 
- Executed focused pytest for the new coverage with `pytest -q tests/test_agialpha_agent_skill_manifest.py tests/test_agialpha_network_compounding_metrics.py` and those tests passed. 
- SecureRails checks: `scripts/secure_rails_claim_boundary_check.py` and `scripts/secure_rails_no_automerge_check.py` passed, while `scripts/secure_rails_policy_check.py` reported existing repository-wide policy violations and `scripts/secure_rails_human_review_check.py` exited with a usage error when invoked without its decision-file argument (these are external repo-level issues, not regressions introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f877fc8c8333aa5835c06fe92c5e)