### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -430,6 +430,11 @@ def _sync_run_to_registry(run: Path) -> None:
         proofbundle_id = proofbundle.get("proofbundle_id")
         if proofbundle_id:
             atomic_write_json(run_registry_dir / "14_proofbundles" / f"{proofbundle_id}.json", proofbundle)
+    atomic_write_json(run_registry_dir / "15_evidence_dockets" / "index.json", {"evidence_dockets": evidence_dockets, **_base()})
+    for docket in evidence_dockets:
+        evidence_docket_id = docket.get("evidence_docket_id")
+        if evidence_docket_id:
+            atomic_write_json(run_registry_dir / "15_evidence_dockets" / f"{evidence_docket_id}.json", docket)
     atomic_write_json(run_registry_dir / "16_replay_report.json", replay_report if replay_report else {"status": "not_reported", **_base()})
     atomic_write_json(run_registry_dir / "17_falsification_audit.json", falsification_audit if falsification_audit else {"status": "not_reported", **_base()})
     atomic_write_json(run_registry_dir / "18_claim_gate_decision.json", gate)
@@ -733,6 +738,11 @@ def run_network_compounding(args):
         proofbundle_id = proofbundle.get("proofbundle_id")
         if proofbundle_id:
             atomic_write_json(run_registry_dir / "14_proofbundles" / f"{proofbundle_id}.json", proofbundle)
+    atomic_write_json(run_registry_dir / "15_evidence_dockets" / "index.json", {"evidence_dockets": dockets, **_base()})
+    for docket in dockets:
+        evidence_docket_id = docket.get("evidence_docket_id")
+        if evidence_docket_id:
+            atomic_write_json(run_registry_dir / "15_evidence_dockets" / f"{evidence_docket_id}.json", docket)
     atomic_write_json(run_registry_dir / "16_replay_report.json", {"replay_pass": False, "replay_passes": 0, "status": "pending_replay_execution", **_base()})
     atomic_write_json(run_registry_dir / "17_falsification_audit.json", {"falsification_pass": False, "status": "pending_falsification_execution", **_base()})
     atomic_write_json(run_registry_dir / "18_claim_gate_decision.json", gate)

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/15_evidence_dockets/ed-skill-1.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/15_evidence_dockets/ed-skill-1.json
@@ -1,0 +1,17 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "evidence_docket_id": "ed-skill-1",
+  "human_review_required": true,
+  "includes_baseline_regressions": true,
+  "includes_evaluator_disagreement": true,
+  "includes_failures": true,
+  "includes_falsification_attempts": true,
+  "includes_rejected_claims": true,
+  "includes_successes": true,
+  "no_auto_merge": true,
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.engine003.evidence_docket.v1",
+  "skill_id": "skill-1",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/15_evidence_dockets/ed-skill-4.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/15_evidence_dockets/ed-skill-4.json
@@ -1,0 +1,17 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "evidence_docket_id": "ed-skill-4",
+  "human_review_required": true,
+  "includes_baseline_regressions": true,
+  "includes_evaluator_disagreement": true,
+  "includes_failures": true,
+  "includes_falsification_attempts": true,
+  "includes_rejected_claims": true,
+  "includes_successes": true,
+  "no_auto_merge": true,
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.engine003.evidence_docket.v1",
+  "skill_id": "skill-4",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/15_evidence_dockets/index.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/15_evidence_dockets/index.json
@@ -1,0 +1,44 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "evidence_dockets": [
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-1",
+      "human_review_required": true,
+      "includes_baseline_regressions": true,
+      "includes_evaluator_disagreement": true,
+      "includes_failures": true,
+      "includes_falsification_attempts": true,
+      "includes_rejected_claims": true,
+      "includes_successes": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "schema_version": "agialpha.engine003.evidence_docket.v1",
+      "skill_id": "skill-1",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    },
+    {
+      "autonomous_persistence_allowed": false,
+      "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+      "evidence_docket_id": "ed-skill-4",
+      "human_review_required": true,
+      "includes_baseline_regressions": true,
+      "includes_evaluator_disagreement": true,
+      "includes_failures": true,
+      "includes_falsification_attempts": true,
+      "includes_rejected_claims": true,
+      "includes_successes": true,
+      "no_auto_merge": true,
+      "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+      "schema_version": "agialpha.engine003.evidence_docket.v1",
+      "skill_id": "skill-4",
+      "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+    }
+  ],
+  "human_review_required": true,
+  "no_auto_merge": true,
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/docs/agialpha-skill-network/generated/index.html
+++ b/docs/agialpha-skill-network/generated/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>AGI ALPHA Skill Network</title>
+<style>body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;background:#08111f;color:#eaf2ff}main{max-width:1180px;margin:auto;padding:40px 20px}.hero{padding:48px;border:1px solid #24415f;border-radius:28px;background:linear-gradient(135deg,#10213c,#07101d 60%,#183b4d)}h1{font-size:clamp(2.4rem,6vw,5rem);margin:.1em 0}h2{margin-top:44px}.thesis{font-size:1.35rem;line-height:1.5;color:#d9ecff}.caveat,.footer{border-left:4px solid #7cc7ff;background:#0d1c31;padding:18px 22px;border-radius:12px}.chain{display:flex;flex-wrap:wrap;gap:8px}.chain span{border:1px solid #31577d;border-radius:999px;padding:8px 12px;background:#0e2038}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px}.card{border:1px solid #284966;border-radius:18px;padding:18px;background:#0d1b2f}.card span{display:block;color:#9fb9d8;font-size:.82rem;text-transform:uppercase}.card strong{font-size:1.4rem}table{width:100%;border-collapse:collapse;background:#09182a;border-radius:16px;overflow:hidden}td,th{border-bottom:1px solid #213b58;padding:11px;text-align:left;vertical-align:top}th{color:#a9d7ff;background:#10233b}a{color:#8bd3ff}.panel{border:1px solid #294e73;border-radius:20px;padding:20px;background:#0a1829;margin:18px 0}code{color:#bde6ff}</style></head>
+<body><main><section class="hero"><p>Skill Network</p><h1>AGI ALPHA Skill Network</h1><div class="thesis"><p>Every Job makes an AI Agent smarter.</p><p>Every new skill can be instantly shared across the network.</p><p>One Agent learns, all Agents level up.</p></div></section>
+<section class="caveat"><strong>Caveat.</strong> Instant sharing means sandboxed registration/importability. Production activation requires validators and human review. Exponential compounding is a strategic target unless the exponential claim gate passes.</section>
+<h2>Proof chain</h2><div class="chain"><span>AGI Job</span><span>Skill Package / Rejected Skill / Failure Learning</span><span>ProofBundle</span><span>Evidence Docket</span><span>Network Skill Vault</span><span>Agent Skill Manifest</span><span>Held-out Reuse Test</span><span>B6 vs B5</span><span>NetworkSkillPropagationLift</span><span>Claim Gate</span><span>Human Review</span></div>
+<div class="panel"><h2>Claim gate panel</h2><p><strong>supported_local_bounded</strong></p><p>We have demonstrated local bounded networked skill compounding: one agent’s proof-bound job produced a validated Skill Package that other agents imported and used to improve held-out adjacent work against no-shared-skill baselines.</p></div>
+<div class="panel"><h2>Exponential compounding status panel</h2><p>Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.</p></div>
+<h2>Status cards</h2><div class="cards"><article class='card'><span>jobs run</span><strong>5</strong></article><article class='card'><span>accepted skill packages</span><strong>2</strong></article><article class='card'><span>rejected skill candidates</span><strong>2</strong></article><article class='card'><span>failure learning packages</span><strong>1</strong></article><article class='card'><span>skills published to vault</span><strong>2</strong></article><article class='card'><span>agents registered</span><strong>4</strong></article><article class='card'><span>skill import events</span><strong>6</strong></article><article class='card'><span>target agents improved on heldout</span><strong>3</strong></article><article class='card'><span>heldout tasks evaluated</span><strong>5</strong></article><article class='card'><span>B6 shared skill beats B5 no shared skill</span><strong>True</strong></article><article class='card'><span>network skill propagation lift</span><strong>0.0128</strong></article><article class='card'><span>compounding exponent proxy</span><strong>not_supported</strong></article><article class='card'><span>exponential compounding supported</span><strong>False</strong></article><article class='card'><span>replay pass rate</span><strong>1.0</strong></article><article class='card'><span>falsification pass</span><strong>True</strong></article><article class='card'><span>critical safety incidents</span><strong>0</strong></article></div>
+<h2>Skill propagation graph</h2><div class="panel"><p>2 accepted skill package(s), 6 import event(s), and 4 agent manifest(s) are represented in generated JSON.</p></div>
+<h2>Skill table</h2><table><thead><tr><th>skill</th><th>source job</th><th>source agent</th><th>skill type</th><th>ProofBundle</th><th>Evidence Docket</th><th>imported by</th><th>held-out lift</th><th>activation status</th><th>human-review status</th></tr></thead><tbody><tr><td>skill-1</td><td>job-1</td><td>agent-1</td><td>workflow_template</td><td>pb-skill-1</td><td>ed-skill-1</td><td>agent-2, agent-3, agent-4</td><td>0.0128</td><td>sandbox_only</td><td>True</td></tr><tr><td>skill-4</td><td>job-4</td><td>agent-1</td><td>workflow_template</td><td>pb-skill-4</td><td>ed-skill-4</td><td>agent-2, agent-3, agent-4</td><td>0.0128</td><td>sandbox_only</td><td>True</td></tr></tbody></table>
+<div class="panel"><h2>Agent Skill Manifest panel</h2><p>Manifests track native, imported, quarantined, and rejected skills. Imported skills remain inactive outside sandbox by default.</p><pre>[
+  {
+    &quot;activation_status&quot;: &quot;sandbox_registered_inactive_outside_sandbox&quot;,
+    &quot;agent_id&quot;: &quot;agent-1&quot;,
+    &quot;agent_role&quot;: &quot;Reviewer Agent&quot;,
+    &quot;autonomous_persistence_allowed&quot;: false,
+    &quot;claim_boundary&quot;: &quot;local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required&quot;,
+    &quot;human_review_required&quot;: true,
+    &quot;human_review_status&quot;: &quot;pending&quot;,
+    &quot;imported_skills&quot;: [],
+    &quot;last_updated&quot;: &quot;seed-123&quot;,
+    &quot;native_skills&quot;: [],
+    &quot;no_auto_merge&quot;: true,
+    &quot;production_activation_allowed&quot;: false,
+    &quot;quarantined_skills&quot;: [],
+    &quot;regulated_boundary&quot;: &quot;regulated-domain firewall enabled; blocked_human_review_required for regulated tasks&quot;,
+    &quot;rejected_skills&quot;: [],
+    &quot;schema_version&quot;: &quot;agialpha.agent_skill_manifest.v1&quot;,
+    &quot;skill_import_policy&quot;: {
+      &quot;auto_activate_allowed&quot;: false,
+      &quot;auto_import_allowed&quot;: true,
+      &quot;human_review_required_for_activation&quot;: true,
+      &quot;regulated_boundary_block_required&quot;: true
+    },
+    &quot;token_boundary&quot;: &quot;$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading&quot;
+  },
+  {
+    &quot;activation_status&quot;: &quot;sandbox_registered_inactive_outside_sandbox&quot;,
+    &quot;agent_id&quot;: &quot;agent-2&quot;,
+    &quot;agent_role&quot;: &quot;Validator Agent&quot;,
+    &quot;autonomous_persistence_allowed&quot;: false,
+    &quot;claim_boundary&quot;: &quot;local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required&quot;,
+    &quot;human_review_required&quot;: true,
+    &quot;human_review_status&quot;: &quot;pending&quot;,
+    &quot;imported_skills&quot;: [
+      &quot;skill-1&quot;,
+      &quot;skill-4&quot;
+    ],
+    &quot;last_updated&quot;: &quot;seed-123&quot;,
+    &quot;native_skills&quot;: [],
+    &quot;no_auto_merge&quot;: true,
+    &quot;production_activation_allowed&quot;: false,
+    &quot;quarantined_skills&quot;: [],
+    &quot;regulated_boundary&quot;: &quot;regulated-domain firewall enabled; blocked_human_review_required for regulated tasks&quot;,
+    &quot;rejected_skills&quot;: [],
+    &quot;schema_version&quot;: &quot;agialpha.agent_skill_manifest.v1&quot;,
+    &quot;skill_import_policy&quot;: {
+      &quot;auto_activate_allowed&quot;: false,
+      &quot;auto_import_allowed&quot;: true,
+      &quot;human_review_required_for_activation&quot;: true,
+      &quot;regulated_boundary_block_required&quot;: true
+    },
+    &quot;token_boundary&quot;: &quot;$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading&quot;
+  },
+  {
+    &quot;activation_status&quot;: &quot;sandbox_registered_inactive_outside_sandbox&quot;,
+    &quot;agent_id&quot;: &quot;agent-3&quot;,
+    &quot;agent_role&quot;: &quot;Operator Agent&quot;,
+    &quot;autonomous_persistence_allowed&quot;: false,
+    &quot;claim_boundary&quot;: &quot;local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required&quot;,
+    &quot;human_review_required&quot;: true,
+    &quot;human_review_status&quot;: &quot;pending&quot;,
+    &quot;imported_skills&quot;: [
+      &quot;skill-1&quot;,
+      &quot;skill-4&quot;
+    ],
+    &quot;last_updated&quot;: &quot;seed-123&quot;,
+    &quot;native_skills&quot;: [],
+    &quot;no_auto_merge&quot;: true,
+    &quot;production_activation_allowed&quot;: false,
+    &quot;quarantined_skills&quot;: [],
+    &quot;regulated_boundary&quot;: &quot;regulated-domain firewall enabled; blocked_human_review_required for regulated tasks&quot;,
+    &quot;rejected_skills&quot;: [],
+    &quot;schema_version&quot;: &quot;agialpha.agent_skill_manifest.v1&quot;,
+    &quot;skill_import_policy&quot;: {
+      &quot;auto_activate_allowed&quot;: false,
+      &quot;auto_import_allowed&quot;: true,
+      &quot;human_review_required_for_activation&quot;: true,
+      &quot;regulated_boundary_block_required&quot;: true
+    },
+    &quot;token_boundary&quot;: &quot;$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading&quot;
+  }
+]</pre></div>
+<div class="panel"><h2>B6 vs B5 comparison</h2><p>B6 beats B5: <strong>True</strong>; NetworkSkillPropagationLift: <strong>0.0128</strong>. Metrics are computed from raw evaluator logs.</p></div>
+<div class="panel"><h2>Failure learning panel</h2><p>1 Failure Learning Package(s) preserved for reuse, rejection, quarantine, or harder tests.</p></div>
+<div class="panel"><h2>Work Vault / $AGIALPHA utility accounting</h2><p>Synthetic local utility receipts only. No wallet, custody, payment, trading, KYC/AML, money transmission, securities functionality, token price, token value, token appreciation, or investment return.</p><p>2 receipt(s) available.</p></div>
+<div class="panel"><h2>Safety and boundaries</h2><p>Claim boundary, token boundary, regulated-boundary firewall, no auto-merge, no autonomous persistence, and human review remain required.</p></div>
+<div class="panel"><h2>Workflow buttons</h2><p><code>agialpha-engine-003-network-compounding.yml</code> · <code>agialpha-engine-003-network-replay.yml</code> · <code>agialpha-engine-003-network-falsification-audit.yml</code> · <code>agialpha-engine-003-network-claim-gate.yml</code></p></div>
+<div class="panel"><h2>Raw JSON links</h2><p><a href="../../_generated/agialpha-skill-network/summary.json">summary</a> · <a href="../../_generated/agialpha-skill-network/network_skill_metrics.json">metrics</a> · <a href="../../_generated/agialpha-skill-network/claim_gate.json">claim gate</a> · <a href="../../_generated/agialpha-skill-network/skill_packages.json">skill packages</a></p></div>
+<p class="footer">No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</p></main></body></html>

--- a/docs/agialpha-skill-network/generated/routes.json
+++ b/docs/agialpha-skill-network/generated/routes.json
@@ -1,0 +1,14 @@
+{
+  "autonomous_persistence_allowed": false,
+  "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
+  "human_review_required": true,
+  "nav_label": "Skill Network",
+  "no_auto_merge": true,
+  "primary_html": "index.html",
+  "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "routes": [
+    "/agialpha-skill-network/",
+    "/experiments/agialpha-engine-003/"
+  ],
+  "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
+}

--- a/tests/test_agialpha_skill_network_run.py
+++ b/tests/test_agialpha_skill_network_run.py
@@ -406,3 +406,21 @@ def test_validate_fails_when_publication_events_contain_unaccepted_skill():
         proc=subprocess.run(['python','-m','agialpha_engine','network-compounding-validate','--run',str(run)], capture_output=True, text=True)
         assert proc.returncode != 0
         assert 'unaccepted skills present in skill publication events' in (proc.stderr + proc.stdout)
+
+
+def test_registry_run_preserves_proofbundles_and_evidence_dockets():
+    with tempfile.TemporaryDirectory() as td:
+        run=Path(td)/'run'; reg=Path(td)/'reg'
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-run','--repo-root','.','--registry',str(reg),'--out',str(run),'--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        registry_run=reg/'runs'/run.name
+        proof_index=registry_run/'14_proofbundles/index.json'
+        docket_index=registry_run/'15_evidence_dockets/index.json'
+        assert proof_index.exists()
+        assert docket_index.exists()
+        proofbundles=json.loads(proof_index.read_text())['proofbundles']
+        dockets=json.loads(docket_index.read_text())['evidence_dockets']
+        assert proofbundles and dockets
+        assert all((registry_run/'14_proofbundles'/f"{pb['proofbundle_id']}.json").exists() for pb in proofbundles)
+        assert all((registry_run/'15_evidence_dockets'/f"{d['evidence_docket_id']}.json").exists() for d in dockets)


### PR DESCRIPTION
### Motivation
- Ensure Engine-003 run artifacts (ProofBundles and Evidence Dockets) are preserved in the append-only Network Skill Vault registry so public evidence and replay/falsification flows can reference full per-run proof material.
- Make the Skill Network public experience deterministic and self-contained and prevent evidence loss during registry syncs and generated-data publication.
- Add a regression test to assert that both indexed and standalone ProofBundles and Evidence Dockets persist through run→replay→falsification lifecycle.

### Description
- Persist Evidence Dockets into the per-run registry mirror by writing `15_evidence_dockets/index.json` and standalone docket files during both the initial run and the registry sync (updates to `agialpha_engine/network_compounding.py`).
- Emit generated public Skill Network UI/data under `docs/agialpha-skill-network/generated/` including a polished `index.html` and `routes.json` that present the operating thesis, caveat, proof chain, claim gate panel, exponential-compounding status, metrics cards, skill table, and raw-JSON links.
- Add a semantic regression test `test_registry_run_preserves_proofbundles_and_evidence_dockets` to `tests/test_agialpha_skill_network_run.py` that runs the network-compounding flow (run→replay→falsification) and validates the registry `runs/<run_id>/14_proofbundles` and `runs/<run_id>/15_evidence_dockets` artifacts exist and are indexed.
- Keep all safety/boundary controls, sandbox-only activation defaults, no autonomous persistence, and utility-only Work Vault receipts; no hard-coded B6/vRCI or fake metrics were introduced.

### Testing
- Executed the end-to-end network flow and generation commands: `python -m agialpha_engine network-compounding-run ...`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, `network-compounding-build-data`, and `network-compounding-render`, and confirmed the run and registry contain proofbundles and evidence dockets (succeeded).
- Ran the full unit test suite with `python -m unittest discover -s tests` and `pytest -q`; all tests passed (`unittest` and `pytest` runs completed successfully).
- Ran SecureRails helper checks (`scripts/secure_rails_claim_boundary_check.py`, `scripts/secure_rails_no_automerge_check.py`, `scripts/audit_docs_workflows.py`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b03c09710833392ca209b443b670f)