### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/redaction.py
+++ b/agialpha_engine/redaction.py
@@ -31,33 +31,72 @@ def _salt_hash(salt: str) -> str:
     return hashlib.sha256(f"{salt}:salt-hash".encode()).hexdigest()
 
 
-def redact_text(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
+def _redact_with_findings(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
     salt = _stable_run_salt(run_id, root_hash)
     salt_hash = _salt_hash(salt)
-    findings = []
-    out = text
+    candidates: list[dict[str, Any]] = []
     for name, pattern in PATTERNS.items():
-        for m in list(pattern.finditer(out)):
-            secret = m.group(0)
+        for match in pattern.finditer(text):
+            secret = match.group(0)
             digest = hashlib.sha256((salt + secret).encode()).hexdigest()[:16]
-            findings.append({"finding_type": name, "salt_hash": salt_hash, "salted_hash": digest, "redacted_preview": "[REDACTED]"})
-            out = out.replace(secret, "[REDACTED]")
-    return out, findings
+            candidates.append(
+                {
+                    "finding_type": name,
+                    "salt_hash": salt_hash,
+                    "salted_hash": digest,
+                    "redacted_preview": "[REDACTED]",
+                    "start": match.start(),
+                    "end": match.end(),
+                    "line": text.count("\n", 0, match.start()) + 1,
+                }
+            )
+
+    selected: list[dict[str, Any]] = []
+    occupied: list[tuple[int, int]] = []
+    for candidate in sorted(candidates, key=lambda c: (c["start"], -(c["end"] - c["start"]))):
+        span = (candidate["start"], candidate["end"])
+        if any(span[0] < used_end and span[1] > used_start for used_start, used_end in occupied):
+            continue
+        selected.append(candidate)
+        occupied.append(span)
+
+    redacted_parts: list[str] = []
+    cursor = 0
+    for finding in sorted(selected, key=lambda f: f["start"]):
+        redacted_parts.append(text[cursor:finding["start"]])
+        redacted_parts.append("[REDACTED]")
+        cursor = finding["end"]
+    redacted_parts.append(text[cursor:])
+
+    public_findings = [
+        {
+            "finding_type": finding["finding_type"],
+            "salt_hash": finding["salt_hash"],
+            "salted_hash": finding["salted_hash"],
+            "redacted_preview": finding["redacted_preview"],
+            "line": finding["line"],
+        }
+        for finding in sorted(selected, key=lambda f: f["start"])
+    ]
+    return "".join(redacted_parts), public_findings
+
+
+def redact_text(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
+    redacted, findings = _redact_with_findings(text, run_id, root_hash)
+    return redacted, [
+        {k: v for k, v in finding.items() if k != "line"}
+        for finding in findings
+    ]
 
 
 def redact_document(text: str, *, run_id: str, root_hash: str, path: str) -> dict[str, Any]:
     """Redact a fixture/report while retaining only type/path/line/salted digest metadata."""
-    redacted_lines: list[str] = []
-    findings: list[dict[str, Any]] = []
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        redacted_line, line_findings = redact_text(line, run_id, root_hash)
-        redacted_lines.append(redacted_line)
-        for finding in line_findings:
-            findings.append({**finding, "path": path, "line": line_number})
+    redacted_text, raw_findings = _redact_with_findings(text, run_id, root_hash)
+    findings = [{**finding, "path": path} for finding in raw_findings]
     return {
         "schema_version": "agialpha.engine.redaction_report.v1",
         "path": path,
-        "redacted_text": "\n".join(redacted_lines),
+        "redacted_text": redacted_text,
         "findings": findings,
         "raw_secret_values_stored": False,
     }

--- a/agialpha_engine/redaction.py
+++ b/agialpha_engine/redaction.py
@@ -23,17 +23,41 @@ PATTERNS = {
 
 
 def _stable_run_salt(run_id: str, root_hash: str) -> str:
+    """Return a replayable run-scoped salt; reports expose only its hash."""
     return hashlib.sha256(f"{run_id}:{root_hash}:redaction-run-salt".encode()).hexdigest()
+
+
+def _salt_hash(salt: str) -> str:
+    return hashlib.sha256(f"{salt}:salt-hash".encode()).hexdigest()
 
 
 def redact_text(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
     salt = _stable_run_salt(run_id, root_hash)
+    salt_hash = _salt_hash(salt)
     findings = []
     out = text
     for name, pattern in PATTERNS.items():
         for m in list(pattern.finditer(out)):
             secret = m.group(0)
             digest = hashlib.sha256((salt + secret).encode()).hexdigest()[:16]
-            findings.append({"finding_type": name, "salted_hash": digest, "redacted_preview": "[REDACTED]"})
+            findings.append({"finding_type": name, "salt_hash": salt_hash, "salted_hash": digest, "redacted_preview": "[REDACTED]"})
             out = out.replace(secret, "[REDACTED]")
     return out, findings
+
+
+def redact_document(text: str, *, run_id: str, root_hash: str, path: str) -> dict[str, Any]:
+    """Redact a fixture/report while retaining only type/path/line/salted digest metadata."""
+    redacted_lines: list[str] = []
+    findings: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        redacted_line, line_findings = redact_text(line, run_id, root_hash)
+        redacted_lines.append(redacted_line)
+        for finding in line_findings:
+            findings.append({**finding, "path": path, "line": line_number})
+    return {
+        "schema_version": "agialpha.engine.redaction_report.v1",
+        "path": path,
+        "redacted_text": "\n".join(redacted_lines),
+        "findings": findings,
+        "raw_secret_values_stored": False,
+    }

--- a/agialpha_skill_network_registry/CHANGELOG.md
+++ b/agialpha_skill_network_registry/CHANGELOG.md
@@ -1,0 +1,7 @@
+# AGI ALPHA Skill Network Registry Changelog
+
+## ENGINE-003 networked skill compounding baseline
+
+- Preserves append-only registry indexes for accepted Skill Packages, rejected Skill Candidates, Failure Learning Packages, skill imports, propagation events, ProofBundles, Evidence Dockets, Work Vault receipts, metrics, and claim-gate decisions.
+- Records that instant sharing means sandboxed registration/importability only; production activation requires validators and human review.
+- Maintains the exponential-boundary caveat unless the multi-cycle exponential claim gate is supported by replayable evidence.

--- a/tests/test_agialpha_agent_skill_manifest.py
+++ b/tests/test_agialpha_agent_skill_manifest.py
@@ -78,3 +78,28 @@ def test_network_d_metric_does_not_render_missing_values_as_zero():
         }
     ])
     assert measured_zero == 0
+
+
+def test_manifest_helper_imports_are_inactive_outside_sandbox_by_default():
+    from agialpha_engine.agent_skill_manifest import create_agent_skill_manifest
+
+    manifest = create_agent_skill_manifest("agent-reviewer", imported_skills=["skill-b", "skill-a"])
+    assert manifest["schema_version"] == "agialpha.agent_skill_manifest.v1"
+    assert manifest["imported_skills"] == ["skill-a", "skill-b"]
+    assert manifest["activation_status"] == "sandbox_registered_inactive_outside_sandbox"
+    assert manifest["production_activation_allowed"] is False
+    assert manifest["human_review_status"] == "pending"
+    assert manifest["autonomous_persistence_allowed"] is False
+    assert manifest["no_auto_merge"] is True
+    assert manifest["manifest_hash"]
+
+
+def test_manifest_helper_add_imported_skill_preserves_inactive_activation_policy():
+    from agialpha_engine.agent_skill_manifest import add_imported_skill, create_agent_skill_manifest
+
+    manifest = create_agent_skill_manifest("agent-operator", native_skills=["native-safe"])
+    updated = add_imported_skill(manifest, "skill-shared")
+    assert updated["native_skills"] == ["native-safe"]
+    assert updated["imported_skills"] == ["skill-shared"]
+    assert updated["activation_status"] == "sandbox_registered_inactive_outside_sandbox"
+    assert updated["production_activation_allowed"] is False

--- a/tests/test_agialpha_skill_network_redaction.py
+++ b/tests/test_agialpha_skill_network_redaction.py
@@ -19,3 +19,23 @@ def test_redact_text_finding_includes_salt_hash_for_replayable_digest():
     assert "abcdefghijklmnopqrstuvwxyz123456" not in redacted
     assert findings and findings[0]["salt_hash"]
     assert findings[0]["salted_hash"]
+
+
+def test_redact_document_redacts_multiline_private_key_before_line_splitting():
+    pem = """safe prefix
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC
+raw-private-key-material
+-----END PRIVATE KEY-----
+contact reviewer@example.com
+"""
+    report = redact_document(pem, run_id="run-003", root_hash="root", path="fixture.pem")
+    assert "-----BEGIN PRIVATE KEY-----" not in report["redacted_text"]
+    assert "raw-private-key-material" not in report["redacted_text"]
+    assert "-----END PRIVATE KEY-----" not in report["redacted_text"]
+    assert "reviewer@example.com" not in report["redacted_text"]
+    private_key_findings = [f for f in report["findings"] if f["finding_type"] == "private_key_block"]
+    assert private_key_findings
+    assert private_key_findings[0]["line"] == 2
+    assert private_key_findings[0]["path"] == "fixture.pem"
+    assert all("raw-private-key-material" not in str(finding) for finding in report["findings"])

--- a/tests/test_agialpha_skill_network_redaction.py
+++ b/tests/test_agialpha_skill_network_redaction.py
@@ -1,0 +1,21 @@
+from agialpha_engine.redaction import redact_document, redact_text
+
+
+def test_network_redaction_report_stores_salt_hash_not_raw_secret():
+    text = "token ghp_abcdefghijklmnopqrstuvwxyz and email reviewer@example.com and phone 415-555-1212"
+    report = redact_document(text, run_id="run-003", root_hash="root", path="fixture.txt")
+    assert "ghp_abcdefghijklmnopqrstuvwxyz" not in report["redacted_text"]
+    assert "reviewer@example.com" not in report["redacted_text"]
+    assert "415-555-1212" not in report["redacted_text"]
+    assert report["raw_secret_values_stored"] is False
+    assert {finding["path"] for finding in report["findings"]} == {"fixture.txt"}
+    assert all(finding["line"] == 1 for finding in report["findings"])
+    assert all(finding.get("salt_hash") for finding in report["findings"])
+    assert all("ghp_abcdefghijklmnopqrstuvwxyz" not in str(finding) for finding in report["findings"])
+
+
+def test_redact_text_finding_includes_salt_hash_for_replayable_digest():
+    redacted, findings = redact_text("Bearer abcdefghijklmnopqrstuvwxyz123456", "run-003", "root")
+    assert "abcdefghijklmnopqrstuvwxyz123456" not in redacted
+    assert findings and findings[0]["salt_hash"]
+    assert findings[0]["salted_hash"]


### PR DESCRIPTION
### Motivation
- Close gaps in ENGINE-003 by making secret/PII redaction replayable and auditable while ensuring no raw secrets are retained. 
- Make Agent Skill Manifest helpers explicit about sandbox-only import activation and human-review gating. 
- Record registry-level changelog guidance about append-only policy, sandbox importability, and the exponential-compounding caveat.

### Description
- Add deterministic redaction tooling in `agialpha_engine/redaction.py` that derives a run-scoped salt, exposes only a `salt_hash` plus salted digests for findings, and provides `redact_document()` reports that include path/line/findings and `raw_secret_values_stored=False`.
- Add a registry changelog `agialpha_skill_network_registry/CHANGELOG.md` documenting append-only preservation, sandbox-only importability, and the exponential-claim boundary caveat.
- Add and/or adjust tests: new `tests/test_agialpha_skill_network_redaction.py` to validate redaction behavior, and extend `tests/test_agialpha_agent_skill_manifest.py` to assert manifests keep imported skills inactive outside sandbox, human-review pending, non-persistent, and no-auto-merge.
- Ensure all changes preserve the ENGINE-003 rules: no raw secret retention, no autonomous persistence, and replayable salted digest evidence for redaction findings.

### Testing
- Ran the Engine-003 local lifecycle: `network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and they completed successfully.
- Ran SecureRails checks (`scripts/secure_rails_claim_boundary_check.py`, `scripts/secure_rails_no_automerge_check.py`) and they passed.
- Ran targeted unit tests and full test suites: `pytest -q` and `python -m unittest discover -s tests`, and the test runs passed (including the newly added redaction and manifest tests).
- Committed changes and created the PR titled "Finish AGI ALPHA Engine 003: Networked Skill Compounding".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a0e0db8488333b1e82180324c7378)