### PR TITLE
Add exponential compounding claim gate with safety counters, docs, and tests

### DIFF
--- a/README_AGIALPHA_SKILL_NETWORK.md
+++ b/README_AGIALPHA_SKILL_NETWORK.md
@@ -22,7 +22,7 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 
 - Claim gate status: supported_local_bounded.
 - Claim gate status: not_supported. Networked skill compounding claim not yet supported.
-- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only.
+- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only. Measured exponential wording requires at least three raw-log-backed cycles with superlinear lift, replay and falsification passing, metrics from raw logs, and no boundary violation.
 
 ## What this does not claim
 

--- a/README_AGIALPHA_SKILL_NETWORK.md
+++ b/README_AGIALPHA_SKILL_NETWORK.md
@@ -22,7 +22,7 @@ No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is a
 
 - Claim gate status: supported_local_bounded.
 - Claim gate status: not_supported. Networked skill compounding claim not yet supported.
-- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only. Measured exponential wording requires at least three raw-log-backed cycles with superlinear lift, replay and falsification passing, metrics from raw logs, and no boundary violation.
+- Exponential compounding is a strategic target. Current evidence reports local bounded network skill propagation only. Measured exponential wording requires at least three raw-log-backed cycles with superlinear lift, cycle raw IDs that match the run raw evaluator log set, replay and falsification passing, metrics from raw logs, and no boundary violation.
 
 ## What this does not claim
 

--- a/agialpha_engine/network_skill_metrics.py
+++ b/agialpha_engine/network_skill_metrics.py
@@ -39,6 +39,23 @@ EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS = (
 RAW_ID_SENTINELS = {"", "not_reported", "unavailable", "pending", "skipped_with_reason"}
 
 
+def _valid_raw_id_collection(raw_ids: Any) -> bool:
+    return (
+        isinstance(raw_ids, (list, tuple, set))
+        and bool(raw_ids)
+        and all(
+            isinstance(raw_id, str) and raw_id.strip() not in RAW_ID_SENTINELS
+            for raw_id in raw_ids
+        )
+    )
+
+
+def _raw_id_set(raw_ids: Any) -> set[str]:
+    if not _valid_raw_id_collection(raw_ids):
+        return set()
+    return {raw_id.strip() for raw_id in raw_ids}
+
+
 def compute_d_metric(rows):
     if not rows:
         return "not_reported"
@@ -100,6 +117,7 @@ def evaluate_exponential_compounding_gate(
     falsification_pass: bool = False,
     metrics_computed_from_raw_logs: bool = False,
     safety_counters: dict[str, Any] | None = None,
+    available_raw_task_result_ids: list[str] | tuple[str, ...] | set[str] | None = None,
 ) -> dict[str, Any]:
     """Evaluate whether measured exponential wording is allowed.
 
@@ -113,18 +131,26 @@ def evaluate_exponential_compounding_gate(
         "Exponential compounding is a strategic target. Current evidence reports "
         "local bounded network skill propagation only."
     )
+    actual_raw_task_result_id_set = _raw_id_set(available_raw_task_result_ids)
+    raw_log_universe_reported = bool(actual_raw_task_result_id_set)
     numeric_lifts: list[float] = []
-    raw_backed = True
+    raw_backed = raw_log_universe_reported
     invalid_raw_cycle_evidence: list[int] = []
+    unknown_raw_task_result_ids: list[str] = []
     for index, cycle in enumerate(cycles):
         lift = cycle.get("network_skill_propagation_lift")
         raw_ids = cycle.get("raw_task_result_ids")
-        raw_ids_valid = (
-            isinstance(raw_ids, (list, tuple, set))
-            and bool(raw_ids)
-            and all(isinstance(raw_id, str) and raw_id.strip() not in RAW_ID_SENTINELS for raw_id in raw_ids)
-        )
-        if not isinstance(lift, (int, float)) or isinstance(lift, bool) or not raw_ids_valid:
+        raw_ids_valid = _valid_raw_id_collection(raw_ids)
+        cycle_raw_id_set = _raw_id_set(raw_ids)
+        missing_cycle_raw_ids = sorted(cycle_raw_id_set - actual_raw_task_result_id_set)
+        if missing_cycle_raw_ids:
+            unknown_raw_task_result_ids.extend(missing_cycle_raw_ids)
+        if (
+            not isinstance(lift, (int, float))
+            or isinstance(lift, bool)
+            or not raw_ids_valid
+            or missing_cycle_raw_ids
+        ):
             raw_backed = False
             invalid_raw_cycle_evidence.append(index)
             continue
@@ -177,7 +203,10 @@ def evaluate_exponential_compounding_gate(
         "missing_hard_safety_counters": missing_hard_safety_counters,
         "nonzero_hard_safety_counters": nonzero_hard_safety_counters,
         "raw_cycle_evidence_valid": raw_backed,
+        "raw_log_universe_reported": raw_log_universe_reported,
+        "available_raw_task_result_ids": sorted(actual_raw_task_result_id_set) if actual_raw_task_result_id_set else "not_reported",
         "invalid_raw_cycle_evidence": invalid_raw_cycle_evidence,
+        "unknown_raw_task_result_ids": sorted(set(unknown_raw_task_result_ids)),
     })
 
 
@@ -208,6 +237,7 @@ def compute_network_skill_metrics(
         falsification_pass=falsification_pass is True,
         metrics_computed_from_raw_logs=bool(raw_task_result_ids),
         safety_counters=safety_counters,
+        available_raw_task_result_ids=raw_task_result_ids,
     )
     d_b5 = compute_d_metric(heldout_rows_b5)
     d_b6 = compute_d_metric(heldout_rows_b6)

--- a/agialpha_engine/network_skill_metrics.py
+++ b/agialpha_engine/network_skill_metrics.py
@@ -23,6 +23,21 @@ REQUIRED_D_FIELDS = (
     "cost_risk_proxy",
 )
 
+EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS = (
+    "raw_secret_leak_count",
+    "external_target_scan_count",
+    "exploit_execution_count",
+    "malware_generation_count",
+    "social_engineering_content_count",
+    "unsafe_automerge_count",
+    "critical_safety_incidents",
+    "unsafe_claims_blocked",
+    "token_value_claims_blocked",
+    "regulated_decisioning_blocked",
+)
+
+RAW_ID_SENTINELS = {"", "not_reported", "unavailable", "pending", "skipped_with_reason"}
+
 
 def compute_d_metric(rows):
     if not rows:
@@ -78,6 +93,94 @@ def _heldout_pair_population_matches(
     return True
 
 
+def evaluate_exponential_compounding_gate(
+    *,
+    compounding_cycles: list[dict[str, Any]] | None = None,
+    replay_pass: bool = False,
+    falsification_pass: bool = False,
+    metrics_computed_from_raw_logs: bool = False,
+    safety_counters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Evaluate whether measured exponential wording is allowed.
+
+    The gate is intentionally separate from local bounded propagation.  It only
+    supports exponential wording when at least three replayed cycles have
+    raw-log-backed, strictly positive, superlinear lift growth and no boundary
+    violations.  Otherwise it returns the required strategic-target caveat.
+    """
+    cycles = compounding_cycles or []
+    status_text = (
+        "Exponential compounding is a strategic target. Current evidence reports "
+        "local bounded network skill propagation only."
+    )
+    numeric_lifts: list[float] = []
+    raw_backed = True
+    invalid_raw_cycle_evidence: list[int] = []
+    for index, cycle in enumerate(cycles):
+        lift = cycle.get("network_skill_propagation_lift")
+        raw_ids = cycle.get("raw_task_result_ids")
+        raw_ids_valid = (
+            isinstance(raw_ids, (list, tuple, set))
+            and bool(raw_ids)
+            and all(isinstance(raw_id, str) and raw_id.strip() not in RAW_ID_SENTINELS for raw_id in raw_ids)
+        )
+        if not isinstance(lift, (int, float)) or isinstance(lift, bool) or not raw_ids_valid:
+            raw_backed = False
+            invalid_raw_cycle_evidence.append(index)
+            continue
+        numeric_lifts.append(float(lift))
+    increments = [round(b - a, 12) for a, b in zip(numeric_lifts, numeric_lifts[1:])]
+    superlinear = (
+        len(numeric_lifts) >= 3
+        and all(lift > 0 for lift in numeric_lifts)
+        and len(increments) >= 2
+        and all(delta > 0 for delta in increments)
+        and all(next_delta > delta for delta, next_delta in zip(increments, increments[1:]))
+    )
+    counters = safety_counters if isinstance(safety_counters, dict) else {}
+    missing_hard_safety_counters = [
+        key for key in EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS if key not in counters
+    ]
+    nonzero_hard_safety_counters = [
+        key
+        for key in EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS
+        if key in counters and (isinstance(counters[key], bool) or counters[key] != 0)
+    ]
+    hard_safety_ok = not missing_hard_safety_counters and not nonzero_hard_safety_counters
+    supported = bool(
+        superlinear
+        and raw_backed
+        and replay_pass
+        and falsification_pass
+        and metrics_computed_from_raw_logs
+        and hard_safety_ok
+    )
+    exponent_proxy: float | str = "not_supported"
+    if supported:
+        first_increment = increments[0]
+        last_increment = increments[-1]
+        exponent_proxy = round(1.0 + (last_increment / max(first_increment, 1e-12)), 6)
+        status_text = (
+            "Measured exponential compounding language is supported for this "
+            "local bounded multi-cycle evidence docket only."
+        )
+    return base_record({
+        "exponential_compounding_supported": supported,
+        "exponential_compounding_status": status_text,
+        "compounding_exponent_proxy": exponent_proxy,
+        "cycles_evaluated": len(cycles),
+        "superlinear_growth_observed": superlinear,
+        "metrics_computed_from_raw_logs": metrics_computed_from_raw_logs,
+        "replay_pass": replay_pass,
+        "falsification_pass": falsification_pass,
+        "hard_safety_ok": hard_safety_ok,
+        "missing_hard_safety_counters": missing_hard_safety_counters,
+        "nonzero_hard_safety_counters": nonzero_hard_safety_counters,
+        "raw_cycle_evidence_valid": raw_backed,
+        "invalid_raw_cycle_evidence": invalid_raw_cycle_evidence,
+    })
+
+
 def compute_network_skill_metrics(
     *,
     jobs_run: int,
@@ -97,7 +200,15 @@ def compute_network_skill_metrics(
     falsification_pass: bool | str = "pending",
     semantic_tests_passed: bool | str = "pending",
     safety_counters: dict[str, Any] | None = None,
+    compounding_cycles: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    exponential_gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=compounding_cycles,
+        replay_pass=replay_pass_rate is True or replay_pass_rate == 1 or replay_pass_rate == 1.0,
+        falsification_pass=falsification_pass is True,
+        metrics_computed_from_raw_logs=bool(raw_task_result_ids),
+        safety_counters=safety_counters,
+    )
     d_b5 = compute_d_metric(heldout_rows_b5)
     d_b6 = compute_d_metric(heldout_rows_b6)
     heldout_metrics_reportable = isinstance(d_b5, float) and isinstance(d_b6, float)
@@ -164,12 +275,9 @@ def compute_network_skill_metrics(
             else "not_reported"
         ),
         "capability_compounding_rate": delta,
-        "compounding_exponent_proxy": "not_supported",
-        "exponential_compounding_supported": False,
-        "exponential_compounding_status": (
-            "Exponential compounding is a strategic target. Current evidence reports "
-            "local bounded network skill propagation only."
-        ),
+        "compounding_exponent_proxy": exponential_gate["compounding_exponent_proxy"],
+        "exponential_compounding_supported": exponential_gate["exponential_compounding_supported"],
+        "exponential_compounding_status": exponential_gate["exponential_compounding_status"],
         "raw_task_result_ids": raw_task_result_ids if raw_task_result_ids else "not_reported",
         "replay_pass_rate": replay_pass_rate,
         "falsification_pass": falsification_pass,

--- a/docs/agialpha-skill-network/exponential-compounding-boundary.md
+++ b/docs/agialpha-skill-network/exponential-compounding-boundary.md
@@ -4,6 +4,7 @@ Exponential compounding language is **strategic-target only** unless the exponen
 
 Required evidence for measured exponential wording:
 - At least 3 completed cycles with raw-task-result-backed, strictly positive lift.
+- Every cycle raw_task_result_id must match the run's actual reported raw evaluator log ID set; sentinel or unknown IDs do not count as evidence.
 - Successive lift increments must increase, so the observed cycle series is superlinear rather than merely positive.
 - Replay passes for all referenced cycle metrics and hashes.
 - Falsification audits pass with no unresolved critical boundary violations.

--- a/docs/agialpha-skill-network/exponential-compounding-boundary.md
+++ b/docs/agialpha-skill-network/exponential-compounding-boundary.md
@@ -3,10 +3,12 @@
 Exponential compounding language is **strategic-target only** unless the exponential claim gate passes.
 
 Required evidence for measured exponential wording:
-- At least 3 completed cycles with superlinear growth signals.
+- At least 3 completed cycles with raw-task-result-backed, strictly positive lift.
+- Successive lift increments must increase, so the observed cycle series is superlinear rather than merely positive.
 - Replay passes for all referenced cycle metrics and hashes.
 - Falsification audits pass with no unresolved critical boundary violations.
 - Claim-boundary, token-boundary, and regulated-boundary gates all pass.
+- Hard safety counters remain zero, including no unsafe claim, token-value claim, regulated decisioning, raw-secret leak, external scan, exploit, malware, social-engineering, auto-merge, or critical incident.
 
 Default wording when evidence is insufficient:
 

--- a/tests/test_agialpha_exponential_claim_gate.py
+++ b/tests/test_agialpha_exponential_claim_gate.py
@@ -12,6 +12,10 @@ def zero_exponential_gate_safety_counters(**overrides):
     return counters
 
 
+def actual_raw_ids():
+    return ["raw-1", "raw-2", "raw-3"]
+
+
 def test_exponential_claim_defaults_to_strategic_target_without_multicycle_evidence():
     with tempfile.TemporaryDirectory() as td:
         run = Path(td) / 'run'
@@ -54,6 +58,7 @@ def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
         safety_counters=zero_exponential_gate_safety_counters(),
+        available_raw_task_result_ids=actual_raw_ids(),
     )
     assert blocked["exponential_compounding_supported"] is False
     assert blocked["compounding_exponent_proxy"] == "not_supported"
@@ -69,6 +74,7 @@ def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
         safety_counters=zero_exponential_gate_safety_counters(),
+        available_raw_task_result_ids=actual_raw_ids(),
     )
     assert supported["exponential_compounding_supported"] is True
     assert supported["superlinear_growth_observed"] is True
@@ -88,6 +94,7 @@ def test_exponential_gate_blocks_boundary_violations_and_missing_raw_ids():
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
         safety_counters=zero_exponential_gate_safety_counters(critical_safety_incidents=1),
+        available_raw_task_result_ids=actual_raw_ids(),
     )
     assert gate["exponential_compounding_supported"] is False
     assert gate["hard_safety_ok"] is False
@@ -108,6 +115,7 @@ def test_exponential_gate_requires_complete_reported_zero_safety_ledger():
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
         safety_counters=None,
+        available_raw_task_result_ids=actual_raw_ids(),
     )
     assert omitted["exponential_compounding_supported"] is False
     assert set(omitted["missing_hard_safety_counters"]) == set(EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS)
@@ -121,6 +129,7 @@ def test_exponential_gate_requires_complete_reported_zero_safety_ledger():
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
         safety_counters=incomplete_counters,
+        available_raw_task_result_ids=actual_raw_ids(),
     )
     assert incomplete["exponential_compounding_supported"] is False
     assert incomplete["missing_hard_safety_counters"] == ["unsafe_automerge_count"]
@@ -139,8 +148,49 @@ def test_exponential_gate_rejects_sentinel_or_non_collection_raw_ids():
         falsification_pass=True,
         metrics_computed_from_raw_logs=True,
         safety_counters=zero_exponential_gate_safety_counters(),
+        available_raw_task_result_ids=actual_raw_ids(),
     )
     assert gate["exponential_compounding_supported"] is False
     assert gate["raw_cycle_evidence_valid"] is False
     assert gate["invalid_raw_cycle_evidence"] == [0, 1]
     assert "strategic target" in gate["exponential_compounding_status"]
+
+
+def test_exponential_gate_requires_cycle_ids_to_match_actual_raw_log_universe():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-does-not-exist"]},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=zero_exponential_gate_safety_counters(),
+        available_raw_task_result_ids=actual_raw_ids(),
+    )
+    assert gate["exponential_compounding_supported"] is False
+    assert gate["raw_cycle_evidence_valid"] is False
+    assert gate["invalid_raw_cycle_evidence"] == [1]
+    assert gate["unknown_raw_task_result_ids"] == ["raw-does-not-exist"]
+
+
+def test_exponential_gate_requires_reported_actual_raw_log_universe():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=zero_exponential_gate_safety_counters(),
+    )
+    assert gate["exponential_compounding_supported"] is False
+    assert gate["raw_log_universe_reported"] is False
+    assert gate["available_raw_task_result_ids"] == "not_reported"

--- a/tests/test_agialpha_exponential_claim_gate.py
+++ b/tests/test_agialpha_exponential_claim_gate.py
@@ -3,6 +3,14 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from agialpha_engine.network_skill_metrics import EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS
+
+
+def zero_exponential_gate_safety_counters(**overrides):
+    counters = {key: 0 for key in EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS}
+    counters.update(overrides)
+    return counters
+
 
 def test_exponential_claim_defaults_to_strategic_target_without_multicycle_evidence():
     with tempfile.TemporaryDirectory() as td:
@@ -32,3 +40,107 @@ def test_exponential_claim_remains_blocked_even_after_replay_and_falsification()
         metrics = json.loads((run / '07_metrics/network_skill_metrics.json').read_text())
         assert metrics['exponential_compounding_supported'] is False
         assert metrics['compounding_exponent_proxy'] in {'not_supported', 'pending', 'not_reported', 'unavailable', 'skipped_with_reason'}
+
+
+def test_exponential_gate_requires_three_raw_log_backed_superlinear_cycles():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    blocked = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=zero_exponential_gate_safety_counters(),
+    )
+    assert blocked["exponential_compounding_supported"] is False
+    assert blocked["compounding_exponent_proxy"] == "not_supported"
+    assert "strategic target" in blocked["exponential_compounding_status"]
+
+    supported = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=zero_exponential_gate_safety_counters(),
+    )
+    assert supported["exponential_compounding_supported"] is True
+    assert supported["superlinear_growth_observed"] is True
+    assert supported["compounding_exponent_proxy"] > 1
+
+
+def test_exponential_gate_blocks_boundary_violations_and_missing_raw_ids():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": []},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=zero_exponential_gate_safety_counters(critical_safety_incidents=1),
+    )
+    assert gate["exponential_compounding_supported"] is False
+    assert gate["hard_safety_ok"] is False
+    assert "local bounded network skill propagation only" in gate["exponential_compounding_status"]
+
+
+def test_exponential_gate_requires_complete_reported_zero_safety_ledger():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    cycles = [
+        {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": ["raw-1"]},
+        {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["raw-2"]},
+        {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+    ]
+    omitted = evaluate_exponential_compounding_gate(
+        compounding_cycles=cycles,
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=None,
+    )
+    assert omitted["exponential_compounding_supported"] is False
+    assert set(omitted["missing_hard_safety_counters"]) == set(EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS)
+    assert omitted["hard_safety_ok"] is False
+
+    incomplete_counters = zero_exponential_gate_safety_counters()
+    incomplete_counters.pop("unsafe_automerge_count")
+    incomplete = evaluate_exponential_compounding_gate(
+        compounding_cycles=cycles,
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=incomplete_counters,
+    )
+    assert incomplete["exponential_compounding_supported"] is False
+    assert incomplete["missing_hard_safety_counters"] == ["unsafe_automerge_count"]
+
+
+def test_exponential_gate_rejects_sentinel_or_non_collection_raw_ids():
+    from agialpha_engine.network_skill_metrics import evaluate_exponential_compounding_gate
+
+    gate = evaluate_exponential_compounding_gate(
+        compounding_cycles=[
+            {"network_skill_propagation_lift": 0.01, "raw_task_result_ids": "not_reported"},
+            {"network_skill_propagation_lift": 0.03, "raw_task_result_ids": ["pending"]},
+            {"network_skill_propagation_lift": 0.08, "raw_task_result_ids": ["raw-3"]},
+        ],
+        replay_pass=True,
+        falsification_pass=True,
+        metrics_computed_from_raw_logs=True,
+        safety_counters=zero_exponential_gate_safety_counters(),
+    )
+    assert gate["exponential_compounding_supported"] is False
+    assert gate["raw_cycle_evidence_valid"] is False
+    assert gate["invalid_raw_cycle_evidence"] == [0, 1]
+    assert "strategic target" in gate["exponential_compounding_status"]


### PR DESCRIPTION
### Motivation

- Introduce a strict, auditable gate for allowing "exponential compounding" wording that requires multi-cycle, raw-log-backed, superlinear evidence and zero hard safety counter reports.
- Prevent premature or unsafe promotion of exponential claims by requiring replay/falsification passes and a completed safety ledger. 
- Make the gate computable and reportable as part of the network skill metrics so downstream tooling can consume a canonical decision record.

### Description

- Add `EXPONENTIAL_GATE_HARD_SAFETY_COUNTERS` and `RAW_ID_SENTINELS` constants and helper logic to validate raw-task-result identifiers. 
- Implement `evaluate_exponential_compounding_gate` to verify at least three strictly positive, raw-log-backed cycles with superlinear successive increments, plus replay/falsification, metrics-from-raw-logs, and zero hard safety counters; it returns a `base_record` dictionary with gate results and provenance fields. 
- Integrate the gate into `compute_network_skill_metrics` to populate `compounding_exponent_proxy`, `exponential_compounding_supported`, and `exponential_compounding_status` from the gate evaluation. 
- Update README and add `docs/agialpha-skill-network/exponential-compounding-boundary.md` to capture the clarified boundary language and required evidence. 
- Add comprehensive unit tests in `tests/test_agialpha_exponential_claim_gate.py` that exercise default behavior, multi-cycle gating, raw-id sentinel rejection, missing/partial safety ledgers, and the computed exponent proxy, plus a small helper `zero_exponential_gate_safety_counters` for test setup.

### Testing

- Ran the new unit tests via `pytest tests/test_agialpha_exponential_claim_gate.py` which exercise CLI runs via subprocess and the `evaluate_exponential_compounding_gate` function, and all tests passed. 
- The changes were exercised by the tests that call `python -m agialpha_engine network-compounding-run`, `network-compounding-replay`, and `network-compounding-falsification-audit` as part of the test scenarios and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6dd237e48333b4c09e8e1db158d7)