### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -998,7 +998,33 @@ def falsification_network_compounding(args):
 def validate_network_compounding(args):
     run=Path(args.run)
     req=['00_manifest.json','02_jobs/source_jobs.json','02_jobs/raw_task_results.json','02_jobs/sandbox_records.json','03_skill_extraction/accepted_skill_packages.json','03_skill_extraction/rejected_skill_candidates.json','03_skill_extraction/failure_learning_packages.json','05_skill_import/skill_import_events.json','06_heldout_reuse_tests/comparison.json','07_metrics/network_skill_metrics.json','11_replay/replay_report.json','12_falsification/falsification_audit.json','13_claim_gate/network_compounding_claim_gate.json','14_proofbundles/index.json']
-    miss=[x for x in req if not (run/x).exists()]
+    docket_req=[
+        'network-skill-evidence-docket/00_manifest.json',
+        'network-skill-evidence-docket/01_claims_matrix.json',
+        'network-skill-evidence-docket/02_scope_and_claim_boundary.md',
+        'network-skill-evidence-docket/03_token_boundary.md',
+        'network-skill-evidence-docket/04_regulated_boundary.md',
+        'network-skill-evidence-docket/05_source_jobs/source_jobs.json',
+        'network-skill-evidence-docket/06_raw_evaluator_logs/raw_task_results.json',
+        'network-skill-evidence-docket/07_skill_extraction/skill_extraction_report.json',
+        'network-skill-evidence-docket/08_skill_packages/accepted_skill_packages.json',
+        'network-skill-evidence-docket/09_rejected_skill_candidates/rejected_skill_candidates.json',
+        'network-skill-evidence-docket/10_failure_learning_packages/failure_learning_packages.json',
+        'network-skill-evidence-docket/11_network_skill_vault/network_skill_vault.json',
+        'network-skill-evidence-docket/12_agent_skill_manifests/agent_skill_manifests.json',
+        'network-skill-evidence-docket/13_skill_import_events/skill_import_events.json',
+        'network-skill-evidence-docket/14_heldout_reuse_tests/heldout_reuse_tests.json',
+        'network-skill-evidence-docket/15_b6_vs_b5_comparison.json',
+        'network-skill-evidence-docket/16_replay_report.json',
+        'network-skill-evidence-docket/17_falsification_audit.json',
+        'network-skill-evidence-docket/18_safety_ledger.json',
+        'network-skill-evidence-docket/19_cost_ledger.json',
+        'network-skill-evidence-docket/20_network_skill_metrics.json',
+        'network-skill-evidence-docket/21_claim_gate_decision.json',
+        'network-skill-evidence-docket/22_human_review_required.md',
+        'network-skill-evidence-docket/23_next_best_actions.md',
+    ]
+    miss=[x for x in req + docket_req if not (run/x).exists()]
     if miss:
         raise SystemExit(f'missing artifacts: {miss}')
     replay=_read(run/'11_replay/replay_report.json',{})
@@ -1173,6 +1199,7 @@ def validate_network_compounding(args):
         "sandbox_record_integrity_pass": True,
         "network_skill_vault_publication_pass": True,
         "agent_manifest_import_coverage_pass": True,
+        "evidence_docket_required_files_present": len(docket_req),
         **_base(),
     })
     _sync_run_to_registry(run, publish_latest=False)

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -1024,7 +1024,7 @@ def validate_network_compounding(args):
         'network-skill-evidence-docket/22_human_review_required.md',
         'network-skill-evidence-docket/23_next_best_actions.md',
     ]
-    miss=[x for x in req + docket_req if not (run/x).exists()]
+    miss=[x for x in req + docket_req if not (run/x).is_file()]
     if miss:
         raise SystemExit(f'missing artifacts: {miss}')
     replay=_read(run/'11_replay/replay_report.json',{})

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/20_validate.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/20_validate.json
@@ -3,6 +3,7 @@
   "autonomous_persistence_allowed": false,
   "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
   "claim_gate_status": "supported_local_bounded",
+  "evidence_docket_required_files_present": 24,
   "falsification_ok": true,
   "human_review_required": true,
   "network_skill_vault_publication_pass": true,

--- a/tests/test_agialpha_skill_network_run.py
+++ b/tests/test_agialpha_skill_network_run.py
@@ -449,3 +449,16 @@ def test_minimum_validator_requires_every_job_learning_outcome():
         assert validation['validation_pass'] is False
         assert validation['checks']['every_job_produces_exactly_one_learning_outcome'] is False
         assert validation['outcome_counts_by_job']['job-3'] == 0
+
+
+def test_validate_fails_when_evidence_docket_section_missing():
+    with tempfile.TemporaryDirectory() as td:
+        run=Path(td)/'run'; reg=Path(td)/'reg'
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-run','--repo-root','.','--registry',str(reg),'--out',str(run),'--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        missing=run/'network-skill-evidence-docket'/'20_network_skill_metrics.json'
+        missing.unlink()
+        proc=subprocess.run(['python','-m','agialpha_engine','network-compounding-validate','--run',str(run)], capture_output=True, text=True)
+        assert proc.returncode != 0
+        assert 'network-skill-evidence-docket/20_network_skill_metrics.json' in (proc.stderr + proc.stdout)

--- a/tests/test_agialpha_skill_network_run.py
+++ b/tests/test_agialpha_skill_network_run.py
@@ -462,3 +462,17 @@ def test_validate_fails_when_evidence_docket_section_missing():
         proc=subprocess.run(['python','-m','agialpha_engine','network-compounding-validate','--run',str(run)], capture_output=True, text=True)
         assert proc.returncode != 0
         assert 'network-skill-evidence-docket/20_network_skill_metrics.json' in (proc.stderr + proc.stdout)
+
+
+def test_validate_fails_when_evidence_docket_section_is_directory():
+    with tempfile.TemporaryDirectory() as td:
+        run=Path(td)/'run'; reg=Path(td)/'reg'
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-run','--repo-root','.','--registry',str(reg),'--out',str(run),'--jobs','5','--target-agents','3','--heldout-tasks','5','--seed','123'])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        corrupted=run/'network-skill-evidence-docket'/'20_network_skill_metrics.json'
+        corrupted.unlink()
+        corrupted.mkdir()
+        proc=subprocess.run(['python','-m','agialpha_engine','network-compounding-validate','--run',str(run)], capture_output=True, text=True)
+        assert proc.returncode != 0
+        assert 'network-skill-evidence-docket/20_network_skill_metrics.json' in (proc.stderr + proc.stdout)


### PR DESCRIPTION
### Motivation
- Strengthen Engine-003 validation so a run cannot be declared valid while missing pieces of the Network Skill Evidence Docket. 
- Make the evidence-docket completeness visible in the validation artifact so registry entries show that the docket gate was exercised.

### Description
- Harden `validate_network_compounding` to require the full Network Skill Evidence Docket (24 expected docket files under `network-skill-evidence-docket/`) and fail with a clear missing-path message when any docket section is absent. (`agialpha_engine/network_compounding.py`)
- Surface docket completeness in the validation report by adding `evidence_docket_required_files_present` to the generated validate artifact and registry run snapshot. (`agialpha_engine/network_compounding.py`, `agialpha_skill_network_registry/runs/.../20_validate.json`)
- Add a semantic test that removes a required evidence-docket section and asserts `network-compounding-validate` fails with the missing docket path, preventing silent acceptance of incomplete evidence chains. (`tests/test_agialpha_skill_network_run.py`)

### Testing
- Ran the full local Engine-003 workflow end-to-end with: `python -m agialpha_engine network-compounding-run ...`, `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`; the run produced expected registry and generated-data artifacts.
- Executed the repository test suites: `python -m unittest discover -s tests` and `pytest -q`, and observed unit tests and pytest suites pass (existing suites completed; newly added semantic test included).
- Ran SecureRails checks: `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_no_automerge_check.py .`, and `python scripts/secure_rails_trust_center_check.py .` which passed; `python scripts/secure_rails_policy_check.py .` reported pre-existing repository-wide policy violations unrelated to these changes (non-blocking for this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de1dac2ec833391d70e59c5d46a49)