### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/context.py
+++ b/agialpha_engine/context.py
@@ -11,6 +11,15 @@ BOUNDARIES={
   "autonomous_persistence_allowed":False,
 }
 
+def atomic_write_text(path: Path, text: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', dir=str(path.parent), prefix=path.name + '.', suffix='.tmp', delete=False) as f:
+        tmp = Path(f.name)
+        f.write(text)
+    tmp.replace(path)
+
+
 def atomic_write_json(path: Path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
     import tempfile

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import hashlib, json, random
 from pathlib import Path
-from .context import BOUNDARIES, atomic_write_json
+from .context import BOUNDARIES, atomic_write_json, atomic_write_text
 from .network_claim_gate import evaluate_network_compounding_claim
 
 ROLES=["Reviewer Agent","Validator Agent","Operator Agent","Documentation Agent","SecureRails Agent"]
@@ -500,10 +500,14 @@ def _sync_run_to_registry(run: Path, *, publish_latest: bool = True) -> None:
     if validate_report:
         atomic_write_json(run_registry_dir / "20_validate.json", validate_report)
     public_summary_text = (
-        "AGI ALPHA Engine-003 run summary.\n"
+        "# AGI ALPHA Engine-003 run summary\n\n"
+        "Every Job makes an AI Agent smarter. Every new skill can be instantly shared across the network. "
+        "One Agent learns, all Agents level up.\n\n"
+        "Instant sharing means sandboxed registration/importability. Production activation requires validators "
+        "and human review. Exponential compounding is a strategic target unless the exponential claim gate passes.\n\n"
         "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.\n"
     )
-    (run_registry_dir / "19_public_summary.md").write_text(public_summary_text, encoding="utf-8")
+    atomic_write_text(run_registry_dir / "19_public_summary.md", public_summary_text)
     atomic_write_json(run_registry_dir / "evidence-run-manifest.json", {"run_id": run.name, "registry": str(reg), "run": str(run), **_base()})
 
 def run_network_compounding(args):
@@ -1316,5 +1320,5 @@ def render_network_data(args):
 <div class="panel"><h2>Workflow buttons</h2><p><code>agialpha-engine-003-network-compounding.yml</code> · <code>agialpha-engine-003-network-replay.yml</code> · <code>agialpha-engine-003-network-falsification-audit.yml</code> · <code>agialpha-engine-003-network-claim-gate.yml</code></p></div>
 <div class="panel"><h2>Raw JSON links</h2><p><a href="../../_generated/agialpha-skill-network/summary.json">summary</a> · <a href="../../_generated/agialpha-skill-network/network_skill_metrics.json">metrics</a> · <a href="../../_generated/agialpha-skill-network/claim_gate.json">claim gate</a> · <a href="../../_generated/agialpha-skill-network/skill_packages.json">skill packages</a></p></div>
 <p class="footer">No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</p></main></body></html>"""
-    (out / "index.html").write_text(html_text, encoding="utf-8")
+    atomic_write_text(out / "index.html", html_text)
     atomic_write_json(out / "routes.json", {"routes": ["/agialpha-skill-network/", "/experiments/agialpha-engine-003/"], "nav_label": "Skill Network", "primary_html": "index.html", **_base()})

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/19_public_summary.md
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/19_public_summary.md
@@ -1,2 +1,7 @@
-AGI ALPHA Engine-003 run summary.
+# AGI ALPHA Engine-003 run summary
+
+Every Job makes an AI Agent smarter. Every new skill can be instantly shared across the network. One Agent learns, all Agents level up.
+
+Instant sharing means sandboxed registration/importability. Production activation requires validators and human review. Exponential compounding is a strategic target unless the exponential claim gate passes.
+
 Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.


### PR DESCRIPTION
### Motivation
- Ensure Engine-003 produces deterministic, atomic text artifacts for public-facing evidence and to surface the operating thesis and required caveats on the public Skill Network pages.

### Description
- Add `atomic_write_text` to `agialpha_engine/context.py` to provide replace-in-place, deterministic writes for Markdown/HTML artifacts.
- Update `agialpha_engine/network_compounding.py` to use `atomic_write_text` when generating the run `19_public_summary.md` and the public `index.html`, and to include the operating thesis + sandboxed-sharing and exponential-compounding caveats in those outputs.
- Refresh the checked-in run summary `agialpha_skill_network_registry/runs/agialpha-skill-network-test/19_public_summary.md` to include the thesis and bounded-evidence caveat.

### Testing
- Ran the full Engine-003 pipeline `python -m agialpha_engine network-compounding-run` followed by `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, and the pipeline completed successfully.
- Ran unit tests with `python -m unittest discover -s tests` and `pytest -q`, and they both succeeded (all tests passed in this environment).
- Executed SecureRails checks; `scripts/secure_rails_claim_boundary_check.py` and `scripts/secure_rails_no_automerge_check.py` passed, while `scripts/secure_rails_human_review_check.py` failed due to a required positional decision-file argument (expected behavior when no decision file is provided).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b605565d48333976ee15afa197b68)