### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/render.py
+++ b/agialpha_engine/render.py
@@ -3,22 +3,103 @@ from __future__ import annotations
 from typing import Any
 
 
+THESIS_LINES = (
+    "Every Job makes an AI Agent smarter.",
+    "Every new skill can be instantly shared across the network.",
+    "One Agent learns, all Agents level up.",
+)
+
+CAVEAT = (
+    "Instant sharing means sandboxed registration and importability. Production "
+    "activation requires validators and human review. Exponential compounding is "
+    "a strategic target unless the exponential claim gate passes."
+)
+
+EXPONENTIAL_BOUNDARY = (
+    "Exponential compounding is a strategic target. Current evidence reports "
+    "local bounded network skill propagation only."
+)
+
+PROOF_CHAIN = (
+    "AGI Job → Skill Package / Rejected Skill / Failure Learning → ProofBundle → "
+    "Evidence Docket → Network Skill Vault → Agent Skill Manifest → Held-out "
+    "Reuse Test → B6 vs B5 → NetworkSkillPropagationLift → Claim Gate → Human Review"
+)
+
+FOOTER_DOCTRINE = (
+    "No Evidence Docket, no empirical SOTA claim. Autonomous evidence production "
+    "is allowed; autonomous claim promotion is not."
+)
+
+STATUS_CARD_KEYS = (
+    ("jobs run", "jobs_run"),
+    ("accepted Skill Packages", "accepted_skill_packages"),
+    ("rejected Skill Candidates", "rejected_skill_candidates"),
+    ("Failure Learning Packages", "failure_learning_packages"),
+    ("skills published", "skills_published_to_vault"),
+    ("agents registered", "agents_registered"),
+    ("skill imports", "skill_import_events"),
+    ("target agents improved", "target_agents_improved_on_heldout"),
+    ("held-out tasks evaluated", "heldout_tasks_evaluated"),
+    ("B6 beats B5", "B6_shared_skill_beats_B5_no_shared_skill"),
+    ("NetworkSkillPropagationLift", "network_skill_propagation_lift"),
+    ("CompoundingExponentProxy", "compounding_exponent_proxy"),
+    ("exponential compounding supported", "exponential_compounding_supported"),
+    ("replay status", "replay_pass_rate"),
+    ("falsification status", "falsification_pass"),
+)
+
+HARD_SAFETY_KEYS = (
+    "raw_secret_leak_count",
+    "external_target_scan_count",
+    "exploit_execution_count",
+    "malware_generation_count",
+    "social_engineering_content_count",
+    "unsafe_automerge_count",
+    "critical_safety_incidents",
+)
+
+
+def _display(value: Any) -> str:
+    if value is None:
+        return "not_reported"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
 def render_skill_network_summary(metrics: dict[str, Any], claim_gate: dict[str, Any]) -> str:
-    return "\n".join(
-        [
-            "# AGI ALPHA Skill Network",
-            "",
-            "Every Job makes an AI Agent smarter.",
-            "Every new skill can be instantly shared across the network.",
-            "One Agent learns, all Agents level up.",
-            "",
-            f"- jobs run: {metrics.get('jobs_run', 'not_reported')}",
-            f"- accepted Skill Packages: {metrics.get('accepted_skill_packages', 'not_reported')}",
-            f"- rejected Skill Candidates: {metrics.get('rejected_skill_candidates', 'not_reported')}",
-            f"- Failure Learning Packages: {metrics.get('failure_learning_packages', 'not_reported')}",
-            f"- NetworkSkillPropagationLift: {metrics.get('network_skill_propagation_lift', 'not_reported')}",
-            f"- Claim gate status: {claim_gate.get('claim_gate_status', 'not_supported')}",
-            "",
-            "Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.",
-        ]
-    )
+    """Render the public-facing Engine-003 summary without promoting unsupported claims."""
+    lines = [
+        "# AGI ALPHA Skill Network",
+        "",
+        *THESIS_LINES,
+        "",
+        "## Caveat",
+        CAVEAT,
+        "",
+        "## Proof chain",
+        PROOF_CHAIN,
+        "",
+        "## Claim gate",
+        f"- Claim gate status: {claim_gate.get('claim_gate_status', 'not_supported')}",
+        f"- Supported wording: {claim_gate.get('supported_wording', 'Networked skill compounding claim not yet supported.')}",
+        "",
+        "## Exponential compounding status",
+        f"- Status: {metrics.get('exponential_compounding_status', EXPONENTIAL_BOUNDARY)}",
+        f"- Supported: {_display(metrics.get('exponential_compounding_supported', False))}",
+        "",
+        "## Status cards",
+    ]
+    for label, key in STATUS_CARD_KEYS:
+        lines.append(f"- {label}: {_display(metrics.get(key, 'not_reported'))}")
+    lines.extend(["", "## Hard safety counters"])
+    for key in HARD_SAFETY_KEYS:
+        lines.append(f"- {key}: {_display(metrics.get(key, 'not_reported'))}")
+    lines.extend([
+        "",
+        "## Boundary doctrine",
+        EXPONENTIAL_BOUNDARY,
+        FOOTER_DOCTRINE,
+    ])
+    return "\n".join(lines)

--- a/tests/test_agialpha_skill_network_render.py
+++ b/tests/test_agialpha_skill_network_render.py
@@ -1,0 +1,30 @@
+import unittest
+
+from agialpha_engine.render import render_skill_network_summary
+
+
+class SkillNetworkRenderTest(unittest.TestCase):
+    def test_summary_renders_caveat_proof_chain_and_footer(self):
+        text = render_skill_network_summary(
+            {
+                "jobs_run": 5,
+                "accepted_skill_packages": 1,
+                "network_skill_propagation_lift": 0.1,
+                "exponential_compounding_supported": False,
+                "raw_secret_leak_count": 0,
+                "unsafe_automerge_count": 0,
+            },
+            {"claim_gate_status": "supported_local_bounded"},
+        )
+        self.assertIn("Every Job makes an AI Agent smarter.", text)
+        self.assertIn("Instant sharing means sandboxed registration and importability", text)
+        self.assertIn("AGI Job → Skill Package / Rejected Skill / Failure Learning", text)
+        self.assertIn("NetworkSkillPropagationLift", text)
+        self.assertIn("Exponential compounding is a strategic target", text)
+        self.assertIn("No Evidence Docket, no empirical SOTA claim", text)
+        self.assertIn("unsafe_automerge_count: 0", text)
+        self.assertNotIn("empirical SOTA claim supported", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Surface a polished, conservative public summary for ENGINE-003 that makes the networked-skill thesis operational, visible, and claim-bounded for GitHub Pages and Evidence Mission Control. 
- Ensure the public renderer explicitly includes the operating thesis, sandbox/human-review caveat, proof chain, claim-gate panel, exponential-boundary language, and hard safety counters so the UI cannot promote unsupported claims.

### Description
- Replace the simple list renderer with `render_skill_network_summary` in `agialpha_engine/render.py` to render thesis lines, a caveat about sandboxed sharing and human review, the proof chain, a claim-gate panel, exponential-compounding status, status cards mapped to measurable metrics, and hard safety counters; add `_display` helper for deterministic formatting. 
- Add a unit regression test `tests/test_agialpha_skill_network_render.py` that asserts the summary includes the thesis, caveat, proof chain, NetworkSkillPropagationLift label, exponential-boundary wording, footer doctrine, and hard-safety counters while avoiding unsupported SOTA language. 
- Preserve the repository doctrine: no automatic activation, evidence-bound wording, and explicit human-review/activation fields are retained in rendered output and metadata.

### Testing
- Ran the Engine-003 end-to-end sequence `python -m agialpha_engine network-compounding-run/replay/falsification-audit/validate/build-data` with the supplied test run parameters and produced the expected run artifacts and generated-data outputs (completed successfully). 
- Executed full test suites with `python -m unittest discover -s tests` and `pytest -q`, and the test run passed (all added and existing tests succeeded, including the new renderer test). 
- Ran SecureRails checks `scripts/secure_rails_claim_boundary_check.py`, `scripts/secure_rails_no_automerge_check.py`, `scripts/secure_rails_trust_center_check.py`, `scripts/secure_rails_work_vault_check.py`, and token-boundary checks which passed for the modified artifacts. 
- Noted: the repository policy evaluation (`python -m secure_rails policy evaluate-repo`) reported existing policy findings (`policy violations found: 1047`) unrelated to the render change and requiring separate mitigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3223ca148333976008282a85ed44)