### PR TITLE
Finish AGI ALPHA Engine 003: Networked Skill Compounding

### DIFF
--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -1218,6 +1218,68 @@ def validate_network_compounding(args):
         proofbundle_errors.append(f"unexpected standalone proofbundle files: {sorted(extra_standalone_ids)}")
     if proofbundle_errors:
         raise SystemExit(f"network-compounding-validate failed: proofbundle integrity errors ({proofbundle_errors})")
+    evidence_docket_doc=_read(run/'15_evidence_dockets/index.json',{})
+    evidence_docket_errors=[]
+    indexed_dockets=evidence_docket_doc.get('evidence_dockets', [])
+    if len(indexed_dockets) != len(accepted):
+        evidence_docket_errors.append(f"evidence docket index count {len(indexed_dockets)} does not match accepted skills {len(accepted)}")
+    accepted_by_skill_id={skill.get('skill_id'): skill for skill in accepted if skill.get('skill_id')}
+    indexed_docket_ids=set()
+    required_docket_flags=(
+        'includes_successes',
+        'includes_failures',
+        'includes_rejected_claims',
+        'includes_evaluator_disagreement',
+        'includes_baseline_regressions',
+        'includes_falsification_attempts',
+    )
+    for docket in indexed_dockets:
+        if not isinstance(docket, dict):
+            evidence_docket_errors.append('indexed evidence docket must be an object')
+            continue
+        docket_id=docket.get('evidence_docket_id')
+        skill_id=docket.get('skill_id')
+        if not isinstance(docket_id, str) or not docket_id.strip():
+            evidence_docket_errors.append('indexed evidence docket missing evidence_docket_id')
+            continue
+        indexed_docket_ids.add(docket_id)
+        docket_file=run/'15_evidence_dockets'/f'{docket_id}.json'
+        if not docket_file.exists():
+            evidence_docket_errors.append(f"{docket_id} standalone evidence docket file missing")
+        else:
+            standalone_docket=_read(docket_file,{})
+            if standalone_docket != docket:
+                evidence_docket_errors.append(f"{docket_id} standalone evidence docket file mismatch")
+        skill=accepted_by_skill_id.get(skill_id)
+        if skill is None:
+            evidence_docket_errors.append(f"{docket_id} has no matching accepted skill")
+        elif skill.get('evidence_docket_id') != docket_id:
+            evidence_docket_errors.append(f"{docket_id} does not match accepted skill evidence_docket_id")
+        for flag in required_docket_flags:
+            if docket.get(flag) is not True:
+                evidence_docket_errors.append(f"{docket_id} missing required true flag {flag}")
+        for boundary_key in ('claim_boundary', 'token_boundary', 'regulated_boundary'):
+            if not docket.get(boundary_key):
+                evidence_docket_errors.append(f"{docket_id} missing {boundary_key}")
+        if docket.get('human_review_required') is not True:
+            evidence_docket_errors.append(f"{docket_id} must require human review")
+        if docket.get('autonomous_persistence_allowed') is not False:
+            evidence_docket_errors.append(f"{docket_id} must block autonomous persistence")
+        if docket.get('no_auto_merge') is not True:
+            evidence_docket_errors.append(f"{docket_id} must block auto-merge")
+    expected_docket_ids={skill.get('evidence_docket_id') for skill in accepted if skill.get('evidence_docket_id')}
+    missing_docket_ids=expected_docket_ids-indexed_docket_ids
+    if missing_docket_ids:
+        evidence_docket_errors.append(f"accepted skills missing evidence dockets: {sorted(missing_docket_ids)}")
+    extra_docket_ids=indexed_docket_ids-expected_docket_ids
+    if extra_docket_ids:
+        evidence_docket_errors.append(f"unexpected evidence dockets: {sorted(extra_docket_ids)}")
+    standalone_docket_ids={path.stem for path in (run/'15_evidence_dockets').glob('*.json') if path.name != 'index.json'}
+    extra_standalone_docket_ids=standalone_docket_ids-indexed_docket_ids
+    if extra_standalone_docket_ids:
+        evidence_docket_errors.append(f"unexpected standalone evidence docket files: {sorted(extra_standalone_docket_ids)}")
+    if evidence_docket_errors:
+        raise SystemExit(f"network-compounding-validate failed: evidence docket integrity errors ({evidence_docket_errors})")
     atomic_write_json(run/'validate.json', {
         "schema_version": "agialpha.skill_network.validation_report.v1",
         "validation_pass": True,
@@ -1225,6 +1287,7 @@ def validate_network_compounding(args):
         "falsification_ok": falsification_ok,
         "claim_gate_status": expected_gate_status,
         "proofbundle_integrity_pass": True,
+        "evidence_docket_integrity_pass": True,
         "sandbox_record_integrity_pass": True,
         "network_skill_vault_publication_pass": True,
         "agent_manifest_import_coverage_pass": True,

--- a/agialpha_engine/network_compounding.py
+++ b/agialpha_engine/network_compounding.py
@@ -1225,6 +1225,7 @@ def validate_network_compounding(args):
         evidence_docket_errors.append(f"evidence docket index count {len(indexed_dockets)} does not match accepted skills {len(accepted)}")
     accepted_by_skill_id={skill.get('skill_id'): skill for skill in accepted if skill.get('skill_id')}
     indexed_docket_ids=set()
+    evidence_docket_dir=(run/'15_evidence_dockets').resolve()
     required_docket_flags=(
         'includes_successes',
         'includes_failures',
@@ -1242,8 +1243,15 @@ def validate_network_compounding(args):
         if not isinstance(docket_id, str) or not docket_id.strip():
             evidence_docket_errors.append('indexed evidence docket missing evidence_docket_id')
             continue
-        indexed_docket_ids.add(docket_id)
+        if '/' in docket_id or '\\' in docket_id or Path(docket_id).name != docket_id or Path(docket_id).is_absolute():
+            evidence_docket_errors.append(f"{docket_id} has unsafe evidence_docket_id path segment")
+            continue
         docket_file=run/'15_evidence_dockets'/f'{docket_id}.json'
+        resolved_docket_file=docket_file.resolve(strict=False)
+        if resolved_docket_file.parent != evidence_docket_dir:
+            evidence_docket_errors.append(f"{docket_id} standalone evidence docket path escapes 15_evidence_dockets")
+            continue
+        indexed_docket_ids.add(docket_id)
         if not docket_file.exists():
             evidence_docket_errors.append(f"{docket_id} standalone evidence docket file missing")
         else:

--- a/agialpha_skill_network_registry/runs/agialpha-skill-network-test/20_validate.json
+++ b/agialpha_skill_network_registry/runs/agialpha-skill-network-test/20_validate.json
@@ -3,6 +3,7 @@
   "autonomous_persistence_allowed": false,
   "claim_boundary": "local bounded public evidence; proof-gated recursive experiment engine; human-reviewed promotion required",
   "claim_gate_status": "supported_local_bounded",
+  "evidence_docket_integrity_pass": true,
   "evidence_docket_required_files_present": 24,
   "falsification_ok": true,
   "human_review_required": true,

--- a/tests/test_agialpha_network_claim_gate.py
+++ b/tests/test_agialpha_network_claim_gate.py
@@ -66,3 +66,27 @@ def test_validate_report_records_evidence_docket_integrity_pass():
         assert validate_report['validation_pass'] is True
         assert validate_report['proofbundle_integrity_pass'] is True
         assert validate_report['evidence_docket_integrity_pass'] is True
+
+
+def test_validate_rejects_evidence_docket_id_path_separator_escape():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        _run_full(run, reg)
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        docket_index_path = run / '15_evidence_dockets' / 'index.json'
+        docket_index = json.loads(docket_index_path.read_text())
+        escaped_docket = dict(docket_index['evidence_dockets'][0])
+        escaped_docket['evidence_docket_id'] = '../escaped-docket'
+        docket_index['evidence_dockets'][0] = escaped_docket
+        docket_index_path.write_text(json.dumps(docket_index, indent=2, sort_keys=True) + '\n')
+        (run / 'escaped-docket.json').write_text(json.dumps(escaped_docket, indent=2, sort_keys=True) + '\n')
+
+        completed = subprocess.run(
+            [sys.executable,'-m','agialpha_engine','network-compounding-validate','--run',str(run)],
+            text=True,
+            capture_output=True,
+        )
+        assert completed.returncode != 0
+        assert 'unsafe evidence_docket_id path segment' in completed.stderr

--- a/tests/test_agialpha_network_claim_gate.py
+++ b/tests/test_agialpha_network_claim_gate.py
@@ -1,12 +1,13 @@
 import json
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
 
 def _run_full(run: Path, reg: Path, jobs: int = 5):
     subprocess.check_call([
-        'python','-m','agialpha_engine','network-compounding-run',
+        sys.executable,'-m','agialpha_engine','network-compounding-run',
         '--repo-root','.','--registry',str(reg),'--out',str(run),
         '--jobs',str(jobs),'--target-agents','3','--heldout-tasks','5','--seed','123'
     ])
@@ -26,9 +27,42 @@ def test_claim_gate_supported_after_replay_and_falsification():
         run = Path(td) / 'run'
         reg = Path(td) / 'reg'
         _run_full(run, reg)
-        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-replay','--run',str(run)])
-        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
-        subprocess.check_call(['python','-m','agialpha_engine','network-compounding-validate','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-validate','--run',str(run)])
         gate = json.loads((run / '13_claim_gate/network_compounding_claim_gate.json').read_text())
         assert gate['claim_gate_status'] == 'supported_local_bounded'
         assert gate['human_review_required'] is True
+
+
+def test_validate_catches_missing_accepted_skill_evidence_docket():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        _run_full(run, reg)
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        accepted = json.loads((run / '03_skill_extraction/accepted_skill_packages.json').read_text())['accepted_skill_packages']
+        missing_docket_id = accepted[0]['evidence_docket_id']
+        (run / '15_evidence_dockets' / f'{missing_docket_id}.json').unlink()
+        completed = subprocess.run(
+            [sys.executable,'-m','agialpha_engine','network-compounding-validate','--run',str(run)],
+            text=True,
+            capture_output=True,
+        )
+        assert completed.returncode != 0
+        assert 'evidence docket integrity errors' in completed.stderr
+
+
+def test_validate_report_records_evidence_docket_integrity_pass():
+    with tempfile.TemporaryDirectory() as td:
+        run = Path(td) / 'run'
+        reg = Path(td) / 'reg'
+        _run_full(run, reg)
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-replay','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-falsification-audit','--run',str(run)])
+        subprocess.check_call([sys.executable,'-m','agialpha_engine','network-compounding-validate','--run',str(run)])
+        validate_report = json.loads((run / 'validate.json').read_text())
+        assert validate_report['validation_pass'] is True
+        assert validate_report['proofbundle_integrity_pass'] is True
+        assert validate_report['evidence_docket_integrity_pass'] is True


### PR DESCRIPTION
### Motivation
- Close validation gaps so ENGINE-003 produces measurable, replayable, and audit-ready evidence before any production activation.
- Ensure accepted Skill Packages are bound to Evidence Dockets and that the run-level validation fails loudly if evidence dockets are missing or malformed.
- Keep the SecureRails boundaries intact and prevent any hard-coded metric shortcuts or overclaims in public artifacts.

### Description
- Add end-to-end Evidence Docket integrity checks to `validate_network_compounding` in `agialpha_engine/network_compounding.py` that verify indexed and standalone docket files, required boolean flags, boundary fields, human-review posture, lack of autonomous persistence, and mapping between accepted skills and their evidence dockets.
- Surface the new validation result by writing `evidence_docket_integrity_pass` into the per-run validate report and update the registry run artifact (`agialpha_skill_network_registry/runs/.../20_validate.json`).
- Add semantic tests in `tests/test_agialpha_network_claim_gate.py` to assert that the validate command fails when an accepted skill’s Evidence Docket file is removed and that a successful validate run records the new evidence-docket integrity flag; also harden test invocation to use `sys.executable` for deterministic subprocess runs.
- Preserve existing SafeRails constraints and regression guards (no hard-coded B6/vRCI), and refresh ProofBundle/evidence-docket publishing hooks so the proof-chain completeness remains verifiable.

### Testing
- Ran the full local network loop with `python -m agialpha_engine network-compounding-run --repo-root . --registry agialpha_skill_network_registry --out /tmp/agialpha-skill-network-test --jobs 5 --target-agents 3 --heldout-tasks 5 --seed 123` and then `network-compounding-replay`, `network-compounding-falsification-audit`, `network-compounding-validate`, and `network-compounding-build-data` successfully, producing the generated docs under `docs/_generated/agialpha-skill-network`.
- Ran unit test suites with `python -m unittest discover -s tests` (496 tests) and `pytest -q` (754 tests), both of which completed OK; the focused claim-gate tests `pytest -q tests/test_agialpha_network_claim_gate.py` passed (4 tests).
- Ran repository checks `python scripts/audit_docs_workflows.py`, `python scripts/secure_rails_no_automerge_check.py`, and `python scripts/secure_rails_claim_boundary_check.py` and they passed; `python scripts/secure_rails_policy_check.py` reported existing repository-wide policy findings (these are pre-existing advisories and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f542d888833387d40313f62e5d9d)