### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/README_AGIALPHA_SKILL_NETWORK.md
+++ b/README_AGIALPHA_SKILL_NETWORK.md
@@ -22,7 +22,7 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 
 - Claim gate status: supported_local_bounded.
 - Claim gate status: not_supported. Networked skill compounding claim not yet supported.
-- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only. Measured exponential wording requires at least three raw-log-backed cycles with superlinear lift, replay and falsification passing, metrics from raw logs, and no boundary violation.
+- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only. Measured exponential wording requires at least three raw-log-backed cycles with superlinear lift, replay and falsification passing, metrics from raw logs, and a complete reported zero-valued hard-safety ledger; missing safety counters or sentinel raw IDs keep the strategic-target caveat in force.
 
 ## What this does not claim
 

--- a/README_AGIALPHA_SKILL_NETWORK.md
+++ b/README_AGIALPHA_SKILL_NETWORK.md
@@ -22,7 +22,7 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 
 - Claim gate status: supported_local_bounded.
 - Claim gate status: not_supported. Networked skill compounding claim not yet supported.
-- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.
+- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only. Measured exponential wording requires at least three raw-log-backed cycles with superlinear lift, replay and falsification passing, metrics from raw logs, and no boundary violation.
 
 ## What this does not claim
 

--- a/agialpha_engine/network_skill_metrics.py
+++ b/agialpha_engine/network_skill_metrics.py
@@ -78,6 +78,89 @@ def _heldout_pair_population_matches(
     return True
 
 
+def evaluate_exponential_compounding_gate(
+    *,
+    compounding_cycles: list[dict[str, Any]] | None = None,
+    replay_pass: bool = False,
+    falsification_pass: bool = False,
+    metrics_computed_from_raw_logs: bool = False,
+    safety_counters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Evaluate whether measured exponential wording is allowed.
+
+    The gate is intentionally separate from local bounded propagation.  It only
+    supports exponential wording when at least three replayed cycles have
+    raw-log-backed, strictly positive, superlinear lift growth and no boundary
+    violations.  Otherwise it returns the required strategic-target caveat.
+    """
+    cycles = compounding_cycles or []
+    status_text = (
+        "Exponential compounding is a strategic target. Current evidence reports "
+        "local bounded network skill propagation only."
+    )
+    numeric_lifts: list[float] = []
+    raw_backed = True
+    for cycle in cycles:
+        lift = cycle.get("network_skill_propagation_lift")
+        raw_ids = cycle.get("raw_task_result_ids")
+        if not isinstance(lift, (int, float)) or not raw_ids:
+            raw_backed = False
+            continue
+        numeric_lifts.append(float(lift))
+    increments = [round(b - a, 12) for a, b in zip(numeric_lifts, numeric_lifts[1:])]
+    superlinear = (
+        len(numeric_lifts) >= 3
+        and all(lift > 0 for lift in numeric_lifts)
+        and len(increments) >= 2
+        and all(delta > 0 for delta in increments)
+        and all(next_delta > delta for delta, next_delta in zip(increments, increments[1:]))
+    )
+    counters = safety_counters or {}
+    hard_safety_ok = all(
+        counters.get(key, 0) == 0
+        for key in (
+            "raw_secret_leak_count",
+            "external_target_scan_count",
+            "exploit_execution_count",
+            "malware_generation_count",
+            "social_engineering_content_count",
+            "unsafe_automerge_count",
+            "critical_safety_incidents",
+            "unsafe_claims_blocked",
+            "token_value_claims_blocked",
+            "regulated_decisioning_blocked",
+        )
+    )
+    supported = bool(
+        superlinear
+        and raw_backed
+        and replay_pass
+        and falsification_pass
+        and metrics_computed_from_raw_logs
+        and hard_safety_ok
+    )
+    exponent_proxy: float | str = "not_supported"
+    if supported:
+        first_increment = increments[0]
+        last_increment = increments[-1]
+        exponent_proxy = round(1.0 + (last_increment / max(first_increment, 1e-12)), 6)
+        status_text = (
+            "Measured exponential compounding language is supported for this "
+            "local bounded multi-cycle evidence docket only."
+        )
+    return base_record({
+        "exponential_compounding_supported": supported,
+        "exponential_compounding_status": status_text,
+        "compounding_exponent_proxy": exponent_proxy,
+        "cycles_evaluated": len(cycles),
+        "superlinear_growth_observed": superlinear,
+        "metrics_computed_from_raw_logs": metrics_computed_from_raw_logs,
+        "replay_pass": replay_pass,
+        "falsification_pass": falsification_pass,
+        "hard_safety_ok": hard_safety_ok,
+    })
+
+
 def compute_network_skill_metrics(
     *,
     jobs_run: int,
@@ -97,7 +180,15 @@ def compute_network_skill_metrics(
     falsification_pass: bool | str = "pending",
     semantic_tests_passed: bool | str = "pending",
     safety_counters: dict[str, Any] | None = None,
+    compounding_cycles: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    exponential_gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=compounding_cycles,
+        replay_pass=replay_pass_rate is True or replay_pass_rate == 1 or replay_pass_rate == 1.0,
+        falsification_pass=falsification_pass is True,
+        metrics_computed_from_raw_logs=bool(raw_task_result_ids),
+        safety_counters=safety_counters,
+    )
     d_b5 = compute_d_metric(heldout_rows_b5)
     d_b6 = compute_d_metric(heldout_rows_b6)
     heldout_metrics_reportable = isinstance(d_b5, float) and isinstance(d_b6, float)
@@ -164,12 +255,9 @@ def compute_network_skill_metrics(
             else "not_reported"
         ),
         "capability_compounding_rate": delta,
-        "compounding_exponent_proxy": "not_supported",
-        "exponential_compounding_supported": False,
-        "exponential_compounding_status": (
-            "Exponential compounding is a strategic target. Current evidence reports "
-            "local bounded network skill propagation only."
-        ),
+        "compounding_exponent_proxy": exponential_gate["compounding_exponent_proxy"],
+        "exponential_compounding_supported": exponential_gate["exponential_compounding_supported"],
+        "exponential_compounding_status": exponential_gate["exponential_compounding_status"],
         "raw_task_result_ids": raw_task_result_ids if raw_task_result_ids else "not_reported",
         "replay_pass_rate": replay_pass_rate,
         "falsification_pass": falsification_pass,

--- a/agialpha_engine/network_skill_metrics.py
+++ b/agialpha_engine/network_skill_metrics.py
@@ -23,6 +23,21 @@ REQUIRED_D_FIELDS = (
     "cost_risk_proxy",
 )
 
+REQUIRED_EXPONENTIAL_HARD_SAFETY_COUNTERS = (
+    "raw_secret_leak_count",
+    "external_target_scan_count",
+    "exploit_execution_count",
+    "malware_generation_count",
+    "social_engineering_content_count",
+    "unsafe_automerge_count",
+    "critical_safety_incidents",
+    "unsafe_claims_blocked",
+    "token_value_claims_blocked",
+    "regulated_decisioning_blocked",
+)
+
+RAW_ID_SENTINELS = {"", "not_reported", "unavailable", "pending", "skipped_with_reason"}
+
 
 def compute_d_metric(rows):
     if not rows:
@@ -78,6 +93,17 @@ def _heldout_pair_population_matches(
     return True
 
 
+def _valid_raw_task_result_ids(value: Any) -> bool:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple, set)):
+        return False
+    if not value:
+        return False
+    return all(
+        isinstance(item, str) and item.strip() not in RAW_ID_SENTINELS
+        for item in value
+    )
+
+
 def evaluate_exponential_compounding_gate(
     *,
     compounding_cycles: list[dict[str, Any]] | None = None,
@@ -99,14 +125,18 @@ def evaluate_exponential_compounding_gate(
         "local bounded network skill propagation only."
     )
     numeric_lifts: list[float] = []
-    raw_backed = True
-    for cycle in cycles:
+    invalid_raw_evidence_cycles: list[int] = []
+    for index, cycle in enumerate(cycles):
         lift = cycle.get("network_skill_propagation_lift")
         raw_ids = cycle.get("raw_task_result_ids")
-        if not isinstance(lift, (int, float)) or not raw_ids:
-            raw_backed = False
+        if not isinstance(lift, (int, float)) or isinstance(lift, bool):
+            invalid_raw_evidence_cycles.append(index)
+            continue
+        if not _valid_raw_task_result_ids(raw_ids):
+            invalid_raw_evidence_cycles.append(index)
             continue
         numeric_lifts.append(float(lift))
+    raw_backed = not invalid_raw_evidence_cycles and len(numeric_lifts) == len(cycles)
     increments = [round(b - a, 12) for a, b in zip(numeric_lifts, numeric_lifts[1:])]
     superlinear = (
         len(numeric_lifts) >= 3
@@ -115,22 +145,21 @@ def evaluate_exponential_compounding_gate(
         and all(delta > 0 for delta in increments)
         and all(next_delta > delta for delta, next_delta in zip(increments, increments[1:]))
     )
-    counters = safety_counters or {}
-    hard_safety_ok = all(
-        counters.get(key, 0) == 0
-        for key in (
-            "raw_secret_leak_count",
-            "external_target_scan_count",
-            "exploit_execution_count",
-            "malware_generation_count",
-            "social_engineering_content_count",
-            "unsafe_automerge_count",
-            "critical_safety_incidents",
-            "unsafe_claims_blocked",
-            "token_value_claims_blocked",
-            "regulated_decisioning_blocked",
+    counters = safety_counters if isinstance(safety_counters, dict) else {}
+    missing_safety_counters = [
+        key for key in REQUIRED_EXPONENTIAL_HARD_SAFETY_COUNTERS if key not in counters
+    ]
+    nonzero_or_invalid_safety_counters = [
+        key
+        for key in REQUIRED_EXPONENTIAL_HARD_SAFETY_COUNTERS
+        if key in counters
+        and (
+            isinstance(counters[key], bool)
+            or not isinstance(counters[key], (int, float))
+            or counters[key] != 0
         )
-    )
+    ]
+    hard_safety_ok = not missing_safety_counters and not nonzero_or_invalid_safety_counters
     supported = bool(
         superlinear
         and raw_backed
@@ -154,6 +183,10 @@ def evaluate_exponential_compounding_gate(
         "compounding_exponent_proxy": exponent_proxy,
         "cycles_evaluated": len(cycles),
         "superlinear_growth_observed": superlinear,
+        "raw_task_result_ids_valid": raw_backed,
+        "invalid_raw_evidence_cycles": invalid_raw_evidence_cycles,
+        "missing_safety_counters": missing_safety_counters,
+        "nonzero_or_invalid_safety_counters": nonzero_or_invalid_safety_counters,
         "metrics_computed_from_raw_logs": metrics_computed_from_raw_logs,
         "replay_pass": replay_pass,
         "falsification_pass": falsification_pass,

--- a/docs/agialpha-skill-network/exponential-compounding-boundary.md
+++ b/docs/agialpha-skill-network/exponential-compounding-boundary.md
@@ -3,10 +3,12 @@
 Exponential compounding language is **strategic-target only** unless the exponential claim gate passes.
 
 Required evidence for measured exponential wording:
-- At least 3 completed cycles with superlinear growth signals.
+- At least 3 completed cycles with raw-task-result-backed, strictly positive lift.
+- Successive lift increments must increase, so the observed cycle series is superlinear rather than merely positive.
 - Replay passes for all referenced cycle metrics and hashes.
 - Falsification audits pass with no unresolved critical boundary violations.
 - Claim-boundary, token-boundary, and regulated-boundary gates all pass.
+- Hard safety counters remain zero, including no unsafe claim, token-value claim, regulated decisioning, raw-secret leak, external scan, exploit, malware, social-engineering, auto-merge, or critical incident.
 
 Default wording when evidence is insufficient:
 

--- a/docs/agialpha-skill-network/exponential-compounding-boundary.md
+++ b/docs/agialpha-skill-network/exponential-compounding-boundary.md
@@ -8,7 +8,7 @@ Required evidence for measured exponential wording:
 - Replay passes for all referenced cycle metrics and hashes.
 - Falsification audits pass with no unresolved critical boundary violations.
 - Claim-boundary, token-boundary, and regulated-boundary gates all pass.
-- Hard safety counters remain zero, including no unsafe claim, token-value claim, regulated decisioning, raw-secret leak, external scan, exploit, malware, social-engineering, auto-merge, or critical incident.
+- Hard safety counters must be explicitly reported and zero, including no unsafe claim, token-value claim, regulated decisioning, raw-secret leak, external scan, exploit, malware, social-engineering, auto-merge, or critical incident. Missing safety-ledger counters are treated as unknown evidence and cannot unlock measured exponential wording.
 
 Default wording when evidence is insufficient:
 

--- a/tests/test_agialpha_exponential_claim_gate.py
+++ b/tests/test_agialpha_exponential_claim_gate.py
@@ -32,3 +32,55 @@ def test_exponential_claim_remains_blocked_even_after_replay_and_falsification()
         metrics = json.loads((run / '07_metrics/network_skill_metrics.json').read_text())
         assert metrics['exponential_compounding_supported'] is False
         assert metrics['compounding_exponent_proxy'] in {'not_supported', 'pending', 'not_reported', 'unavailable', 'skipped_with_reason'}
+
+
+def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    blocked = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters={"critical_safety_incidents": 0},
+    )
+    assert blocked["exponential_compounding_supported"] is False
+    assert blocked["compounding_exponent_proxy"] == "not_supported"
+    assert "strategic target" in blocked["exponential_compounding_status"]
+
+    supported = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters={"critical_safety_incidents": 0},
+    )
+    assert supported["exponential_compounding_supported"] is True
+    assert supported["superlinear_growth_observed"] is True
+    assert supported["compounding_exponent_proxy"] > 1
+
+
+def test_exponential_gate_blocks_boundary_violations_and_missing_raw_ids():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": []},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters={"critical_safety_incidents": 1},
+    )
+    assert gate["exponential_compounding_supported"] is False
+    assert gate["hard_safety_ok"] is False
+    assert "local bounded network skill propagation only" in gate["exponential_compounding_status"]

--- a/tests/test_agialpha_exponential_claim_gate.py
+++ b/tests/test_agialpha_exponential_claim_gate.py
@@ -34,6 +34,14 @@ def test_exponential_claim_remains_blocked_even_after_replay_and_falsification()
         assert metrics['compounding_exponent_proxy'] in {'not_supported', 'pending', 'not_reported', 'unavailable', 'skipped_with_reason'}
 
 
+def _zero_exponential_safety_counters():
+    from agialpha_engine.network_skill_metrics import (
+        REQUIRED_EXPONENTIAL_HARD_SAFETY_COUNTERS,
+    )
+
+    return {key: 0 for key in REQUIRED_EXPONENTIAL_HARD_SAFETY_COUNTERS}
+
+
 def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
     from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
 
@@ -45,7 +53,7 @@ def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
         replay_pass=True,
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
-        safety_counters={"critical_safety_incidents": 0},
+        safety_counters=_zero_exponential_safety_counters(),
     )
     assert blocked["exponential_compounding_supported"] is False
     assert blocked["compounding_exponent_proxy"] == "not_supported"
@@ -60,7 +68,7 @@ def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
         replay_pass=True,
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
-        safety_counters={"critical_safety_incidents": 0},
+        safety_counters=_zero_exponential_safety_counters(),
     )
     assert supported["exponential_compounding_supported"] is True
     assert supported["superlinear_growth_observed"] is True
@@ -70,6 +78,8 @@ def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
 def test_exponential_gate_blocks_boundary_violations_and_missing_raw_ids():
     from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
 
+    counters = _zero_exponential_safety_counters()
+    counters["critical_safety_incidents"] = 1
     gate = evaluate_exponential_compounding_gate(
         compounding_cycles=[
             {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
@@ -79,8 +89,60 @@ def test_exponential_gate_blocks_boundary_violations_and_missing_raw_ids():
         replay_pass=True,
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
-        safety_counters={"critical_safety_incidents": 1},
+        safety_counters=counters,
     )
     assert gate["exponential_compounding_supported"] is False
     assert gate["hard_safety_ok"] is False
+    assert gate["raw_task_result_ids_valid"] is False
+    assert gate["nonzero_or_invalid_safety_counters"] == ["critical_safety_incidents"]
     assert "local bounded network skill propagation only" in gate["exponential_compounding_status"]
+
+
+def test_exponential_gate_requires_complete_reported_safety_ledger():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    cycles = [
+        {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+        {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+        {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+    ]
+    omitted = evaluate_exponential_compounding_gate(
+        compounding_cycles=cycles,
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+    )
+    assert omitted["exponential_compounding_supported"] is False
+    assert omitted["hard_safety_ok"] is False
+    assert "raw_secret_leak_count" in omitted["missing_safety_counters"]
+
+    partial_counters = _zero_exponential_safety_counters()
+    partial_counters.pop("regulated_decisioning_blocked")
+    partial = evaluate_exponential_compounding_gate(
+        compounding_cycles=cycles,
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=partial_counters,
+    )
+    assert partial["exponential_compounding_supported"] is False
+    assert partial["missing_safety_counters"] == ["regulated_decisioning_blocked"]
+
+
+def test_exponential_gate_rejects_sentinel_or_non_collection_raw_ids():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": "not_reported"},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["pending"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=_zero_exponential_safety_counters(),
+    )
+    assert gate["exponential_compounding_supported"] is False
+    assert gate["raw_task_result_ids_valid"] is False
+    assert gate["invalid_raw_evidence_cycles"] == [0, 2]


### PR DESCRIPTION
### Motivation
- Prevent unsupported exponential claim language by gating measured exponential wording on multi-cycle, raw-log-backed, replayed and falsified evidence with zero hard safety incidents.
- Make the Engine-003 public metrics and pages reflect only evidence-backed claims and preserve the local-bounded caveat.
- Provide deterministic, testable logic that derives compounding-related metrics from raw held-out results rather than static placeholders.

### Description
- Add a dedicated exponential-compounding evidence gate `evaluate_exponential_compounding_gate` and integrate it into `compute_network_skill_metrics` so `compounding_exponent_proxy`, `exponential_compounding_supported`, and `exponential_compounding_status` are computed from measured evidence (file: `agialpha_engine/network_skill_metrics.py`).
- Gate semantics require at least three raw-task-result-backed cycles with strictly positive lifts, increasing successive lift increments (superlinear), replay+falsification passing, metrics from raw logs, and zero hard safety counters before supporting measured exponential wording.
- Add semantic tests that exercise the exponential gate and its failure modes (file: `tests/test_agialpha_exponential_claim_gate.py`).
- Update documentation to reflect the raw-log-backed multi-cycle evidence requirements and retain the public caveat wording (files: `docs/agialpha-skill-network/exponential-compounding-boundary.md` and `README_AGIALPHA_SKILL_NETWORK.md`).

### Testing
- Ran an end-to-end local Engine-003 cycle: `python -m agialpha_engine network-compounding-run`, then `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`; the run completed and produced evidence-docket artifacts.
- Ran full test suites: `python -m unittest discover -s tests` and `pytest -q`, and targeted `pytest tests/test_agialpha_exponential_claim_gate.py`; all tests passed (full suite run reported 747 tests passing).
- Ran SecureRails checks relevant to this change: `scripts/secure_rails_safety_ledger_check.py`, `scripts/secure_rails_no_automerge_check.py`, and `scripts/secure_rails_claim_boundary_check.py`; these checks passed for the generated run artifacts.
- Ran docs/workflow audits via `agialpha_docs` helpers to ensure generated-data and workflow catalog traces; audits reported no missing workflows or claim issues for the public experience.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6dd237e48333b4c09e8e1db158d7)