### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/.github/workflows/agialpha-engine-003-network-claim-gate.yml
+++ b/.github/workflows/agialpha-engine-003-network-claim-gate.yml
@@ -48,9 +48,16 @@ jobs:
           if not run_id:
               print("")
               raise SystemExit(0)
-          candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+          candidates = [Path('agialpha-engine-runs') / run_id, Path('agialpha_skill_network_registry') / 'runs' / run_id]
+          required = [
+              Path('02_jobs/source_jobs.json'),
+              Path('02_jobs/raw_task_results.json'),
+              Path('03_skill_extraction/accepted_skill_packages.json'),
+              Path('06_heldout_reuse_tests/comparison.json'),
+              Path('13_claim_gate/network_compounding_claim_gate.json'),
+          ]
           for path in candidates:
-              if path.exists() and path.is_dir():
+              if path.exists() and path.is_dir() and all((path / rel).exists() for rel in required):
                   print(path)
                   break
           else:

--- a/.github/workflows/agialpha-engine-003-network-falsification-audit.yml
+++ b/.github/workflows/agialpha-engine-003-network-falsification-audit.yml
@@ -48,9 +48,16 @@ jobs:
           if not run_id:
               print("")
               raise SystemExit(0)
-          candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+          candidates = [Path('agialpha-engine-runs') / run_id, Path('agialpha_skill_network_registry') / 'runs' / run_id]
+          required = [
+              Path('02_jobs/source_jobs.json'),
+              Path('02_jobs/raw_task_results.json'),
+              Path('03_skill_extraction/accepted_skill_packages.json'),
+              Path('06_heldout_reuse_tests/comparison.json'),
+              Path('13_claim_gate/network_compounding_claim_gate.json'),
+          ]
           for path in candidates:
-              if path.exists() and path.is_dir():
+              if path.exists() and path.is_dir() and all((path / rel).exists() for rel in required):
                   print(path)
                   break
           else:

--- a/.github/workflows/agialpha-engine-003-network-replay.yml
+++ b/.github/workflows/agialpha-engine-003-network-replay.yml
@@ -48,9 +48,16 @@ jobs:
           if not run_id:
               print("")
               raise SystemExit(0)
-          candidates = [Path('agialpha_skill_network_registry') / 'runs' / run_id, Path('agialpha-engine-runs') / run_id]
+          candidates = [Path('agialpha-engine-runs') / run_id, Path('agialpha_skill_network_registry') / 'runs' / run_id]
+          required = [
+              Path('02_jobs/source_jobs.json'),
+              Path('02_jobs/raw_task_results.json'),
+              Path('03_skill_extraction/accepted_skill_packages.json'),
+              Path('06_heldout_reuse_tests/comparison.json'),
+              Path('13_claim_gate/network_compounding_claim_gate.json'),
+          ]
           for path in candidates:
-              if path.exists() and path.is_dir():
+              if path.exists() and path.is_dir() and all((path / rel).exists() for rel in required):
                   print(path)
                   break
           else:

--- a/tests/test_agialpha_network_compounding_metrics.py
+++ b/tests/test_agialpha_network_compounding_metrics.py
@@ -410,3 +410,22 @@ class NetworkCompoundingNoFixedMetricRegressionTest(unittest.TestCase):
         self.assertIn("B6_shared_skill_beats_B5_no_shared_skill", network_text)
         self.assertIn("D_shared_skill_network", network_text)
         self.assertIn("D_no_shared_skill", network_text)
+
+    def test_replay_sidecar_workflows_do_not_select_registry_mirror_without_full_run_layout(self):
+        """Replay/falsification/claim-gate workflows must create a full run when latest points at registry mirror indexes."""
+        for workflow in [
+            Path(".github/workflows/agialpha-engine-003-network-replay.yml"),
+            Path(".github/workflows/agialpha-engine-003-network-falsification-audit.yml"),
+            Path(".github/workflows/agialpha-engine-003-network-claim-gate.yml"),
+        ]:
+            text = workflow.read_text(encoding="utf-8")
+            self.assertIn("Path('02_jobs/source_jobs.json')", text)
+            self.assertIn("Path('02_jobs/raw_task_results.json')", text)
+            self.assertIn("Path('03_skill_extraction/accepted_skill_packages.json')", text)
+            self.assertIn("Path('06_heldout_reuse_tests/comparison.json')", text)
+            self.assertIn("Path('13_claim_gate/network_compounding_claim_gate.json')", text)
+            self.assertIn("all((path / rel).exists() for rel in required)", text)
+            self.assertLess(
+                text.index("Path('agialpha-engine-runs') / run_id"),
+                text.index("Path('agialpha_skill_network_registry') / 'runs' / run_id"),
+            )


### PR DESCRIPTION
### Motivation
- Prevent replay/falsification/claim-gate workflows from mistakenly reusing an append-only registry mirror that lacks the full runnable ENGINE-003 artifact layout, and ensure CI falls back to creating a deterministic local run when needed.
- Make the network-compounding run/replay/validate lifecycle deterministic and auditable by requiring explicit evidence artifacts before sidecar workflows reuse an external run path.

### Description
- Require a minimal full-run layout in the run discovery logic of the ENGINE-003 sidecar workflows by preferring `agialpha-engine-runs/<run_id>` and validating presence of `02_jobs/source_jobs.json`, `02_jobs/raw_task_results.json`, `03_skill_extraction/accepted_skill_packages.json`, `06_heldout_reuse_tests/comparison.json`, and `13_claim_gate/network_compounding_claim_gate.json` before reusing a registry path. 
- If the required layout is missing the workflow falls back to creating a deterministic local run at `/tmp/agialpha-skill-network-test` and proceeds with `network-compounding-run`/`replay`/`falsification-audit` as before. 
- Applied the same guard to `.github/workflows/agialpha-engine-003-network-replay.yml`, `agialpha-engine-003-network-falsification-audit.yml`, and `agialpha-engine-003-network-claim-gate.yml` to ensure consistent behavior across sidecar runs. 
- Added a regression unit test `test_replay_sidecar_workflows_do_not_select_registry_mirror_without_full_run_layout` to `tests/test_agialpha_network_compounding_metrics.py` that asserts the workflows contain the new required-layout check and the candidate-ordering (prefer local engine run first).

### Testing
- Ran the deterministic ENGINE-003 flow end-to-end locally with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` and then executed `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data`; all commands completed without error. 
- Executed the unit test suite with `python -m unittest discover -s tests` and the targeted tests `python -m unittest tests.test_agialpha_network_compounding_metrics` and `pytest -q` where available; the test suite passed (all tests green). 
- Ran SecureRails checks with `python scripts/secure_rails_claim_boundary_check.py`, `python scripts/secure_rails_no_automerge_check.py`, `python scripts/secure_rails_trust_center_check.py`, and `python scripts/check_pages_architecture.py`; checks passed where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ade783448333b635878496196153)