### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha-skill-network/index.html
+++ b/agialpha-skill-network/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Skill Network · AGI ALPHA Engine 003</title>
+  <style>
+    :root { color-scheme: dark; --bg:#07111f; --panel:#0d1b2f; --line:#2b4f73; --text:#edf6ff; --muted:#adc2d8; --accent:#86d7ff; }
+    body { margin:0; font-family:Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background:radial-gradient(circle at top left,#17345a,var(--bg) 52%); color:var(--text); }
+    main { max-width:1120px; margin:auto; padding:44px 22px 64px; }
+    nav { display:flex; justify-content:space-between; gap:16px; align-items:center; margin-bottom:28px; color:var(--muted); }
+    nav a, a { color:var(--accent); }
+    .hero { border:1px solid var(--line); border-radius:30px; padding:44px; background:linear-gradient(135deg,rgba(24,55,93,.92),rgba(8,17,31,.88)); box-shadow:0 22px 80px rgba(0,0,0,.35); }
+    h1 { font-size:clamp(2.4rem,7vw,5.6rem); line-height:.95; margin:.1em 0 .35em; letter-spacing:-.06em; }
+    .kicker { text-transform:uppercase; letter-spacing:.18em; color:#a6dfff; font-size:.78rem; }
+    .thesis { font-size:clamp(1.15rem,2.5vw,1.55rem); line-height:1.45; color:#e3f4ff; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:16px; margin:26px 0; }
+    .card,.panel { border:1px solid var(--line); border-radius:20px; padding:20px; background:rgba(13,27,47,.9); }
+    .card span { display:block; color:var(--muted); font-size:.8rem; text-transform:uppercase; letter-spacing:.08em; }
+    .card strong { display:block; margin-top:8px; font-size:1.35rem; }
+    .caveat { border-left:5px solid var(--accent); background:#0b2138; padding:18px 22px; border-radius:16px; margin:24px 0; }
+    .chain { display:flex; flex-wrap:wrap; gap:8px; }
+    .chain span { border:1px solid #365f86; border-radius:999px; padding:8px 12px; background:#102542; }
+    .actions { display:flex; flex-wrap:wrap; gap:12px; }
+    .button { border:1px solid var(--accent); border-radius:999px; padding:10px 14px; text-decoration:none; background:#0e2c48; }
+    footer { margin-top:34px; color:#d8e9f8; border-top:1px solid var(--line); padding-top:20px; }
+  </style>
+</head>
+<body>
+<main>
+  <nav aria-label="Evidence Mission Control navigation">
+    <strong>Skill Network</strong>
+    <span><a href="../docs/agialpha-skill-network/">docs page</a> · <a href="../experiments/agialpha-engine-003/">ENGINE-003 experiment</a> · <a href="../docs/_generated/agialpha-skill-network/summary.json">raw summary JSON</a></span>
+  </nav>
+  <section class="hero">
+    <p class="kicker">AGI ALPHA Engine 003 / Networked Skill Compounding</p>
+    <h1>Networked Skill Compounding</h1>
+    <div class="thesis">
+      <p>Every Job makes an AI Agent smarter.</p>
+      <p>Every new skill can be instantly shared across the network.</p>
+      <p>One Agent learns, all Agents level up.</p>
+    </div>
+  </section>
+
+  <section class="caveat">
+    <strong>Boundary caveat:</strong> Instant sharing means sandboxed registration and importability. Production activation requires validators and human review. Exponential compounding is a strategic target unless the exponential claim gate passes.
+  </section>
+
+  <section class="grid" aria-label="Engine 003 evidence panels">
+    <article class="card"><span>Measured claim</span><strong>local bounded networked skill compounding</strong></article>
+    <article class="card"><span>Exponential status</span><strong>strategic target unless gate passes</strong></article>
+    <article class="card"><span>Activation posture</span><strong>sandboxed import; human review required</strong></article>
+    <article class="card"><span>Accounting boundary</span><strong>utility-only $AGIALPHA records</strong></article>
+  </section>
+
+  <section class="panel">
+    <h2>Proof chain</h2>
+    <div class="chain"><span>AGI Job</span><span>Skill Package / Rejected Skill / Failure Learning</span><span>ProofBundle</span><span>Evidence Docket</span><span>Network Skill Vault</span><span>Agent Skill Manifest</span><span>Held-out Reuse Test</span><span>B6 vs B5</span><span>NetworkSkillPropagationLift</span><span>Claim Gate</span><span>Human Review</span></div>
+  </section>
+
+  <section class="panel">
+    <h2>Public evidence surfaces</h2>
+    <p>This route exposes the Skill Network nav target used by Evidence Mission Control. The generated data and detailed institutional page remain the source of truth for claim-gate status, skill tables, agent manifests, B6 vs B5 comparison, failure learning, Work Vault receipts, safety boundaries, workflow buttons, and raw JSON links.</p>
+    <div class="actions">
+      <a class="button" href="../docs/agialpha-skill-network/">Open polished Skill Network page</a>
+      <a class="button" href="../experiments/agialpha-engine-003/">Open ENGINE-003 experiment</a>
+      <a class="button" href="../docs/_generated/agialpha-skill-network/network_skill_metrics.json">NetworkSkillPropagationLift JSON</a>
+      <a class="button" href="../docs/_generated/agialpha-skill-network/claim_gate.json">Claim gate JSON</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Safety and boundaries</h2>
+    <p>Accepted Skill Packages require raw evaluator logs, validators, replay, ProofBundles, Evidence Dockets, Work Vault utility receipts, redaction, falsification, and human review before any activation outside sandbox. Regulated-domain automation, autonomous persistence, auto-merge, wallet/custody/payment/trading/KYC/AML paths, and token-price or investment-return claims remain blocked.</p>
+  </section>
+
+  <footer>No Evidence Docket, no empirical SOTA claim. Autonomous evidence production is allowed; autonomous claim promotion is not.</footer>
+</main>
+</body>
+</html>

--- a/tests/test_agialpha_skill_network_render.py
+++ b/tests/test_agialpha_skill_network_render.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from agialpha_engine.render import render_skill_network_summary
 
@@ -24,6 +25,18 @@ class SkillNetworkRenderTest(unittest.TestCase):
         self.assertIn("No Evidence Docket, no empirical SOTA claim", text)
         self.assertIn("unsafe_automerge_count: 0", text)
         self.assertNotIn("empirical SOTA claim supported", text)
+
+
+    def test_public_skill_network_route_exists_with_required_nav_and_caveat(self):
+        page = Path("agialpha-skill-network/index.html")
+        self.assertTrue(page.exists())
+        text = page.read_text(encoding="utf-8")
+        self.assertIn("Skill Network", text)
+        self.assertIn("Every Job makes an AI Agent smarter.", text)
+        self.assertIn("Instant sharing means sandboxed registration and importability", text)
+        self.assertIn("AGI Job</span><span>Skill Package / Rejected Skill / Failure Learning", text)
+        self.assertIn("NetworkSkillPropagationLift", text)
+        self.assertIn("No Evidence Docket, no empirical SOTA claim", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Finish and operationalize ENGINE-003 so the Skill Network thesis becomes deterministic, measurable, falsifiable, and visible as generated public data. 
- Replace placeholder/empty modules and hard-coded shortcuts (B6 wins, fixed vRCI) with deterministic metric computation, sandboxing, proofbundle binding, validation, and claim-gate logic. 
- Ensure every job produces reusable learning artifacts (accepted/rejected/failure packages), skills are published to a Network Skill Vault, and held-out B6 vs B5 comparisons are computed from raw logs. 

### Description
- Implemented and populated core engine modules used by ENGINE-003 including metric adapters, deterministic local sandbox helpers, ProofBundle builders, and validation helpers, and ensured they use deterministic hashing and stable JSON ordering. 
- Added Engine-003 orchestration: `network-compounding-*` CLI commands wired in `agialpha_engine/cli.py`, claim-gate evaluator, network compounding run/replay/falsification/validate/build-data flows, and generator that mirrors run artifacts into `agialpha_skill_network_registry` and `docs/_generated/agialpha-skill-network`. 
- Removed hard-coded B6/vRCI shortcuts and added guards/semantic tests preventing reintroduction of fixed wins or fabricated metrics. 
- Exposed a polished public route at `/agialpha-skill-network/` (added `agialpha-skill-network/index.html`) and updated tests to assert the required thesis lines, caveat, proof chain, NetworkSkillPropagationLift links, and boundary doctrine are present. 

### Testing
- Ran the deterministic network compounding pipeline locally with `python -m agialpha_engine network-compounding-run/replay/falsification-audit/validate` and `network-compounding-build-data`, and these commands completed and produced registry + generated-data artifacts successfully. 
- Ran unit test suite with `python -m unittest discover -s tests` (495 tests) and the broader test suite with `pytest -q` (753 tests), and both test runs completed successfully. 
- Executed key SecureRails checks (`scripts/secure_rails_claim_boundary_check.py`, `scripts/secure_rails_no_automerge_check.py`, `scripts/secure_rails_trust_center_check.py`) which passed for the scanned scopes, noting some SecureRails utilities require specific input arguments when invoked directly and may report repository-wide policy items if run unscoped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fd05cb9483338f13d085f758c2b4)