### PR TITLE
Add per-run redaction salt, normalize receipts ledger payload, and strengthen vault validation

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -705,7 +705,8 @@ def run_network_compounding(args):
         receipt_target_agents=[i["target_agent_id"] for i in skill_imports if i.get("target_agent_id")]
         import_fee_units=len(skill_imports)
         receipts.append({"schema_version":"agialpha.skill_network.work_vault_receipt.v1","receipt_id":f"receipt-{receipt_index}-{receipt_skill['skill_id']}","skill_id":receipt_skill['skill_id'],"source_job_id":receipt_skill['source_job_id'],"source_agent_id":receipt_skill['source_agent_id'],"target_agent_ids":receipt_target_agents,"covered_import_ids":[i["import_id"] for i in skill_imports if i.get("import_id")],"utility_budget_units":100,"alpha_work_units_estimated":42,"validator_fee_units":8,"replay_fee_units":5,"proofbundle_fee_units":3,"evidence_docket_fee_units":3,"skill_publication_fee_units":2,"skill_import_fee_units":import_fee_units,"unused_budget_refund_units":100-42-8-5-3-3-2-import_fee_units,"settlement_mode":"synthetic_local_json_receipt_only","wallet_used":False,"custody_used":False,"payment_executed":False,"token_price_used":False,"investment_claim_made":False,"receipt_note":"Synthetic local utility receipt only. No wallet, custody, payment, trading, KYC/AML, money transmission, securities functionality, token price, token value, token appreciation, or investment return.",**_base()})
-    atomic_write_json(out/'08_work_vault/skill_work_vault_receipts.json',{"receipts":receipts,"receipt_count":len(receipts),"covered_import_count":sum(len(r.get("covered_import_ids", [])) for r in receipts),**_base()})
+    receipt_ledger_payload = {"schema_version":"agialpha.skill_work_vault_receipts.v1","receipts":receipts,"receipt_count":len(receipts),"covered_import_count":sum(len(r.get("covered_import_ids", [])) for r in receipts),**_base()}
+    atomic_write_json(out/'08_work_vault/skill_work_vault_receipts.json', receipt_ledger_payload)
     pending_replay_report = {"replay_pass": False, "replay_passes": 0, "status": "pending_replay_execution", **_base()}
     pending_falsification_audit = {"falsification_pass": False, "status": "pending_falsification_execution", "adversarial_checks": ["fake skill metric rejected", "forbidden claim injection rejected", "regulated-domain skill blocked", "token-value skill blocked", "raw secret-like string redacted", "auto-merge attempt rejected", "replay mismatch detected", "missing skill evidence detected", "missing ProofBundle detected", "missing Evidence Docket detected", "skill import without ProofBundle/Evidence Docket rejected", "poisoned skill import quarantined"], **_base()}
     proofbundles=[]
@@ -774,7 +775,7 @@ def run_network_compounding(args):
         "16_replay_report.json": pending_replay_report,
         "17_falsification_audit.json": pending_falsification_audit,
         "18_safety_ledger.json": {**derived_safety_counters, **_base()},
-        "19_cost_ledger.json": {"receipts": receipts, "receipt_count": len(receipts), "covered_import_count": sum(len(r.get("covered_import_ids", [])) for r in receipts), **_base()},
+        "19_cost_ledger.json": receipt_ledger_payload,
         "20_network_skill_metrics.json": metrics,
         "21_claim_gate_decision.json": gate,
     }
@@ -787,7 +788,7 @@ def run_network_compounding(args):
     atomic_write_json(out/'13_claim_gate/network_compounding_claim_gate.json',gate)
     atomic_write_json(out/'evidence-run-manifest.json',{"run":str(out),"run_id":run_id,"registry":str(reg),**_base()})
     # registry + generated placeholders
-    atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'skill_propagation_events.json',{"skill_propagation_events":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json',{"receipts":receipts,"receipt_count":len(receipts),"covered_import_count":sum(len(r.get("covered_import_ids", [])) for r in receipts),**_base()}); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()}); atomic_write_json(reg/'proofbundles.json',{"proofbundles":proofbundles,**_base()}); atomic_write_json(reg/'evidence_dockets.json',{"evidence_dockets":dockets,**_base()})
+    atomic_write_json(reg/'latest.json',{"run_id":run_id,**_base()}); atomic_write_json(reg/'agents.json',{"agents":agents,**_base()}); atomic_write_json(reg/'agent_skill_manifests.json',{"manifests":manifests,**_base()}); atomic_write_json(reg/'skill_packages.json',{"skill_packages":accepted,**_base()}); atomic_write_json(reg/'rejected_skill_candidates.json',{"rejected_skill_candidates":rejected,**_base()}); atomic_write_json(reg/'failure_learning_packages.json',{"failure_learning_packages":failure,**_base()}); atomic_write_json(reg/'skill_imports.json',{"skill_imports":imports,**_base()}); atomic_write_json(reg/'skill_propagation_events.json',{"skill_propagation_events":imports,**_base()}); atomic_write_json(reg/'network_skill_metrics.json',metrics); atomic_write_json(reg/'claim_gate_decisions.json',gate); atomic_write_json(reg/'work_vault_receipts.json', receipt_ledger_payload); atomic_write_json(reg/'lineage_graph.json',{"edges":[{"from":s['source_job_id'],"to":s['skill_id']} for s in accepted],**_base()}); atomic_write_json(reg/'proofbundles.json',{"proofbundles":proofbundles,**_base()}); atomic_write_json(reg/'evidence_dockets.json',{"evidence_dockets":dockets,**_base()})
     existing_registry = _read(reg/'registry.json', {})
     registry_contract = {
         "schema_version":"agialpha.skill_network.registry.v1",
@@ -828,7 +829,7 @@ def run_network_compounding(args):
     atomic_write_json(run_registry_dir / "10_heldout_reuse_tests.json", {"B5_no_shared_skill": b5, "B6_shared_skill_network": b6, **_base()})
     atomic_write_json(run_registry_dir / "11_b6_vs_b5_network_comparison.json", comparison_payload)
     atomic_write_json(run_registry_dir / "12_network_skill_metrics.json", metrics)
-    atomic_write_json(run_registry_dir / "13_work_vault_receipts.json", {"receipts": receipts, "receipt_count": len(receipts), "covered_import_count": sum(len(r.get("covered_import_ids", [])) for r in receipts), **_base()})
+    atomic_write_json(run_registry_dir / "13_work_vault_receipts.json", receipt_ledger_payload)
     atomic_write_json(run_registry_dir / "14_proofbundles" / "index.json", {"proofbundles": proofbundles, **_base()})
     for proofbundle in proofbundles:
         proofbundle_id = proofbundle.get("proofbundle_id")

--- a/agialpha_engine/redaction.py
+++ b/agialpha_engine/redaction.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import secrets
 from typing import Any
 
 PATTERNS = {
@@ -22,8 +23,13 @@ PATTERNS = {
 }
 
 
-def _stable_run_salt(run_id: str, root_hash: str) -> str:
-    """Return a replayable run-scoped salt; reports expose only its hash."""
+def generate_run_redaction_salt() -> str:
+    """Return a per-run random redaction salt; callers must not persist it directly."""
+    return secrets.token_hex(32)
+
+
+def _fallback_run_salt(run_id: str, root_hash: str) -> str:
+    """Return a deterministic fallback salt for legacy callers without run state."""
     return hashlib.sha256(f"{run_id}:{root_hash}:redaction-run-salt".encode()).hexdigest()
 
 
@@ -31,8 +37,8 @@ def _salt_hash(salt: str) -> str:
     return hashlib.sha256(f"{salt}:salt-hash".encode()).hexdigest()
 
 
-def _redact_with_findings(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
-    salt = _stable_run_salt(run_id, root_hash)
+def _redact_with_findings(text: str, run_id: str, root_hash: str, salt: str | None = None) -> tuple[str, list[dict[str, Any]]]:
+    salt = salt or _fallback_run_salt(run_id, root_hash)
     salt_hash = _salt_hash(salt)
     candidates: list[dict[str, Any]] = []
     for name, pattern in PATTERNS.items():
@@ -81,17 +87,22 @@ def _redact_with_findings(text: str, run_id: str, root_hash: str) -> tuple[str, 
     return "".join(redacted_parts), public_findings
 
 
-def redact_text(text: str, run_id: str, root_hash: str) -> tuple[str, list[dict[str, Any]]]:
-    redacted, findings = _redact_with_findings(text, run_id, root_hash)
+def redact_text(text: str, run_id: str, root_hash: str, *, salt: str | None = None) -> tuple[str, list[dict[str, Any]]]:
+    redacted, findings = _redact_with_findings(text, run_id, root_hash, salt=salt)
     return redacted, [
         {k: v for k, v in finding.items() if k != "line"}
         for finding in findings
     ]
 
 
-def redact_document(text: str, *, run_id: str, root_hash: str, path: str) -> dict[str, Any]:
-    """Redact a fixture/report while retaining only type/path/line/salted digest metadata."""
-    redacted_text, raw_findings = _redact_with_findings(text, run_id, root_hash)
+def redact_document(text: str, *, run_id: str, root_hash: str, path: str, salt: str | None = None) -> dict[str, Any]:
+    """Redact a fixture/report while retaining only type/path/line/salted digest metadata.
+
+    Engine runs should pass a per-run random salt from ``generate_run_redaction_salt``;
+    legacy callers get a deterministic fallback so replay tests remain stable.  Reports
+    expose only salt hashes and salted digests, never the raw salt or raw secret value.
+    """
+    redacted_text, raw_findings = _redact_with_findings(text, run_id, root_hash, salt=salt)
     findings = [{**finding, "path": path} for finding in raw_findings]
     return {
         "schema_version": "agialpha.engine.redaction_report.v1",

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/13_work_vault_receipts.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/13_work_vault_receipts.json
@@ -86,5 +86,6 @@
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.skill_work_vault_receipts.v1",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }

--- a/agialpha_skill_network_registry/work_vault_receipts.json
+++ b/agialpha_skill_network_registry/work_vault_receipts.json
@@ -86,5 +86,6 @@
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.skill_work_vault_receipts.v1",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }

--- a/docs/_generated/agialpha-skill-network/work_vault_receipts.json
+++ b/docs/_generated/agialpha-skill-network/work_vault_receipts.json
@@ -86,5 +86,6 @@
     }
   ],
   "regulated_boundary": "regulated-domain firewall enabled; blocked_human_review_required for regulated tasks",
+  "schema_version": "agialpha.skill_work_vault_receipts.v1",
   "token_boundary": "$AGIALPHA utility-only accounting; no wallet/custody/payment/KYC/AML/trading"
 }

--- a/scripts/secure_rails_work_vault_check.py
+++ b/scripts/secure_rails_work_vault_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import json, sys
+import json, re, sys
 from pathlib import Path
 
 FORBIDDEN = ["equity","debt","yield","dividend","ownership","profit right","passive income","guaranteed return","investment return","token appreciation","financial product","claim on revenue","claim on assets"]
@@ -17,10 +17,32 @@ def fail(msg):
     print(f"INVALID: {msg}")
     return 1
 
+NEGATION_MARKERS = ("no", "not", "never", "without", "does not", "must not")
+NEGATION_CLAUSE_DELIMITERS = ".;\n"
+
+def _term_pattern(word):
+    return re.compile(r"(?<![a-z0-9])" + re.escape(word) + r"(?![a-z0-9])")
+
+def _is_negated_token_boundary_occurrence(line, start):
+    """Return true only when the forbidden term is negated in its own clause.
+
+    Negation markers from an earlier sentence or semicolon-separated clause must
+    not clear a later positive forbidden claim such as
+    ``No token appreciation; grants equity to holders``.  Commas are not clause
+    delimiters here because utility-only receipts use comma-separated lists like
+    ``No wallet, custody, ..., token appreciation, or investment return``.
+    """
+    clause_start = max(line.rfind(delimiter, 0, start) for delimiter in NEGATION_CLAUSE_DELIMITERS) + 1
+    prefix = line[clause_start:start]
+    return any(re.search(r"(?<![a-z0-9])" + re.escape(marker) + r"(?![a-z0-9])", prefix) for marker in NEGATION_MARKERS)
+
 def check_forbidden_text(obj):
-    t="\n".join(s.lower() for s in walk_strings(obj))
-    for w in FORBIDDEN:
-        if w in t: return w
+    lines = [s.lower() for s in walk_strings(obj)]
+    for line in lines:
+        for w in FORBIDDEN:
+            for match in _term_pattern(w).finditer(line):
+                if not _is_negated_token_boundary_occurrence(line, match.start()):
+                    return w
     return None
 
 def main():
@@ -75,6 +97,31 @@ def main():
         if obj.get('human_review_required') is not True: return fail('human_review_required must be true')
         if obj.get('auto_merge_allowed') is not False: return fail('auto_merge_allowed must be false')
         if not obj.get('claim_boundary'): return fail('claim_boundary missing')
+    elif sv in {"agialpha.skill_work_vault_receipt.v1", "agialpha.skill_network.work_vault_receipt.v1"}:
+        receipts = [obj]
+        for receipt in receipts:
+            for field in ["receipt_id", "skill_id", "source_job_id", "source_agent_id", "receipt_note"]:
+                if not receipt.get(field): return fail(f'{field} missing')
+            for field in ["wallet_used", "custody_used", "payment_executed", "token_price_used", "investment_claim_made"]:
+                if receipt.get(field) is not False: return fail(f'{field} must be false')
+            if receipt.get("human_review_required") is not True: return fail('human_review_required must be true')
+            if receipt.get("autonomous_persistence_allowed") is not False: return fail('autonomous_persistence_allowed must be false')
+            if receipt.get("no_auto_merge") is not True: return fail('no_auto_merge must be true')
+            if not receipt.get("claim_boundary"): return fail('claim_boundary missing')
+    elif sv=="agialpha.skill_work_vault_receipts.v1":
+        receipts = obj.get("receipts")
+        if not isinstance(receipts, list) or not receipts: return fail('receipts must be a non-empty array')
+        if obj.get("receipt_count") != len(receipts): return fail('receipt_count mismatch')
+        for receipt in receipts:
+            if not isinstance(receipt, dict): return fail('receipt entries must be objects')
+            for field in ["receipt_id", "skill_id", "source_job_id", "source_agent_id", "receipt_note"]:
+                if not receipt.get(field): return fail(f'{field} missing')
+            for field in ["wallet_used", "custody_used", "payment_executed", "token_price_used", "investment_claim_made"]:
+                if receipt.get(field) is not False: return fail(f'{field} must be false')
+            if receipt.get("human_review_required") is not True: return fail('human_review_required must be true')
+            if receipt.get("autonomous_persistence_allowed") is not False: return fail('autonomous_persistence_allowed must be false')
+            if receipt.get("no_auto_merge") is not True: return fail('no_auto_merge must be true')
+            if not receipt.get("claim_boundary"): return fail('claim_boundary missing')
     else:
         return fail(f'unsupported schema_version: {sv}')
     print(f"OK: {p}")

--- a/scripts/secure_rails_work_vault_check.py
+++ b/scripts/secure_rails_work_vault_check.py
@@ -17,24 +17,40 @@ def fail(msg):
     print(f"INVALID: {msg}")
     return 1
 
-NEGATION_MARKERS = ("no", "not", "never", "without", "does not", "must not")
+NEGATION_MARKERS = ("does not", "must not", "without", "never", "not", "no")
 NEGATION_CLAUSE_DELIMITERS = ".;\n"
+NEGATED_LIST_CONNECTOR_RE = re.compile(r"(?<![a-z0-9])(?:grants?|gives?|issues?|offers?|provides?|promises?|pays?|earns?|receives?|conveys?|creates?|includes?|entitles?)\b")
 
 def _term_pattern(word):
     return re.compile(r"(?<![a-z0-9])" + re.escape(word) + r"(?![a-z0-9])")
 
-def _is_negated_token_boundary_occurrence(line, start):
-    """Return true only when the forbidden term is negated in its own clause.
+def _marker_pattern(marker):
+    return re.compile(r"(?<![a-z0-9])" + re.escape(marker) + r"(?![a-z0-9])")
 
-    Negation markers from an earlier sentence or semicolon-separated clause must
-    not clear a later positive forbidden claim such as
-    ``No token appreciation; grants equity to holders``.  Commas are not clause
-    delimiters here because utility-only receipts use comma-separated lists like
-    ``No wallet, custody, ..., token appreciation, or investment return``.
+def _marker_negates_term(marker, marker_end, line, start):
+    span = line[marker_end:start]
+    if marker in {"does not", "must not", "never"}:
+        return len(span) <= 96
+    if NEGATED_LIST_CONNECTOR_RE.search(span):
+        return False
+    return len(span) <= 160
+
+def _is_negated_token_boundary_occurrence(line, start):
+    """Return true only when the forbidden term is negated by a governing marker.
+
+    Negation markers from an earlier sentence, semicolon-delimited clause, or an
+    unrelated comma item must not clear a later positive forbidden claim such as
+    ``No wallet, grants equity to holders``.  Utility-only receipts still allow
+    comma-separated negative lists such as ``No wallet, ..., token appreciation``.
     """
     clause_start = max(line.rfind(delimiter, 0, start) for delimiter in NEGATION_CLAUSE_DELIMITERS) + 1
     prefix = line[clause_start:start]
-    return any(re.search(r"(?<![a-z0-9])" + re.escape(marker) + r"(?![a-z0-9])", prefix) for marker in NEGATION_MARKERS)
+    for marker in NEGATION_MARKERS:
+        matches = list(_marker_pattern(marker).finditer(prefix))
+        for match in reversed(matches):
+            if _marker_negates_term(marker, clause_start + match.end(), line, start):
+                return True
+    return False
 
 def check_forbidden_text(obj):
     lines = [s.lower() for s in walk_strings(obj)]

--- a/scripts/secure_rails_work_vault_check.py
+++ b/scripts/secure_rails_work_vault_check.py
@@ -20,6 +20,7 @@ def fail(msg):
 NEGATION_MARKERS = ("does not", "must not", "without", "never", "not", "no")
 NEGATION_CLAUSE_DELIMITERS = ".;\n"
 NEGATED_LIST_CONNECTOR_RE = re.compile(r"(?<![a-z0-9])(?:grants?|gives?|issues?|offers?|provides?|promises?|pays?|earns?|receives?|conveys?|creates?|includes?|entitles?)\b")
+POSITIVE_BARE_NEGATION_RE = re.compile(r"^\s*(?:only|just|merely|solely|also)\b")
 
 def _term_pattern(word):
     return re.compile(r"(?<![a-z0-9])" + re.escape(word) + r"(?![a-z0-9])")
@@ -31,6 +32,8 @@ def _marker_negates_term(marker, marker_end, line, start):
     span = line[marker_end:start]
     if marker in {"does not", "must not", "never"}:
         return len(span) <= 96
+    if marker == "not" and POSITIVE_BARE_NEGATION_RE.search(span):
+        return False
     if NEGATED_LIST_CONNECTOR_RE.search(span):
         return False
     return len(span) <= 160

--- a/tests/test_agialpha_skill_network_redaction.py
+++ b/tests/test_agialpha_skill_network_redaction.py
@@ -1,4 +1,4 @@
-from agialpha_engine.redaction import redact_document, redact_text
+from agialpha_engine.redaction import generate_run_redaction_salt, redact_document, redact_text
 
 
 def test_network_redaction_report_stores_salt_hash_not_raw_secret():
@@ -39,3 +39,17 @@ contact reviewer@example.com
     assert private_key_findings[0]["line"] == 2
     assert private_key_findings[0]["path"] == "fixture.pem"
     assert all("raw-private-key-material" not in str(finding) for finding in report["findings"])
+
+
+def test_network_redaction_supports_per_run_random_salt_without_storing_it():
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+    salt_a = generate_run_redaction_salt()
+    salt_b = generate_run_redaction_salt()
+    assert salt_a != salt_b
+    report_a = redact_document(secret, run_id="run-003", root_hash="root", path="fixture.txt", salt=salt_a)
+    report_b = redact_document(secret, run_id="run-003", root_hash="root", path="fixture.txt", salt=salt_b)
+    assert secret not in str(report_a)
+    assert secret not in str(report_b)
+    assert report_a["findings"][0]["salt_hash"] != report_b["findings"][0]["salt_hash"]
+    assert salt_a not in str(report_a)
+    assert salt_b not in str(report_b)

--- a/tests/test_secure_rails_work_vault_check.py
+++ b/tests/test_secure_rails_work_vault_check.py
@@ -64,6 +64,19 @@ class T(unittest.TestCase):
         self.assertNotEqual(r.returncode,0)
         self.assertIn('forbidden token language: equity',r.stdout)
 
+    def test_unrelated_comma_negation_does_not_clear_positive_forbidden_claim(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='No wallet, grants equity to holders'
+        r=self.run_check(obj)
+        self.assertNotEqual(r.returncode,0)
+        self.assertIn('forbidden token language: equity',r.stdout)
+
+    def test_direct_verb_negation_can_clear_forbidden_term(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='Utility-only accounting does not grant equity to holders'
+        r=self.run_check(obj)
+        self.assertEqual(r.returncode,0,r.stdout+r.stderr)
+
     def test_utility_only_negated_receipt_note_passes_forbidden_text_check(self):
         obj={
             'schema_version':'agialpha.skill_network.work_vault_receipt.v1',

--- a/tests/test_secure_rails_work_vault_check.py
+++ b/tests/test_secure_rails_work_vault_check.py
@@ -77,6 +77,20 @@ class T(unittest.TestCase):
         r=self.run_check(obj)
         self.assertEqual(r.returncode,0,r.stdout+r.stderr)
 
+    def test_not_only_positive_construction_does_not_negate_forbidden_claim(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='This work offers not only equity but also dividend rights to holders.'
+        r=self.run_check(obj)
+        self.assertNotEqual(r.returncode,0)
+        self.assertIn('forbidden token language: equity',r.stdout)
+
+    def test_not_only_single_forbidden_term_fails_without_second_term(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='This work offers not only dividend rights to holders.'
+        r=self.run_check(obj)
+        self.assertNotEqual(r.returncode,0)
+        self.assertIn('forbidden token language: dividend',r.stdout)
+
     def test_utility_only_negated_receipt_note_passes_forbidden_text_check(self):
         obj={
             'schema_version':'agialpha.skill_network.work_vault_receipt.v1',

--- a/tests/test_secure_rails_work_vault_check.py
+++ b/tests/test_secure_rails_work_vault_check.py
@@ -56,3 +56,31 @@ class T(unittest.TestCase):
             obj=json.loads(json.dumps(base))
             obj.pop(field,None)
             self.assertNotEqual(self.run_check(obj).returncode,0)
+
+    def test_negated_clause_does_not_clear_later_positive_forbidden_claim(self):
+        obj=json.loads(Path('docs/secure-rails/templates/work-vault-example.json').read_text())
+        obj['claim_boundary']='No token appreciation; grants equity to holders'
+        r=self.run_check(obj)
+        self.assertNotEqual(r.returncode,0)
+        self.assertIn('forbidden token language: equity',r.stdout)
+
+    def test_utility_only_negated_receipt_note_passes_forbidden_text_check(self):
+        obj={
+            'schema_version':'agialpha.skill_network.work_vault_receipt.v1',
+            'receipt_id':'receipt-test',
+            'skill_id':'skill-test',
+            'source_job_id':'job-test',
+            'source_agent_id':'agent-test',
+            'receipt_note':'Synthetic local utility receipt only. No wallet, custody, payment, trading, KYC/AML, money transmission, securities functionality, token price, token value, token appreciation, or investment return.',
+            'wallet_used':False,
+            'custody_used':False,
+            'payment_executed':False,
+            'token_price_used':False,
+            'investment_claim_made':False,
+            'human_review_required':True,
+            'autonomous_persistence_allowed':False,
+            'no_auto_merge':True,
+            'claim_boundary':'local bounded public evidence'
+        }
+        r=self.run_check(obj)
+        self.assertEqual(r.returncode,0,r.stdout+r.stderr)


### PR DESCRIPTION
### Motivation

- Ensure receipts are emitted with a single, explicit receipts-ledger schema and reused across outputs for consistency.
- Support per-run random redaction salts so replayable runs can redact secrets without storing raw salts while preserving replayable digests.
- Harden the secure rails work-vault checker to correctly detect forbidden token language in complex clauses and to validate receipt schemas.

### Description

- Create `receipt_ledger_payload` in `network_compounding.py` with schema version `agialpha.skill_work_vault_receipts.v1` and replace multiple inline receipts payload writes to reuse that payload for registry, docket, and run outputs.
- Add `generate_run_redaction_salt()` to `agialpha_engine/redaction.py` and accept an optional `salt` parameter in `redact_text` and `redact_document`; keep a deterministic `_fallback_run_salt` for legacy/replay cases and ensure docstrings clarify that raw salts are not persisted in reports.
- Improve `scripts/secure_rails_work_vault_check.py` with negation-aware clause detection for forbidden terms, stricter term boundary matching, and added validation branches for `agialpha.skill_work_vault_receipt.v1` and `agialpha.skill_work_vault_receipts.v1` schema rules.
- Update generated/sample JSON files and tests to reflect the new receipts ledger schema and the redaction salt API, and add tests exercising negation handling and per-run random salt usage.

### Testing

- Ran the test suite including `tests/test_agialpha_skill_network_redaction.py` and `tests/test_secure_rails_work_vault_check.py` which exercise redaction salt behavior and vault/receipt validation, and all tests passed.
- Verified updated sample/generated JSON files include the new `schema_version` field for receipts and that the secure-rails checker accepts and rejects cases as expected via unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0180e46483338bfb37c59f0962ca)