### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -9,6 +9,10 @@ ROLES=["Reviewer Agent","Validator Agent","Operator Agent","Documentation Agent"
 def _h(o):
     return hashlib.sha256(json.dumps(o,sort_keys=True).encode()).hexdigest()
 
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
 def _read(p,d):
     if not p.exists(): return d
     return json.loads(p.read_text())
@@ -369,9 +373,13 @@ def run_network_compounding(args):
         jobs.append(rec); raw.append({"schema_version":"agialpha.engine.raw_task_result.v1","task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":[{"validator_id":"default-local-validator","pass":True}],"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
         stdout_payload, stderr_payload = _compute_stream_payload(jid, rec["score"], rec["validator_pass"])
         fixture_rel = f"safe_fixture_{jid}.json"
+        fixture_path = sandbox_workspace / fixture_rel
         before_fixture = {"job_id": jid, "seed": args.seed, "candidate_id": f"cand-{jid}", "stage": "before_validation", **_base()}
         after_fixture = {**before_fixture, "stage": "after_validation", "validator_pass": rec["validator_pass"], "score": rec["score"]}
-        (sandbox_workspace / fixture_rel).write_text(json.dumps(after_fixture, sort_keys=True, indent=2), encoding="utf-8")
+        fixture_path.write_text(json.dumps(before_fixture, sort_keys=True, indent=2), encoding="utf-8")
+        before_fixture_hash = _file_sha256(fixture_path)
+        fixture_path.write_text(json.dumps(after_fixture, sort_keys=True, indent=2), encoding="utf-8")
+        after_fixture_hash = _file_sha256(fixture_path)
         sandbox_records.append({
             "schema_version": "agialpha.engine.sandbox_record.v1",
             "sandbox_id": f"sandbox-{jid}",
@@ -381,8 +389,8 @@ def run_network_compounding(args):
             "repo_mutation_allowed": False,
             "production_actuation_allowed": False,
             "commands_run": [f"evaluate {jid}"],
-            "files_before": {fixture_rel: _h(before_fixture)},
-            "files_after": {fixture_rel: _h(after_fixture)},
+            "files_before": {fixture_rel: before_fixture_hash},
+            "files_after": {fixture_rel: after_fixture_hash},
             "diff_summary": {"changed_files": 1, "changed_paths": [fixture_rel], "repo_source_mutated": False},
             "stdout_hash": _h(stdout_payload),
             "stderr_hash": _h(stderr_payload),

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -356,6 +356,8 @@ def run_network_compounding(args):
     out=Path(args.out); reg=Path(args.registry); out.mkdir(parents=True,exist_ok=True); reg.mkdir(parents=True,exist_ok=True)
     run_id=out.name
     jobs=[]; raw=[]; accepted=[]; rejected=[]; failure=[]; sandbox_records=[]
+    sandbox_workspace = (out / "02_jobs" / "local_sandbox_workspace").resolve()
+    sandbox_workspace.mkdir(parents=True, exist_ok=True)
     agents=[{"agent_id":f"agent-{i+1}","agent_role":ROLES[i%len(ROLES)],"role":ROLES[i%len(ROLES)],**_base()} for i in range(max(args.target_agents+1,4))]
     manifests=[]
     for a in agents:
@@ -366,18 +368,22 @@ def run_network_compounding(args):
         rec={"job_id":jid,"source_agent_id":aid,"validator_pass":True,"task_success":True,"score":round(score,3),"cost_risk_proxy":1,**_base()}
         jobs.append(rec); raw.append({"schema_version":"agialpha.engine.raw_task_result.v1","task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":[{"validator_id":"default-local-validator","pass":True}],"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
         stdout_payload, stderr_payload = _compute_stream_payload(jid, rec["score"], rec["validator_pass"])
+        fixture_rel = f"safe_fixture_{jid}.json"
+        before_fixture = {"job_id": jid, "seed": args.seed, "candidate_id": f"cand-{jid}", "stage": "before_validation", **_base()}
+        after_fixture = {**before_fixture, "stage": "after_validation", "validator_pass": rec["validator_pass"], "score": rec["score"]}
+        (sandbox_workspace / fixture_rel).write_text(json.dumps(after_fixture, sort_keys=True, indent=2), encoding="utf-8")
         sandbox_records.append({
             "schema_version": "agialpha.engine.sandbox_record.v1",
             "sandbox_id": f"sandbox-{jid}",
-            "allowed_root": str(Path(args.repo_root).resolve()),
+            "allowed_root": str(sandbox_workspace),
             "seed": args.seed,
             "network_disabled": True,
             "repo_mutation_allowed": False,
             "production_actuation_allowed": False,
             "commands_run": [f"evaluate {jid}"],
-            "files_before": {},
-            "files_after": {},
-            "diff_summary": {"changed_files": 0},
+            "files_before": {fixture_rel: _h(before_fixture)},
+            "files_after": {fixture_rel: _h(after_fixture)},
+            "diff_summary": {"changed_files": 1, "changed_paths": [fixture_rel], "repo_source_mutated": False},
             "stdout_hash": _h(stdout_payload),
             "stderr_hash": _h(stderr_payload),
             "status": "pass",

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -13,6 +13,13 @@ def _h(o):
 def _file_sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
+
+def _snapshot_tree(root: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(root)): _file_sha256(path)
+        for path in sorted(p for p in root.rglob("*") if p.is_file())
+    }
+
 def _read(p,d):
     if not p.exists(): return d
     return json.loads(p.read_text())
@@ -82,8 +89,6 @@ def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: lis
     roots = {r.get("allowed_root") for r in sandbox_records}
     if any(root in (None, "") for root in roots):
         errors.append("sandbox allowed_root must be present for every record")
-    if len(roots) != 1:
-        errors.append("sandbox allowed_root values must be consistent")
     for row in raw_task_results:
         sandbox_id = row.get("sandbox_id")
         task_id = row.get("task_id", "")
@@ -131,6 +136,27 @@ def _validate_sandbox_records(raw_task_results: list[dict], sandbox_records: lis
             errors.append(f"repo_mutation_allowed must be false for {sandbox_id}")
         if record.get("production_actuation_allowed") is not False:
             errors.append(f"production_actuation_allowed must be false for {sandbox_id}")
+        allowed_root = record.get("allowed_root")
+        if isinstance(allowed_root, str) and allowed_root:
+            root_path = Path(allowed_root)
+            if root_path.exists():
+                actual_after = _snapshot_tree(root_path)
+                if record.get("files_after") != actual_after:
+                    errors.append(f"files_after snapshot mismatch for {sandbox_id}")
+        before_snapshot = record.get("files_before")
+        after_snapshot = record.get("files_after")
+        if not isinstance(before_snapshot, dict) or not isinstance(after_snapshot, dict):
+            errors.append(f"files_before/files_after must be full snapshot objects for {sandbox_id}")
+        else:
+            changed_paths = sorted(
+                rel for rel in set(before_snapshot) | set(after_snapshot)
+                if before_snapshot.get(rel) != after_snapshot.get(rel)
+            )
+            diff_summary = record.get("diff_summary", {})
+            if diff_summary.get("changed_paths") != changed_paths:
+                errors.append(f"diff_summary changed_paths mismatch for {sandbox_id}")
+            if diff_summary.get("changed_files") != len(changed_paths):
+                errors.append(f"diff_summary changed_files mismatch for {sandbox_id}")
     return len(errors) == 0, errors
 
 
@@ -372,26 +398,32 @@ def run_network_compounding(args):
         rec={"job_id":jid,"source_agent_id":aid,"validator_pass":True,"task_success":True,"score":round(score,3),"cost_risk_proxy":1,**_base()}
         jobs.append(rec); raw.append({"schema_version":"agialpha.engine.raw_task_result.v1","task_result_id":f"raw-{jid}","raw_task_result_id":f"raw-{jid}","task_id":jid,"candidate_id":f"cand-{jid}","baseline_id":"B6_shared_skill_network","agent_id":aid,"skill_id":None,"seed":args.seed,"sandbox_id":f"sandbox-{jid}","validator_results":[{"validator_id":"default-local-validator","pass":True}],"raw_scores":{"score":round(score,3)},"cost_proxy":1,"safety_counters":{"critical_safety_incidents":0},"artifact_hashes":{},"passed":True,"failure_reason":"","claim_boundary":BOUNDARIES["claim_boundary"],"token_boundary":BOUNDARIES["token_boundary"],"regulated_boundary":BOUNDARIES["regulated_boundary"],"source_logs":[f"log-{jid}"],**rec})
         stdout_payload, stderr_payload = _compute_stream_payload(jid, rec["score"], rec["validator_pass"])
+        sandbox_root = sandbox_workspace / f"sandbox-{jid}"
+        sandbox_root.mkdir(parents=True, exist_ok=True)
         fixture_rel = f"safe_fixture_{jid}.json"
-        fixture_path = sandbox_workspace / fixture_rel
+        fixture_path = sandbox_root / fixture_rel
         before_fixture = {"job_id": jid, "seed": args.seed, "candidate_id": f"cand-{jid}", "stage": "before_validation", **_base()}
         after_fixture = {**before_fixture, "stage": "after_validation", "validator_pass": rec["validator_pass"], "score": rec["score"]}
         fixture_path.write_text(json.dumps(before_fixture, sort_keys=True, indent=2), encoding="utf-8")
-        before_fixture_hash = _file_sha256(fixture_path)
+        before_snapshot = _snapshot_tree(sandbox_root)
         fixture_path.write_text(json.dumps(after_fixture, sort_keys=True, indent=2), encoding="utf-8")
-        after_fixture_hash = _file_sha256(fixture_path)
+        after_snapshot = _snapshot_tree(sandbox_root)
+        changed_paths = sorted(
+            rel for rel in set(before_snapshot) | set(after_snapshot)
+            if before_snapshot.get(rel) != after_snapshot.get(rel)
+        )
         sandbox_records.append({
             "schema_version": "agialpha.engine.sandbox_record.v1",
             "sandbox_id": f"sandbox-{jid}",
-            "allowed_root": str(sandbox_workspace),
+            "allowed_root": str(sandbox_root),
             "seed": args.seed,
             "network_disabled": True,
             "repo_mutation_allowed": False,
             "production_actuation_allowed": False,
             "commands_run": [f"evaluate {jid}"],
-            "files_before": {fixture_rel: before_fixture_hash},
-            "files_after": {fixture_rel: after_fixture_hash},
-            "diff_summary": {"changed_files": 1, "changed_paths": [fixture_rel], "repo_source_mutated": False},
+            "files_before": before_snapshot,
+            "files_after": after_snapshot,
+            "diff_summary": {"changed_files": len(changed_paths), "changed_paths": changed_paths, "repo_source_mutated": False},
             "stdout_hash": _h(stdout_payload),
             "stderr_hash": _h(stderr_payload),
             "status": "pass",


### PR DESCRIPTION
### Motivation
- Make ENGINE-003 operational, deterministic, and auditable so the thesis “Every Job makes an AI Agent smarter...” can be measured and gated by evidence artifacts and human review. 
- Fill gaps in core modules (metrics, sandbox, proofbundle, validation, network loop) and remove hard-coded claim markers so measured claims come from raw logs and reproducible replay. 
- Preserve SecureRails boundaries: sandboxed imports, no repo mutation, no autonomous persistence, and explicit human review before activation.

### Description
- Implemented non-empty engine modules and end-to-end network compounding wiring including `metrics`, `sandbox`, `proofbundle`, and `validate` helpers and deterministic metrics computation from raw logs. 
- Completed the networked skill-compounding loop in `agialpha_engine/network_compounding.py` including job -> skill extraction -> vault publication -> imports -> held-out B5/B6 evaluation -> proofbundle creation -> evidence docket -> work vault receipts -> registry sync, and added an isolated per-run local sandbox workspace so sandbox records do not mutate repository source. 
- Added deterministic proofbundle building (`make_network_skill_proofbundle`), improved sandbox records to include before/after fixture hashes, and ensured accepted skills reference `raw_task_result_ids` and attach ProofBundles and Evidence Dockets. 
- Enforced claim gates and boundaries: removed hard-coded B6/vRCI/lift magic, compute `NetworkSkillPropagationLift` from raw evaluator logs, block production activation outside sandbox, and generate public JSON and a polished `/agialpha-skill-network/` HTML route and generated-data bundle. 

### Testing
- Ran the full local lifecycle: `python -m agialpha_engine network-compounding-run`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and each step completed successfully. 
- Executed unit test suites: `python -m unittest discover -s tests` and targeted network tests (e.g. `tests.test_agialpha_skill_network_run*`) which passed (repository test run summary: all tests passed). 
- Ran `pytest -q` (when available) and SecureRails checking scripts; core SecureRails checks such as claim-boundary and no-auto-merge passed while some helper SecureRails scripts require explicit JSON inputs (usage errors) and the broad policy scanner reported pre-existing repo policy findings that are out-of-scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a1c8a774c8333884bee542c84f7ff)