### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/metrics.py
+++ b/agialpha_engine/metrics.py
@@ -139,7 +139,18 @@ def compute_network_skill_propagation_metrics(
         semantic_tests_passed=semantic_tests_passed,
         safety_counters=safety_counters,
     )
+    reportable_metric_keys = (
+        "D_no_shared_skill_B5",
+        "D_shared_skill_network_B6",
+        "network_skill_propagation_lift",
+    )
     metrics["metrics_computed_from_raw_logs"] = bool(
-        raw_task_result_ids and heldout_rows_b5 and heldout_rows_b6
+        raw_task_result_ids
+        and heldout_rows_b5
+        and heldout_rows_b6
+        and all(
+            type(metrics.get(key)) in (int, float)
+            for key in reportable_metric_keys
+        )
     )
     return metrics

--- a/agialpha_engine/metrics.py
+++ b/agialpha_engine/metrics.py
@@ -88,3 +88,58 @@ def stronger_claim_supported(metrics: dict[str, Any]) -> bool:
     ]
     safety_ok = all(metrics.get(k) == 0 for k in SAFETY_COUNTERS)
     return all(bool_gates) and safety_ok
+
+
+def compute_network_skill_propagation_metrics(
+    *,
+    heldout_rows_b5: list[dict[str, Any]],
+    heldout_rows_b6: list[dict[str, Any]],
+    raw_task_result_ids: list[str],
+    jobs_run: int = 0,
+    jobs_with_skill_extraction: int = 0,
+    accepted_skill_packages: int = 0,
+    rejected_skill_candidates: int = 0,
+    failure_learning_packages: int = 0,
+    skills_published_to_vault: int = 0,
+    agents_registered: int = 0,
+    agent_skill_manifests_created: int | None = None,
+    skill_import_events: int = 0,
+    target_agents_with_imported_skill: int = 0,
+    replay_pass_rate: float | str = "pending",
+    falsification_pass: bool | str = "pending",
+    semantic_tests_passed: bool | str = "pending",
+    safety_counters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Compute ENGINE-003 network-skill propagation metrics from raw held-out rows.
+
+    This adapter keeps the top-level metrics module useful for Engine-003 while
+    delegating the actual D_network and lift formulas to
+    :mod:`agialpha_engine.network_skill_metrics`.  It intentionally requires raw
+    held-out row references and returns ``not_reported`` for incomplete row
+    inputs rather than fabricating zeroes.
+    """
+    from .network_skill_metrics import compute_network_skill_metrics
+
+    metrics = compute_network_skill_metrics(
+        jobs_run=jobs_run,
+        jobs_with_skill_extraction=jobs_with_skill_extraction,
+        accepted_skill_packages=accepted_skill_packages,
+        rejected_skill_candidates=rejected_skill_candidates,
+        failure_learning_packages=failure_learning_packages,
+        skills_published_to_vault=skills_published_to_vault,
+        agents_registered=agents_registered,
+        agent_skill_manifests_created=agent_skill_manifests_created,
+        skill_import_events=skill_import_events,
+        target_agents_with_imported_skill=target_agents_with_imported_skill,
+        heldout_rows_b5=heldout_rows_b5,
+        heldout_rows_b6=heldout_rows_b6,
+        raw_task_result_ids=raw_task_result_ids,
+        replay_pass_rate=replay_pass_rate,
+        falsification_pass=falsification_pass,
+        semantic_tests_passed=semantic_tests_passed,
+        safety_counters=safety_counters,
+    )
+    metrics["metrics_computed_from_raw_logs"] = bool(
+        raw_task_result_ids and heldout_rows_b5 and heldout_rows_b6
+    )
+    return metrics

--- a/agialpha_engine/metrics.py
+++ b/agialpha_engine/metrics.py
@@ -118,7 +118,10 @@ def compute_network_skill_propagation_metrics(
     held-out row references and returns ``not_reported`` for incomplete row
     inputs rather than fabricating zeroes.
     """
-    from .network_skill_metrics import compute_network_skill_metrics
+    from .network_skill_metrics import (
+        _heldout_pair_population_matches,
+        compute_network_skill_metrics,
+    )
 
     metrics = compute_network_skill_metrics(
         jobs_run=jobs_run,
@@ -148,6 +151,7 @@ def compute_network_skill_propagation_metrics(
         raw_task_result_ids
         and heldout_rows_b5
         and heldout_rows_b6
+        and _heldout_pair_population_matches(heldout_rows_b5, heldout_rows_b6)
         and all(
             type(metrics.get(key)) in (int, float)
             for key in reportable_metric_keys

--- a/tests/test_agialpha_network_compounding_metrics.py
+++ b/tests/test_agialpha_network_compounding_metrics.py
@@ -258,6 +258,40 @@ def test_network_skill_metrics_schema_allows_not_reported_manifest_count():
     assert "-1" not in manifest_schema["oneOf"][1]["enum"]
 
 
+def test_top_level_metrics_module_exposes_engine003_network_propagation_adapter():
+    from agialpha_engine.metrics import compute_network_skill_propagation_metrics
+
+    metrics = compute_network_skill_propagation_metrics(
+        jobs_run=5,
+        jobs_with_skill_extraction=5,
+        accepted_skill_packages=1,
+        rejected_skill_candidates=2,
+        failure_learning_packages=2,
+        skills_published_to_vault=1,
+        agents_registered=3,
+        agent_skill_manifests_created=3,
+        skill_import_events=3,
+        target_agents_with_imported_skill=3,
+        heldout_rows_b5=[{
+            "task_id": "heldout-a", "success_score": 0.4, "validator_pass": 1,
+            "replay_pass": 1, "proofbundle": 1, "docket": 1, "cost_risk_proxy": 1,
+        }],
+        heldout_rows_b6=[{
+            "task_id": "heldout-a", "success_score": 0.7, "validator_pass": 1,
+            "replay_pass": 1, "proofbundle": 1, "docket": 1, "cost_risk_proxy": 1,
+        }],
+        raw_task_result_ids=["raw-heldout-a-b5", "raw-heldout-a-b6"],
+    )
+
+    assert metrics["D_no_shared_skill_B5"] == 0.4
+    assert metrics["D_shared_skill_network_B6"] == 0.7
+    assert metrics["network_skill_propagation_lift"] == 0.3
+    assert metrics["B6_shared_skill_beats_B5_no_shared_skill"] is True
+    assert metrics["metrics_computed_from_raw_logs"] is True
+    assert metrics["hard_coded_metric_count"] == 0
+    assert metrics["fake_zero_metric_count"] == 0
+
+
 class NetworkCompoundingNoFixedMetricRegressionTest(unittest.TestCase):
     def test_cli_does_not_reintroduce_fixed_b6_or_vrci_metrics(self):
         """Regression guard for ENGINE-003: no literal B6 win or fixed vRCI shortcuts."""

--- a/tests/test_agialpha_network_compounding_metrics.py
+++ b/tests/test_agialpha_network_compounding_metrics.py
@@ -292,6 +292,30 @@ def test_top_level_metrics_module_exposes_engine003_network_propagation_adapter(
     assert metrics["fake_zero_metric_count"] == 0
 
 
+def test_top_level_metrics_adapter_does_not_badge_incomplete_raw_rows_as_computed():
+    from agialpha_engine.metrics import compute_network_skill_propagation_metrics
+
+    metrics = compute_network_skill_propagation_metrics(
+        jobs_run=5,
+        jobs_with_skill_extraction=5,
+        accepted_skill_packages=1,
+        rejected_skill_candidates=2,
+        failure_learning_packages=2,
+        skills_published_to_vault=1,
+        agents_registered=3,
+        skill_import_events=3,
+        target_agents_with_imported_skill=3,
+        heldout_rows_b5=[{"success_score": 0.4}],
+        heldout_rows_b6=[{"success_score": 0.7}],
+        raw_task_result_ids=["raw-incomplete-b5", "raw-incomplete-b6"],
+    )
+
+    assert metrics["D_no_shared_skill_B5"] == "not_reported"
+    assert metrics["D_shared_skill_network_B6"] == "not_reported"
+    assert metrics["network_skill_propagation_lift"] == "not_reported"
+    assert metrics["metrics_computed_from_raw_logs"] is False
+
+
 class NetworkCompoundingNoFixedMetricRegressionTest(unittest.TestCase):
     def test_cli_does_not_reintroduce_fixed_b6_or_vrci_metrics(self):
         """Regression guard for ENGINE-003: no literal B6 win or fixed vRCI shortcuts."""

--- a/tests/test_agialpha_network_compounding_metrics.py
+++ b/tests/test_agialpha_network_compounding_metrics.py
@@ -316,6 +316,75 @@ def test_top_level_metrics_adapter_does_not_badge_incomplete_raw_rows_as_compute
     assert metrics["metrics_computed_from_raw_logs"] is False
 
 
+def test_top_level_metrics_adapter_does_not_badge_unmatched_heldout_populations_as_computed():
+    from agialpha_engine.metrics import compute_network_skill_propagation_metrics
+
+    complete_b5 = {
+        "task_id": "heldout-a", "success_score": 0.4, "validator_pass": 1,
+        "replay_pass": 1, "proofbundle": 1, "docket": 1, "cost_risk_proxy": 1,
+    }
+    complete_b6 = {
+        "task_id": "heldout-b", "success_score": 0.7, "validator_pass": 1,
+        "replay_pass": 1, "proofbundle": 1, "docket": 1, "cost_risk_proxy": 1,
+    }
+
+    metrics = compute_network_skill_propagation_metrics(
+        jobs_run=5,
+        jobs_with_skill_extraction=5,
+        accepted_skill_packages=1,
+        rejected_skill_candidates=2,
+        failure_learning_packages=2,
+        skills_published_to_vault=1,
+        agents_registered=3,
+        skill_import_events=3,
+        target_agents_with_imported_skill=3,
+        heldout_rows_b5=[complete_b5],
+        heldout_rows_b6=[complete_b6],
+        raw_task_result_ids=["raw-heldout-a-b5", "raw-heldout-b-b6"],
+    )
+
+    assert metrics["D_no_shared_skill_B5"] == 0.4
+    assert metrics["D_shared_skill_network_B6"] == 0.7
+    assert metrics["network_skill_propagation_lift"] == 0.3
+    assert metrics["target_agents_improved_on_heldout"] == "not_reported"
+    assert metrics["metrics_computed_from_raw_logs"] is False
+
+
+def test_top_level_metrics_adapter_does_not_badge_different_row_counts_as_computed():
+    from agialpha_engine.metrics import compute_network_skill_propagation_metrics
+
+    complete_b5 = {
+        "task_id": "heldout-a", "success_score": 0.4, "validator_pass": 1,
+        "replay_pass": 1, "proofbundle": 1, "docket": 1, "cost_risk_proxy": 1,
+    }
+    complete_b6_a = {
+        "task_id": "heldout-a", "success_score": 0.7, "validator_pass": 1,
+        "replay_pass": 1, "proofbundle": 1, "docket": 1, "cost_risk_proxy": 1,
+    }
+    complete_b6_b = {**complete_b6_a, "task_id": "heldout-b", "success_score": 0.8}
+
+    metrics = compute_network_skill_propagation_metrics(
+        jobs_run=5,
+        jobs_with_skill_extraction=5,
+        accepted_skill_packages=1,
+        rejected_skill_candidates=2,
+        failure_learning_packages=2,
+        skills_published_to_vault=1,
+        agents_registered=3,
+        skill_import_events=3,
+        target_agents_with_imported_skill=3,
+        heldout_rows_b5=[complete_b5],
+        heldout_rows_b6=[complete_b6_a, complete_b6_b],
+        raw_task_result_ids=["raw-heldout-a-b5", "raw-heldout-a-b6", "raw-heldout-b-b6"],
+    )
+
+    assert metrics["D_no_shared_skill_B5"] == 0.4
+    assert metrics["D_shared_skill_network_B6"] == 0.75
+    assert metrics["network_skill_propagation_lift"] == 0.35
+    assert metrics["target_agents_improved_on_heldout"] == "not_reported"
+    assert metrics["metrics_computed_from_raw_logs"] is False
+
+
 class NetworkCompoundingNoFixedMetricRegressionTest(unittest.TestCase):
     def test_cli_does_not_reintroduce_fixed_b6_or_vrci_metrics(self):
         """Regression guard for ENGINE-003: no literal B6 win or fixed vRCI shortcuts."""


### PR DESCRIPTION
### Motivation
- Make ENGINE-003 measurable and testable by computing network skill propagation metrics from raw held-out rows rather than relying on hard-coded wins or fixed vRCI values.
- Expose a stable top-level adapter so other engine code and CI tests can compute `NetworkSkillPropagationLift` deterministically from raw B5/B6 rows and preserve `not_reported` semantics for incomplete evidence.

### Description
- Add `compute_network_skill_propagation_metrics` to `agialpha_engine/metrics.py` which delegates D_network and lift computations to `agialpha_engine.network_skill_metrics` and sets `metrics_computed_from_raw_logs` only when raw held-out rows and IDs are present.
- Add a semantic regression test `test_top_level_metrics_module_exposes_engine003_network_propagation_adapter` to `tests/test_agialpha_network_compounding_metrics.py` that verifies D_no_shared_skill, D_shared_skill_network, NetworkSkillPropagationLift, the raw-log provenance flag, and that no hard-coded/fake-zero metric shortcuts are introduced.
- Preserve strict boundary and safety defaults in metrics output (`human_review_required`, `autonomous_persistence_allowed=False`, `no_auto_merge=True`) and continue returning `"not_reported"` when evidence is incomplete.

### Testing
- Ran the end-to-end ENGINE-003 workflow locally with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` and then executed `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`, all of which completed successfully.
- Ran unit test suite with `python -m unittest discover -s tests` and `pytest -q`, and the full test matrix passed (local results: all tests passed; targeted `pytest` run for ENGINE-003 metric tests passed).
- Executed the new metric unit test (`pytest -q tests/test_agialpha_network_compounding_metrics.py`) and it passed, confirming no hard-coded B6/vRCI shortcuts and correct raw-log-derived lift computation.
- Ran SecureRails checks and repository policy scripts where applicable; some standalone SecureRails scripts require invocation arguments and the global policy checker reported existing baseline policy items (these scripts were not weakened).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c675355348333863d14743aad6d7c)