### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -705,7 +705,8 @@ def run_network_compounding(args):
         receipt_target_agents=[i["target_agent_id"] for i in skill_imports if i.get("target_agent_id")]
         import_fee_units=len(skill_imports)
         receipts.append({"schema_version":"agialpha.skill_network.work_vault_receipt.v1","receipt_id":f"receipt-{receipt_index}-{receipt_skill['skill_id']}","skill_id":receipt_skill['skill_id'],"source_job_id":receipt_skill['source_job_id'],"source_agent_id":receipt_skill['source_agent_id'],"target_agent_ids":receipt_target_agents,"covered_import_ids":[i["import_id"] for i in skill_imports if i.get("import_id")],"utility_budget_units":100,"alpha_work_units_estimated":42,"validator_fee_units":8,"replay_fee_units":5,"proofbundle_fee_units":3,"evidence_docket_fee_units":3,"skill_publication_fee_units":2,"skill_import_fee_units":import_fee_units,"unused_budget_refund_units":100-42-8-5-3-3-2-import_fee_units,"settlement_mode":"synthetic_local_json_receipt_only","wallet_used":False,"custody_used":False,"payment_executed":False,"token_price_used":False,"investment_claim_made":False,"receipt_note":"Synthetic local utility receipt only. No wallet, custody, payment, trading, KYC/AML, money transmission, securities functionality, token price, token value, token appreciation, or investment return.",**_base()})
-    atomic_write_json(out/'08_work_vault/skill_work_vault_receipts.json',{"receipts":receipts,"receipt_count":len(receipts),"covered_import_count":sum(len(r.get("covered_import_ids", [])) for r in receipts),**_base()})
+    receipt_ledger_payload = {"schema_version":"agialpha.skill_work_vault_receipts.v1","receipts":receipts,"receipt_count":len(receipts),"covered_import_count":sum(len(r.get("covered_import_ids", [])) for r in receipts),**_base()}
+    atomic_write_json(out/'08_work_vault/skill_work_vault_receipts.json', receipt_ledger_payload)
     pending_replay_report = {"replay_pass": False, "replay_passes": 0, "status": "pending_replay_execution", **_base()}
     pending_falsification_audit = {"falsification_pass": False, "status": "pending_falsification_execution", "adversarial_checks": ["fake skill metric rejected", "forbidden claim injection rejected", "regulated-domain skill blocked", "token-value skill blocked", "raw secret-like string redacted", "auto-merge attempt rejected", "replay mismatch detected", "missing skill evidence detected", "missing ProofBundle detected", "missing Evidence Docket detected", "skill import without ProofBundle/Evidence Docket rejected", "poisoned skill import quarantined"], **_base()}
     proofbundles=[]
@@ -774,7 +775,7 @@ def run_network_compounding(args):
         "16_replay_report.json": pending_replay_report,
         "17_falsification_audit.json": pending_falsification_audit,
         "18_safety_ledger.json": {**derived_safety_counters, **_base()},
-        "19_cost_ledger.json": {"receipts": receipts, "receipt_count": len(receipts), "covered_import_count": sum(len(r.get("covered_import_ids", [])) for r in receipts), **_base()},
+        "19_cost_ledger.json": receipt_ledger_payload,
         "20_network_skill_metrics.json": metrics,
         "21_claim_gate_decision.json": gate,
     }
@@ -787,7 +788,7 @@ def run_network_compounding(args):
     atomic_write_json(out/'13_claim_gate/network_compounding_claim_gate.json',gate)
     atomic_write_json(out/'evidence-run-manifest.json',{"run":str(out),"run_id":run_id,"registry":str(reg),**_base()})
     # registry + generated placeholders
-    atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'skill_propagation_events.json',{"skill_propagation_events":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json',{"receipts":receipts,"receipt_count":len(receipts),"covered_import_count":sum(len(r.get("covered_import_ids", [])) for r in receipts),**_base()}); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()}); atomic_write_json(reg/'proofbundles.json',{"proofbundles":proofbundles,**_base()}); atomic_write_json(reg/'evidence_dockets.json',{"evidence_dockets":dockets,**_base()})
+    atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'skill_propagation_events.json',{"skill_propagation_events":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json', receipt_ledger_payload); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()}); atomic_write_json(reg/'proofbundles.json',{"proofbundles":proofbundles,**_base()}); atomic_write_json(reg/'evidence_dockets.json',{"evidence_dockets":dockets,**_base()})
     existing_registry = _read(reg/'registry.json', {})
     registry_contract = {
         "schema_version":"agialpha.skill_network.registry.v1",
@@ -828,7 +829,7 @@ def run_network_compounding(args):
     atomic_write_json(run_registry_dir / "10_heldout_reuse_tests.json", {"B5_no_shared_skill": b5, "B6_shared_skill_network": b6, **_base()})
     atomic_write_json(run_registry_dir / "11_b6_vs_b5_network_comparison.json", comparison_payload)
     atomic_write_json(run_registry_dir / "12_network_skill_metrics.json", metrics)
-    atomic_write_json(run_registry_dir / "13_work_vault_receipts.json", {"receipts": receipts, "receipt_count": len(receipts), "covered_import_count": sum(len(r.get("covered_import_ids", [])) for r in receipts), **_base()})
+    atomic_write_json(run_registry_dir / "13_work_vault_receipts.json", receipt_ledger_payload)
     atomic_write_json(run_registry_dir / "14_proofbundles" / "index.json", {"proofbundles": proofbundles, **_base()})
     for proofbundle in proofbundles:
         proofbundle_id = proofbundle.get("proofbundle_id")

--- a/agialpha_engine/redaction.py
+++ b/agialpha_engine/redaction.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import secrets
 from typing import Any
 
 PATTERNS = {
@@ -22,8 +23,13 @@ PATTERNS = {
 }
 
 
-def _stable_run_salt(run_id: str, root_hash: str) -> str:
-    """Return a replayable run-scoped salt; reports expose only its hash."""
+def generate_run_redaction_salt() -> str:
+    """Return a per-run random redaction salt; callers must not persist it directly."""
+    return secrets.token_hex(32)
+
+
+def _fallback_run_salt(run_id: str, root_hash: str) -> str:
+    """Return a deterministic fallback salt for legacy callers without run state."""
     return hashlib.sha256(f"{run_id}:{root_hash}:redaction-run-salt".encode()).hexdigest()
 
 
@@ -31,8 +37,8 @@ def _salt_hash(salt: str) -> str:
     return hashlib.sha256(f"{salt}:salt-hash".encode()).hexdigest()
 
 
-def _redact_with_findings(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
-    salt = _stable_run_salt(run_id, root_hash)
+def _redact_with_findings(text: str, run_id: str, root_hash: str, salt: str | None = None) -> tuple[str, list[dict[str, Any]]]:
+    salt = salt or _fallback_run_salt(run_id, root_hash)
     salt_hash = _salt_hash(salt)
     candidates: list[dict[str, Any]] = []
     for name, pattern in PATTERNS.items():
@@ -81,17 +87,22 @@ def _redact_with_findings(text: str, run_id: str, root_hash: str) -> tuple[str, 
     return "".join(redacted_parts), public_findings
 
 
-def redact_text(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
-    redacted, findings = _redact_with_findings(text, run_id, root_hash)
+def redact_text(text: str, run_id: str, root_hash: str, *, salt: str | None = None) -> tuple[str, list[dict[str, Any]]]:
+    redacted, findings = _redact_with_findings(text, run_id, root_hash, salt=salt)
     return redacted, [
         {k: v for k, v in finding.items() if k != "line"}
         for finding in findings
     ]
 
 
-def redact_document(text: str, *, run_id: str, root_hash: str, path: str) -> dict[str, Any]:
-    """Redact a fixture/report while retaining only type/path/line/salted digest metadata."""
-    redacted_text, raw_findings = _redact_with_findings(text, run_id, root_hash)
+def redact_document(text: str, *, run_id: str, root_hash: str, path: str, salt: str | None = None) -> dict[str, Any]:
+    """Redact a fixture/report while retaining only type/path/line/salted digest metadata.
+
+    Engine runs should pass a per-run random salt from ``generate_run_redaction_salt``;
+    legacy callers get a deterministic fallback so replay tests remain stable.  Reports
+    expose only salt hashes and salted digests, never the raw salt or raw secret value.
+    """
+    redacted_text, raw_findings = _redact_with_findings(text, run_id, root_hash, salt=salt)
     findings = [{**finding, "path": path} for finding in raw_findings]
     return {
         "schema_version": "agialpha.engine.redaction_report.v1",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/13_work_vault_receipts.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/13_work_vault_receipts.json
@@ -86,5 +86,6 @@
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.skill_work_vault_receipts.v1",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }

--- a/agialpha_skill_network_registry/work_vault_receipts.json
+++ b/agialpha_skill_network_registry/work_vault_receipts.json
@@ -86,5 +86,6 @@
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.skill_work_vault_receipts.v1",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }

--- a/docs/_generated/agialpha-skill-network/work_vault_receipts.json
+++ b/docs/_generated/agialpha-skill-network/work_vault_receipts.json
@@ -86,5 +86,6 @@
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.skill_work_vault_receipts.v1",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }

--- a/scripts/secure_rails_work_vault_check.py
+++ b/scripts/secure_rails_work_vault_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import json, sys
+import json, re, sys
 from pathlib import Path
 
 FORBIDDEN = ["equity","debt","yield","dividend","ownership","profit right","passive income","guaranteed return","investment return","token appreciation","financial product","claim on revenue","claim on assets"]
@@ -17,18 +17,32 @@ def fail(msg):
     print(f"INVALID: {msg}")
     return 1
 
-def _is_negated_token_boundary_line(line, word):
-    idx = line.find(word)
+NEGATION_MARKERS = ("no", "not", "never", "without", "does not", "must not")
+CLAUSE_DELIMITERS = ";.\n"
+
+def _clause_prefix_before_term(line, idx):
+    clause_start = max(line.rfind(delimiter, 0, idx) for delimiter in CLAUSE_DELIMITERS) + 1
+    return line[clause_start:idx]
+
+def _is_negated_token_boundary_line(line, word, idx=None):
+    if idx is None:
+        idx = line.find(word)
     if idx < 0:
         return False
-    prefix = line[:idx]
-    return any(marker in prefix for marker in ["no ", "not ", "never ", "without ", "does not ", "must not "])
+    prefix = _clause_prefix_before_term(line, idx)
+    return any(re.search(rf"(?:^|\b){re.escape(marker)}(?:\b|\s)", prefix) for marker in NEGATION_MARKERS)
+
+def _has_unnegated_forbidden_term(line, word):
+    for match in re.finditer(re.escape(word), line):
+        if not _is_negated_token_boundary_line(line, word, match.start()):
+            return True
+    return False
 
 def check_forbidden_text(obj):
     lines = [s.lower() for s in walk_strings(obj)]
     for line in lines:
         for w in FORBIDDEN:
-            if w in line and not _is_negated_token_boundary_line(line, w):
+            if _has_unnegated_forbidden_term(line, w):
                 return w
     return None
 

--- a/scripts/secure_rails_work_vault_check.py
+++ b/scripts/secure_rails_work_vault_check.py
@@ -17,10 +17,19 @@ def fail(msg):
     print(f"INVALID: {msg}")
     return 1
 
+def _is_negated_token_boundary_line(line, word):
+    idx = line.find(word)
+    if idx < 0:
+        return False
+    prefix = line[:idx]
+    return any(marker in prefix for marker in ["no ", "not ", "never ", "without ", "does not ", "must not "])
+
 def check_forbidden_text(obj):
-    t="\n".join(s.lower() for s in walk_strings(obj))
-    for w in FORBIDDEN:
-        if w in t: return w
+    lines = [s.lower() for s in walk_strings(obj)]
+    for line in lines:
+        for w in FORBIDDEN:
+            if w in line and not _is_negated_token_boundary_line(line, w):
+                return w
     return None
 
 def main():
@@ -75,6 +84,31 @@ def main():
         if obj.get('human_review_required') is not True: return fail('human_review_required must be true')
         if obj.get('auto_merge_allowed') is not False: return fail('auto_merge_allowed must be false')
         if not obj.get('claim_boundary'): return fail('claim_boundary missing')
+    elif sv in {"agialpha.skill_work_vault_receipt.v1", "agialpha.skill_network.work_vault_receipt.v1"}:
+        receipts = [obj]
+        for receipt in receipts:
+            for field in ["receipt_id", "skill_id", "source_job_id", "source_agent_id", "receipt_note"]:
+                if not receipt.get(field): return fail(f'{field} missing')
+            for field in ["wallet_used", "custody_used", "payment_executed", "token_price_used", "investment_claim_made"]:
+                if receipt.get(field) is not False: return fail(f'{field} must be false')
+            if receipt.get("human_review_required") is not True: return fail('human_review_required must be true')
+            if receipt.get("autonomous_persistence_allowed") is not False: return fail('autonomous_persistence_allowed must be false')
+            if receipt.get("no_auto_merge") is not True: return fail('no_auto_merge must be true')
+            if not receipt.get("claim_boundary"): return fail('claim_boundary missing')
+    elif sv=="agialpha.skill_work_vault_receipts.v1":
+        receipts = obj.get("receipts")
+        if not isinstance(receipts, list) or not receipts: return fail('receipts must be a non-empty array')
+        if obj.get("receipt_count") != len(receipts): return fail('receipt_count mismatch')
+        for receipt in receipts:
+            if not isinstance(receipt, dict): return fail('receipt entries must be objects')
+            for field in ["receipt_id", "skill_id", "source_job_id", "source_agent_id", "receipt_note"]:
+                if not receipt.get(field): return fail(f'{field} missing')
+            for field in ["wallet_used", "custody_used", "payment_executed", "token_price_used", "investment_claim_made"]:
+                if receipt.get(field) is not False: return fail(f'{field} must be false')
+            if receipt.get("human_review_required") is not True: return fail('human_review_required must be true')
+            if receipt.get("autonomous_persistence_allowed") is not False: return fail('autonomous_persistence_allowed must be false')
+            if receipt.get("no_auto_merge") is not True: return fail('no_auto_merge must be true')
+            if not receipt.get("claim_boundary"): return fail('claim_boundary missing')
     else:
         return fail(f'unsupported schema_version: {sv}')
     print(f"OK: {p}")

--- a/tests/test_agialpha_skill_network_redaction.py
+++ b/tests/test_agialpha_skill_network_redaction.py
@@ -1,4 +1,4 @@
-from agialpha_engine.redaction import redact_document, redact_text
+from agialpha_engine.redaction import generate_run_redaction_salt, redact_document, redact_text
 
 
 def test_network_redaction_report_stores_salt_hash_not_raw_secret():
@@ -39,3 +39,17 @@ contact reviewer@example.com
     assert private_key_findings[0]["line"] == 2
     assert private_key_findings[0]["path"] == "fixture.pem"
     assert all("raw-private-key-material" not in str(finding) for finding in report["findings"])
+
+
+def test_network_redaction_supports_per_run_random_salt_without_storing_it():
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+    salt_a = generate_run_redaction_salt()
+    salt_b = generate_run_redaction_salt()
+    assert salt_a != salt_b
+    report_a = redact_document(secret, run_id="run-003", root_hash="root", path="fixture.txt", salt=salt_a)
+    report_b = redact_document(secret, run_id="run-003", root_hash="root", path="fixture.txt", salt=salt_b)
+    assert secret not in str(report_a)
+    assert secret not in str(report_b)
+    assert report_a["findings"][0]["salt_hash"] != report_b["findings"][0]["salt_hash"]
+    assert salt_a not in str(report_a)
+    assert salt_b not in str(report_b)

--- a/tests/test_secure_rails_work_vault_check.py
+++ b/tests/test_secure_rails_work_vault_check.py
@@ -21,6 +21,27 @@ class T(unittest.TestCase):
         obj['hard_safety_counters']['exploit_execution_count']=1
         self.assertNotEqual(self.run_check(obj).returncode,0)
 
+
+    def test_unrelated_negated_clause_does_not_hide_later_forbidden_claim(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='No token appreciation; grants equity to holders.'
+        r=self.run_check(obj)
+        self.assertNotEqual(r.returncode,0)
+        self.assertIn('forbidden token language: equity',r.stdout)
+
+    def test_repeated_term_after_negated_clause_still_fails(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='No equity rights; equity grants are available.'
+        r=self.run_check(obj)
+        self.assertNotEqual(r.returncode,0)
+        self.assertIn('forbidden token language: equity',r.stdout)
+
+    def test_negated_utility_boundary_list_remains_allowed(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='No token appreciation, investment return, equity, debt, yield, dividends, or ownership rights.'
+        r=self.run_check(obj)
+        self.assertEqual(r.returncode,0,r.stdout+r.stderr)
+
     def test_mark_validators_required_must_be_array(self):
         obj=json.loads(Path('docs/secure-rails/templates/mark-allocation-example.json').read_text())
         obj['validators_required']='claim_boundary_validator'


### PR DESCRIPTION
### Motivation
- Ensure Work Vault receipts are explicit, schema-versioned, and clearly utility-only so $AGIALPHA accounting remains non-financial and auditable.
- Strengthen redaction so per-run random salts are supported for replayable redaction digests while preserving deterministic fallbacks for legacy replayability.
- Harden SecureRails work-vault checks to validate receipt payloads and avoid false positives for explicitly negated token-boundary language.

### Description
- Introduced an aggregate schema-backed receipts ledger (`receipt_ledger_payload`) and write it into run artifacts, registry mirrors, evidence dockets, and generated docs so work-vault receipts carry `schema_version: "agialpha.skill_work_vault_receipts.v1"` and remain utility-only.
- Extended redaction in `agialpha_engine/redaction.py` with `generate_run_redaction_salt()` and a deterministic fallback salt, and added optional `salt` parameters to `redact_text()` and `redact_document()` so runs can use per-run salts while reports continue to expose only salt hashes and salted digests.
- Updated `scripts/secure_rails_work_vault_check.py` to validate single receipts and aggregated receipt ledgers, to enforce `wallet_used/custody_used/payment_executed/token_price_used/investment_claim_made` are `false`, and to tolerate explicitly negated token-boundary phrasing to avoid false positives.
- Added a semantic test for redaction (`tests/test_agialpha_skill_network_redaction.py`) that verifies per-run salts differ, secrets are redacted, salt-hashes differ between salts, and raw salts are not stored; regenerated registry and generated-data artifacts under `agialpha_skill_network_registry/` and `docs/_generated/agialpha-skill-network/` to include the new receipts payload.

### Testing
- Ran the full local Engine-003 workflow commands `python -m agialpha_engine network-compounding-run`, `python -m agialpha_engine network-compounding-replay`, `python -m agialpha_engine network-compounding-falsification-audit`, `python -m agialpha_engine network-compounding-validate`, and `python -m agialpha_engine network-compounding-build-data`, which completed successfully.
- Executed SecureRails checks `python scripts/secure_rails_claim_boundary_check.py .`, `python scripts/secure_rails_no_automerge_check.py .`, `python scripts/secure_rails_trust_center_check.py .`, `python scripts/check_pages_architecture.py`, `python scripts/audit_docs_workflows.py`, and the updated `python scripts/secure_rails_work_vault_check.py <path>` which passed for the produced receipts payloads.
- Unit test suite passed with `python -m unittest discover -s tests` and `pytest -q` completed successfully (736 passed), and targeted semantic tests for redaction and receipts passed (`pytest tests/test_agialpha_skill_network_redaction.py tests/test_agialpha_skill_work_vault_receipts.py` both passed).
- One repo-wide SecureRails policy scan (`python scripts/secure_rails_policy_check.py .`) reported existing policy violations unrelated to these changes and thus returned a nonzero result (noted as a repo-level audit finding to triage separately).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0180e46483338bfb37c59f0962ca)